### PR TITLE
[v8] Fix Art Mode detection on 2024+ Frame TVs

### DIFF
--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -38,11 +38,13 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.helpers.typing import ConfigType
 
+from .api.art import SamsungTVAsyncArt
 from .api.samsungws import ConnectionFailure, SamsungTVWS
 from .api.smartthings import SmartThingsTV
 from .const import (
@@ -62,12 +64,15 @@ from .const import (
     CONF_SHOW_CHANNEL_NR,
     CONF_SOURCE_LIST,
     CONF_ST_ENTRY_UNIQUE_ID,
+    CONF_SUPPORTS_GET_BRIGHTNESS,
+    CONF_SUPPORTS_GET_COLOR_TEMPERATURE,
     CONF_SYNC_TURN_OFF,
     CONF_SYNC_TURN_ON,
     CONF_UPDATE_CUSTOM_PING_URL,
     CONF_UPDATE_METHOD,
     CONF_USE_ST_INT_API_KEY,
     CONF_WS_NAME,
+    DATA_ART_API,
     DATA_CFG,
     DATA_CFG_YAML,
     DATA_OPTIONS,
@@ -1020,6 +1025,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN][entry.entry_id][DATA_CFG_YAML] = add_conf
     entry.async_on_unload(entry.add_update_listener(_update_listener))
 
+    # Create the single shared Frame Art API instance BEFORE forwarding
+    # platforms. Platform setups run concurrently and used to race on
+    # hass.data[...][DATA_ART_API], each creating its own instance on a miss
+    # (sensor.py even unconditionally). Multiple clients on the TV's
+    # com.samsung.art-app channel make it route d2d_service_message responses
+    # unpredictably and eventually stop handshaking new connections, so art
+    # mode detection silently dies. One instance here, everyone reuses it.
+    hass.data[DOMAIN][entry.entry_id][DATA_ART_API] = SamsungTVAsyncArt(
+        host=config[CONF_HOST],
+        port=config.get(CONF_PORT, DEFAULT_PORT),
+        token=config.get(CONF_TOKEN),
+        session=async_get_clientsession(hass),
+        timeout=DEFAULT_TIMEOUT,
+        name=f"{WS_PREFIX} {config.get(CONF_WS_NAME, 'HomeAssistant')} Art",
+        supports_get_brightness=entry.data.get(CONF_SUPPORTS_GET_BRIGHTNESS),
+        supports_get_color_temperature=entry.data.get(
+            CONF_SUPPORTS_GET_COLOR_TEMPERATURE
+        ),
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, SAMSMART_PLATFORM)
 
     return True
@@ -1030,6 +1055,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(
         entry, SAMSMART_PLATFORM
     ):
+        if art_api := hass.data[DOMAIN][entry.entry_id].pop(DATA_ART_API, None):
+            await art_api.close()
         hass.data[DOMAIN][entry.entry_id].pop(DATA_CFG)
         hass.data[DOMAIN][entry.entry_id].pop(DATA_OPTIONS)
         if not hass.data[DOMAIN][entry.entry_id]:

--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -155,13 +155,18 @@ class SamsungTVAsyncArt:
 
     @property
     def _ws_url(self) -> str:
-        """Get the WebSocket URL for the art API."""
+        """Get the WebSocket URL for the art API.
+
+        The art-app channel must be opened WITHOUT the remote-control token:
+        2024 Frame TVs (e.g. QN55LS03DA, ws API 2.0.25) treat a token on this
+        channel as a pending device authorization and never send
+        ms.channel.connect — the connection idles until the TV drops it with
+        ms.channel.timeOut. Tokenless connections complete the handshake
+        immediately; the channel itself is unauthenticated.
+        """
         scheme = "wss" if self._port == 8002 else "ws"
         name = _serialize_string(self._name)
-        token_part = (
-            f"&token={self._token}" if self._token and self._port == 8002 else ""
-        )
-        return f"{scheme}://{self._host}:{self._port}/api/v2/channels/{ART_ENDPOINT}?name={name}{token_part}"
+        return f"{scheme}://{self._host}:{self._port}/api/v2/channels/{ART_ENDPOINT}?name={name}"
 
     async def _get_session(self) -> aiohttp.ClientSession:
         """Get or create aiohttp session."""

--- a/custom_components/samsungtv_smart/api/samsungws.py
+++ b/custom_components/samsungtv_smart/api/samsungws.py
@@ -832,8 +832,11 @@ class SamsungTVWS:
             return
 
         is_ssl = self._is_ssl_connection()
+        # use_token=False: the art-app channel is unauthenticated; sending the
+        # remote-control token makes 2024 Frame TVs hold the handshake and
+        # close with ms.channel.timeOut instead of ms.channel.connect.
         url = self._format_websocket_url(
-            _WS_ENDPOINT_ART, is_ssl=is_ssl, use_token=True
+            _WS_ENDPOINT_ART, is_ssl=is_ssl, use_token=False
         )
         sslopt = {"cert_reqs": ssl.CERT_NONE} if is_ssl else {}
 

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -574,7 +574,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                     CONF_SUPPORTS_GET_COLOR_TEMPERATURE
                 ),
             )
-            self._art_api.register_capability_callback(self._persist_art_capability)
+        self._art_api.register_capability_callback(self._persist_art_capability)
         self._frame_tv_supported: bool | None = None
         self._frame_art_last_result: dict | None = None
 

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -79,15 +79,19 @@ async def async_setup_entry(
 
     entities = []
 
-    # Create the Art API instance
-    art_api = SamsungTVAsyncArt(
-        host=host,
-        port=port,
-        token=token,
-        session=session,
-        timeout=5,
-        name=f"{WS_PREFIX} {ws_name} Art",
-    )
+    # Reuse the shared Art API instance (created in __init__.py) so all
+    # platforms talk over a single art-app WebSocket; the TV misbehaves with
+    # multiple clients on that channel. Create one only as a fallback.
+    art_api = hass.data[DOMAIN][entry.entry_id].get(DATA_ART_API)
+    if not art_api:
+        art_api = SamsungTVAsyncArt(
+            host=host,
+            port=port,
+            token=token,
+            session=session,
+            timeout=5,
+            name=f"{WS_PREFIX} {ws_name} Art",
+        )
 
     # Check Frame TV support:
     # If already confirmed as a Frame TV (persisted flag), skip the live check.


### PR DESCRIPTION
Two root causes, found by probing a QN55LS03DA (ws API 2.0.25) directly:

1. The com.samsung.art-app channel rejects connections that carry the remote-control token: the TV completes the websocket handshake but never sends ms.channel.connect, idling until it drops the connection with ms.channel.timeOut. SamsungTVAsyncArt.open() only waits ~6s for the connect event, so every art connection failed ("Did not receive connect/ready event"), tripping the backoff loop; art mode state never updated and set_artmode retries all failed. The channel itself is unauthenticated - connect without the token, in both art.py and the legacy samsungws art thread.

2. Platform setups race to create the shared art API client: sensor.py unconditionally created its own instance and overwrote the shared one, while switch/select/number/media_player create private instances on a miss. Multiple concurrent clients on the art channel make the TV route d2d_service_message responses unpredictably and eventually stop handshaking new connections. Create one shared instance in async_setup_entry before platforms are forwarded, close it on unload, and make sensor.py reuse it. media_player now registers its capability persistence callback on the shared instance too.

Verified live against a 2024 Frame (QN55LS03DA): art_mode_status attribute, the art mode switch, and the brightness/color-temperature entities all track the TV again, with no Art API connection warnings.