### PR TITLE
Fix: set auth_method to ST_ENTRY when token comes from SmartThings integration

### DIFF
--- a/custom_components/samsungtv_smart/config_flow.py
+++ b/custom_components/samsungtv_smart/config_flow.py
@@ -474,7 +474,7 @@ class SamsungTVSmartOAuth2FlowHandler(
             self._st_entry_unique_id = st_entry_unique_id
 
         self._api_key = api_key
-        self._auth_method = AUTH_METHOD_PAT
+        self._auth_method = AUTH_METHOD_ST_ENTRY if st_entry_unique_id else AUTH_METHOD_PAT
 
         use_ha_name = user_input.get(CONF_USE_HA_NAME, False)
         if use_ha_name:


### PR DESCRIPTION
## Summary

`async_step_manual()` in `config_flow.py` unconditionally sets `auth_method = AUTH_METHOD_PAT` (line 477) even when the token was sourced from the native SmartThings integration via `st_entry_unique_id`.

This causes the SmartThings access token to expire after 24 hours without being refreshed, because `media_player.py` only activates the auto-refresh callback when `auth_method == AUTH_METHOD_ST_ENTRY`.

## How to reproduce

1. Have the native HA SmartThings integration configured
2. Add SamsungTV Smart, select "SmartThings Integration Link"
3. Complete setup — works initially
4. Wait 24 hours — integration goes `unavailable` with `Authentication failed with SmartThings`
5. Inspecting `.storage/core.config_entries` shows `auth_method: pat` despite selecting ST link

## Root cause

`async_step_manual()` is reached when the user goes through the manual config flow. When `st_entry_unique_id` is present, the token is correctly pulled from the SmartThings integration (line 473), but line 477 hardcodes `self._auth_method = AUTH_METHOD_PAT`. This prevents the token refresh callback in `media_player.py` (line 563) from being activated.

Note: `async_step_st_integration()` correctly sets `AUTH_METHOD_ST_ENTRY` on line 536, but certain flow paths route through `async_step_manual()` instead.

## Fix

One-line change on line 477:

```python
# Before
self._auth_method = AUTH_METHOD_PAT

# After
self._auth_method = AUTH_METHOD_ST_ENTRY if st_entry_unique_id else AUTH_METHOD_PAT
```

When `st_entry_unique_id` is set, the token came from the SmartThings integration and should be tagged accordingly so the refresh callback is used.