### PR TITLE
[v8] Fix SmartThings token refresh and unavailable-cascade killing Art Mode

### DIFF
--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -443,6 +443,21 @@ def get_smartthings_api_key(hass: HomeAssistant, st_unique_id: str) -> str | Non
     return None
 
 
+@callback
+def has_refreshable_oauth_token(entry: ConfigEntry) -> bool:
+    """Return True if the entry stores an OAuth token that can be refreshed.
+
+    Some entries created through the OAuth flow end up labeled with a
+    different auth_method (e.g. "pat", because the access token doubles as
+    the API key) while still holding a refreshable oauth_token. Token
+    management must follow the token data, not the label: SmartThings
+    access tokens expire after 24 hours, and skipping refresh for these
+    entries kills every SmartThings-backed entity a day later.
+    """
+    oauth_token = entry.data.get(CONF_OAUTH_TOKEN)
+    return isinstance(oauth_token, dict) and bool(oauth_token.get("refresh_token"))
+
+
 async def async_get_samsungtv_api_key(  # noqa: C901
     hass: HomeAssistant, entry: ConfigEntry
 ) -> str | None:
@@ -458,8 +473,10 @@ async def async_get_samsungtv_api_key(  # noqa: C901
     """
     auth_method = entry.data.get(CONF_AUTH_METHOD)
 
-    # Method 1: OAuth2 - own token with refresh
-    if auth_method == AUTH_METHOD_OAUTH:
+    # Method 1: OAuth2 - own token with refresh. Entries holding a
+    # refreshable oauth_token take this path regardless of their label,
+    # so their 24h access token keeps being renewed.
+    if auth_method == AUTH_METHOD_OAUTH or has_refreshable_oauth_token(entry):
         oauth_token = entry.data.get(CONF_OAUTH_TOKEN)
         if oauth_token and isinstance(oauth_token, dict):
             access_token = oauth_token.get("access_token")
@@ -477,21 +494,12 @@ async def async_get_samsungtv_api_key(  # noqa: C901
                         )
                         return access_token  # Try with expired token anyway
 
-                    # Check if another refresh is already in progress
-                    if is_oauth_refresh_in_progress(entry.entry_id):
-                        _LOGGER.debug(
-                            "OAuth refresh already in progress, using current token"
-                        )
-                        # Re-read from entry in case it was just refreshed
-                        updated_entry = hass.config_entries.async_get_entry(
-                            entry.entry_id
-                        )
-                        if updated_entry:
-                            updated_token = updated_entry.data.get(CONF_OAUTH_TOKEN, {})
-                            return updated_token.get("access_token", access_token)
-                        return access_token
-
-                    # Acquire lock to prevent concurrent refresh
+                    # Acquire lock to prevent concurrent refresh. If another
+                    # task is already refreshing, WAIT for it instead of
+                    # returning the current (expired) token: platform setups
+                    # (ST sensors, power switch) race the media_player refresh
+                    # at startup, and a stale token here makes their setup
+                    # fail with an auth error until the next reload.
                     lock = get_oauth_refresh_lock(entry.entry_id)
                     async with lock:
                         # Double-check after acquiring lock - token might have been refreshed

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -595,6 +595,19 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         st_entry_uniqueid: str | None = config.get(CONF_ST_ENTRY_UNIQUE_ID)
         auth_method: str | None = config.get(CONF_AUTH_METHOD)
 
+        # Entries created through the OAuth flow can carry a different
+        # auth_method label (e.g. "pat", since the access token doubles as
+        # the API key) while still holding a refreshable oauth_token. Treat
+        # those as OAuth: their access token expires after 24 hours, and
+        # skipping the refresh path kills SmartThings a day later.
+        oauth_token = config.get(CONF_OAUTH_TOKEN)
+        if (
+            auth_method != AUTH_METHOD_OAUTH
+            and isinstance(oauth_token, dict)
+            and oauth_token.get("refresh_token")
+        ):
+            auth_method = AUTH_METHOD_OAUTH
+
         # Store auth method for later use
         self._auth_method = auth_method
 
@@ -1604,6 +1617,21 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             ClientResponseError,
         ) as exc:
             _LOGGER.debug("%s - SmartThings error: [%s]", self.entity_id, exc)
+            self._st_last_exc = exc
+            return False
+        except Exception as exc:  # pylint: disable=broad-except
+            # A SmartThings cloud failure (expired token, rate limit, API
+            # change) must not propagate out of async_update: HA would mark
+            # the whole entity unavailable, and dependent entities (art mode
+            # switch, frame art sensor) would wrongly report the TV as off.
+            # Local WebSocket control keeps working without SmartThings.
+            if type(exc) is not type(self._st_last_exc):
+                _LOGGER.warning(
+                    "%s - SmartThings update failed, continuing with local"
+                    " control only: %s",
+                    self.entity_id,
+                    exc,
+                )
             self._st_last_exc = exc
             return False
 

--- a/custom_components/samsungtv_smart/select.py
+++ b/custom_components/samsungtv_smart/select.py
@@ -459,17 +459,21 @@ class SamsungTVPictureModeSelect(SelectEntity):
         return len(self._attr_options) > 0
 
     def _get_api_key(self) -> str:
-        """Get current API key, refreshing from entry data for OAuth."""
+        """Get current API key, refreshing from entry data for OAuth.
+
+        The oauth_token is preferred whenever present, regardless of the
+        entry's auth_method label: OAuth-created entries can be labeled
+        "pat" (the access token doubles as the API key), and after a token
+        refresh the oauth_token always holds the current access token.
+        """
         entry = self.hass.config_entries.async_get_entry(self._entry.entry_id)
         if entry:
-            auth_method = entry.data.get(CONF_AUTH_METHOD)
-            if auth_method == AUTH_METHOD_OAUTH:
-                oauth_token = entry.data.get(CONF_OAUTH_TOKEN)
-                if oauth_token and isinstance(oauth_token, dict):
-                    new_key = oauth_token.get("access_token")
-                    if new_key:
-                        self._api_key = new_key
-                        return new_key
+            oauth_token = entry.data.get(CONF_OAUTH_TOKEN)
+            if isinstance(oauth_token, dict):
+                new_key = oauth_token.get("access_token")
+                if new_key:
+                    self._api_key = new_key
+                    return new_key
             api_key = entry.data.get(CONF_API_KEY)
             if api_key:
                 self._api_key = api_key

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -36,9 +36,7 @@ from homeassistant.helpers.update_coordinator import (
 from . import async_get_samsungtv_api_key
 from .api.art import SamsungTVAsyncArt
 from .const import (
-    AUTH_METHOD_OAUTH,
     CONF_API_KEY,
-    CONF_AUTH_METHOD,
     CONF_DEVICE_ID,
     CONF_IS_FRAME_TV,
     CONF_OAUTH_TOKEN,
@@ -163,17 +161,15 @@ async def async_setup_entry(
     else:
         _LOGGER.info("Frame TV art mode not supported on %s", host)
 
-    # Add SmartThings sensors if SmartThings is configured
-    api_key = config.get(CONF_API_KEY)
+    # Add SmartThings sensors if SmartThings is configured.
+    # Resolve the API key through the shared helper instead of the cached
+    # config snapshot: at startup the stored OAuth access token may already
+    # be expired (e.g. HA was down for >24h), and this setup runs exactly
+    # once — a stale token here means get_device() fails with an auth error
+    # and the SmartThings sensors silently never get created. The helper
+    # refreshes the token (or waits for an in-flight refresh) first.
+    api_key = await async_get_samsungtv_api_key(hass, entry)
     device_id = config.get(CONF_DEVICE_ID)
-    auth_method = config.get(CONF_AUTH_METHOD)
-
-    # For OAuth, get token from oauth_token if api_key is not available
-    if auth_method == AUTH_METHOD_OAUTH and not api_key:
-        oauth_token = config.get(CONF_OAUTH_TOKEN)
-        if oauth_token and isinstance(oauth_token, dict):
-            api_key = oauth_token.get("access_token")
-            _LOGGER.debug("SmartThings sensors using OAuth token")
 
     if api_key and device_id:
         try:
@@ -637,8 +633,11 @@ class FrameArtCoordinator(DataUpdateCoordinator):
                     state = self._hass.states.get(entity.entity_id)
                     if state:
                         # "unknown" = WebSocket not yet connected (booting up).
-                        # Only treat "off" and "unavailable" as truly powered off.
-                        return state.state in ("off", "unavailable")
+                        # "unavailable" = the media_player update failed (e.g.
+                        # SmartThings cloud error) — not a power statement;
+                        # the direct art API fallback will determine the
+                        # actual state. Only a real "off" is powered off.
+                        return state.state == "off"
                     break
         except Exception as ex:
             _LOGGER.debug("Could not check media_player power state: %s", ex)

--- a/custom_components/samsungtv_smart/switch.py
+++ b/custom_components/samsungtv_smart/switch.py
@@ -287,24 +287,27 @@ class FrameArtModeSwitch(SwitchEntity):
         "unknown" means the WebSocket connection is not yet established —
         typically the TV is booting up. Treat it as on so that Art Mode
         activation is not blocked during the startup transient.
+
+        "unavailable" (or no media_player at all) says nothing about the TV
+        itself — e.g. a SmartThings cloud failure crashes the media_player
+        update while the TV keeps working locally. Ask the TV directly over
+        the local REST API instead of assuming it is off.
         """
         entity_id = self._get_media_player_entity_id()
-        if not entity_id:
-            return False
+        state = self._hass.states.get(entity_id) if entity_id else None
 
-        state = self._hass.states.get(entity_id)
-        if state is None:
-            return False
+        if state is None or state.state == "unavailable":
+            try:
+                return await self._art_api.on()
+            except Exception:  # pylint: disable=broad-except
+                return False
 
         # TV is clearly on (watching TV, idle, paused...) or still starting up
-        if state.state not in (STATE_OFF, "unavailable"):
+        if state.state != STATE_OFF:
             return True
 
         # media_player says "off" — but Art Mode may be active
-        if state.state == STATE_OFF:
-            return state.attributes.get("art_mode_status") == "on"
-
-        return False
+        return state.attributes.get("art_mode_status") == "on"
 
     async def _turn_on_tv(self) -> bool:
         """Turn on the TV using media_player service."""
@@ -612,12 +615,14 @@ class FrameArtModeSwitch(SwitchEntity):
         art_status = new_state.attributes.get("art_mode_status")
         if art_status == "on":
             self._attr_is_on = True
-        elif new_state.state in (STATE_OFF, "unavailable"):
+        elif new_state.state == STATE_OFF:
             self._attr_is_on = False
-        elif new_state.state == "unknown":
-            # TV is booting up — WebSocket not yet established.
+        elif new_state.state in ("unknown", "unavailable"):
+            # "unknown": TV is booting up — WebSocket not yet established.
+            # "unavailable": the media_player update failed (e.g. SmartThings
+            # cloud error) — that says nothing about the TV itself.
             # Schedule a deferred re-check so the switch reflects the actual
-            # Art Mode state once the TV is fully ready, without blocking here.
+            # Art Mode state (asking the TV directly), without guessing here.
             self._hass.async_create_background_task(
                 self._deferred_state_refresh(delay=8),
                 f"art_mode_switch_deferred_refresh_{self._entry.entry_id}",


### PR DESCRIPTION
Fix SmartThings token refresh and unavailable-cascade killing Art Mode
A SmartThings OAuth access token expiring (they last 24h) took down most
of the integration's entities, including local-only Art Mode detection:

1. Token refresh never ran for entries labeled auth_method "pat" that
   actually hold a refreshable oauth_token (OAuth-created entries store
   the access token as the API key under that label). Every refresh path
   was gated on auth_method == "oauth", so the token silently expired
   and all SmartThings calls started failing with auth errors.
   - media_player now treats an entry with a refreshable oauth_token as
     OAuth for token management.
   - async_get_samsungtv_api_key (used by the ST sensors and the power
     switch) applies the same rule.

2. The resulting SmartThingsAuthenticationFailedError escaped
   _async_st_update (which only caught transport errors), crashed
   async_update, and HA marked the whole media_player unavailable. A
   cloud failure must not disable local control: catch the remaining
   exceptions, log once per error type, and continue with local updates.

3. The art mode switch and the frame art coordinator both treated an
   "unavailable" media_player as "TV powered off", forcing Art Mode to
   "off" while the TV was actually displaying art. "unavailable" is not
   a power statement: the switch now asks the TV directly over the
   local REST API, its state-change handler schedules a re-check
   instead of guessing, and the coordinator only short-circuits on a
   real "off".

4. async_get_samsungtv_api_key returned the current (expired) token
   when another task was already refreshing, so platform setups racing
   the media_player refresh at startup failed with auth errors. Wait on
   the refresh lock and return the fresh token instead.

5. The SmartThings sensor setup read the API key from the cached config
   snapshot, and it runs exactly once: starting HA with an already
   expired token made get_device() fail with an auth error and silently
   skip creating the light-level / brightness-intensity sensors until
   the next reload. Resolve the key through async_get_samsungtv_api_key
   instead, so the token is refreshed (or an in-flight refresh awaited)
   before the SmartThings calls.

6. The picture mode select's _get_api_key() only consulted oauth_token
   when the entry was labeled "oauth". Prefer a present oauth_token
   regardless of the label; it always holds the current access token
   after a refresh.

Verified live against a 2024 Frame (QN55LS03DA), including a cold start
with the stored token forcibly expired: the token refreshes during
startup, the SmartThings entities (power switch, picture mode,
brightness intensity, light level) are all created, and the Art Mode
switch / Frame Art sensor correctly track the TV.