### PR TITLE
[v8] Fix Art Mode desync on 2024+ Frames (PowerState=standby) + code-review fixes

### DIFF
--- a/custom_components/samsungtv_smart/api/samsungws.py
+++ b/custom_components/samsungtv_smart/api/samsungws.py
@@ -1099,12 +1099,17 @@ class SamsungTVWS:
 
     def stop_poll(self):
         """Stop polling the TV for status."""
-        if self._ping_thread is not None and not self._ping_thread.is_alive():
+        # NOTE: the guard must check that the thread IS alive (a previous
+        # inverted check made this a no-op in the normal case, leaking the
+        # ping thread and its WebSocket client threads on every reload —
+        # which kept stale clients connected to the TV's art-app channel in
+        # parallel with the new entry instance).
+        if self._ping_thread is not None and self._ping_thread.is_alive():
             self._ping_thread_run = False
             self._ping_thread.join()
             if self._is_connected:
                 self.stop_client()
-            self._ping_thread = None
+        self._ping_thread = None
 
     def disable_art_thread(self):
         """Disable the SamsungArt WebSocket thread.

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -67,7 +67,6 @@ from homeassistant.util.async_ import run_callback_threadsafe
 from . import (
     get_oauth_refresh_lock,
     get_smartthings_api_key,
-    is_oauth_refresh_in_progress,
     set_oauth_refresh_in_progress,
 )
 from .api.art import SamsungTVAsyncArt
@@ -595,6 +594,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         # port 1516 (deep standby) cannot pin a stale "art mode on" forever.
         self._ip_art_mode_failures = 0
         self._ip_art_mode_refresh_unsub: Callable[[], None] | None = None
+        self._ip_art_mode_initial_task: asyncio.Task | None = None
 
         # upnp initialization
         self._upnp = SamsungUPnP(host=self._host, session=session)
@@ -717,27 +717,11 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         if self._auth_method != AUTH_METHOD_OAUTH:
             return True
 
-        # Check if another refresh is already in progress (global check)
-        if is_oauth_refresh_in_progress(self._entry_id):
-            _LOGGER.debug(
-                "OAuth refresh already in progress (global), waiting for result"
-            )
-            # Wait a bit and then check if token was refreshed
-            await asyncio.sleep(0.5)
-            # Re-read token from entry
-            entry = self.hass.config_entries.async_get_entry(self._entry_id)
-            if entry:
-                oauth_token = entry.data.get(CONF_OAUTH_TOKEN, {})
-                new_token = oauth_token.get("access_token")
-                if new_token and new_token != self._st_api_key:
-                    self._st_api_key = new_token
-                    if self._st:
-                        self._st._api_key = new_token
-                        self._st._st.authenticate(new_token)
-                    return True
-            return False
-
-        # Acquire global lock
+        # Acquire the global per-entry lock. If another task is already
+        # refreshing, this WAITS for it to finish instead of sleeping an
+        # arbitrary 0.5s (a real SmartThings refresh round-trip routinely
+        # takes longer, which left this update cycle on the stale token);
+        # the double-check below then adopts the freshly stored token.
         lock = get_oauth_refresh_lock(self._entry_id)
         async with lock:
             # Double-check after acquiring lock - another entity might have refreshed
@@ -1134,11 +1118,19 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             self.hass, self._refresh_ip_art_mode, IP_ART_MODE_REFRESH_INTERVAL
         )
         # Kick off a non-blocking initial read so the value is available
-        # well before the first scheduled interval fires.
-        self.hass.async_create_task(self._refresh_ip_art_mode())
+        # well before the first scheduled interval fires. Track the task so
+        # it is cancelled if the entity is removed while the (executor-backed,
+        # up to ~10s) IP request is still in flight — otherwise it could call
+        # async_write_ha_state() on a removed entity.
+        self._ip_art_mode_initial_task = self.hass.async_create_task(
+            self._refresh_ip_art_mode()
+        )
 
     async def async_will_remove_from_hass(self):
         """Run when entity will be removed from hass."""
+        if self._ip_art_mode_initial_task is not None:
+            self._ip_art_mode_initial_task.cancel()
+            self._ip_art_mode_initial_task = None
         if self._ip_art_mode_refresh_unsub is not None:
             self._ip_art_mode_refresh_unsub()
             self._ip_art_mode_refresh_unsub = None
@@ -3560,9 +3552,13 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             return {"error": "Frame TV not supported"}
         try:
             result = await self._art_api.get_brightness()
+            # API may return a dict {"value": N} or a raw int depending on path
+            tv_value = result.get("value") if isinstance(result, dict) else result
+            if tv_value is not None:
+                tv_value = int(tv_value)
             # Convert TV's 1-10 scale to 0-100 for UI
-            ui_brightness = result * 10 if result else None
-            return {"brightness_tv": result, "brightness_ui": ui_brightness}
+            ui_brightness = tv_value * 10 if tv_value is not None else None
+            return {"brightness_tv": tv_value, "brightness_ui": ui_brightness}
         except Exception as ex:
             _LOGGER.error("Error getting brightness: %s", ex)
             return {"error": str(ex)}
@@ -3603,7 +3599,11 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             return {"error": "Frame TV not supported"}
         try:
             result = await self._art_api.get_color_temperature()
-            return {"color_temperature": result}
+            # API may return a dict {"value": N} or a raw int depending on path
+            value = result.get("value") if isinstance(result, dict) else result
+            if value is not None:
+                value = int(value)
+            return {"color_temperature": value}
         except Exception as ex:
             _LOGGER.error("Error getting color temperature: %s", ex)
             return {"error": str(ex)}

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -967,13 +967,22 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         return self._ip_control_client
 
     async def _refresh_ip_art_mode(self, _now=None) -> None:
-        """Refresh the cached Art Mode value via IP Control (artModeControl).
+        """Refresh the cached Art Mode value via IP Control.
 
         Called periodically by ``async_track_time_interval`` and once eagerly
         from ``async_added_to_hass`` so the first value is available shortly
         after startup. The cached result is consumed by
         ``extra_state_attributes`` as the authoritative source for
         ``art_mode_status`` when this TV is paired.
+
+        The power state is read FIRST (powerControl): artModeControl alone
+        cannot tell a powered-off TV from one displaying art — it keeps
+        answering with the last mode even when the panel is off. powerControl,
+        by contrast, reports 'powerOn' while Art Mode is displayed and
+        'powerOff' when the TV is really off, so combining both yields a
+        cache that is safe to trust unconditionally. This also makes the
+        cache independent of the REST device-info ``PowerState``, which 2024+
+        Frame models report as 'standby' WHILE actively displaying art.
 
         Failure handling:
         - No paired client (no token) → cache cleared to ``None``; the
@@ -996,7 +1005,13 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 self.async_write_ha_state()
             return
         try:
-            value = await client.async_get_art_mode()
+            power = await client.async_get_power_state()
+            if power == "powerOff":
+                # TV is really off — art cannot be displayed. Don't query
+                # artModeControl: it would answer with the last mode.
+                value = False
+            else:
+                value = await client.async_get_art_mode()
         except SamsungIPControlAuthError as ex:
             _LOGGER.warning(
                 "IP Control art-mode read for %s: token rejected (%s) — "
@@ -1917,17 +1932,20 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         # Determine Art Mode status for state attributes.
         #
         # Priority order:
-        #  1. device_info PowerState='standby' (Phase 1) — definitive when the
-        #     device-info REST poll reports the TV as fully off. Wins over the
-        #     IP Control cache below because that cache could still be holding
-        #     a recent "Art Mode on" value during the brief window between a
-        #     power-off and the next IP Control refresh.
-        #  2. IP Control cache (Phase 2) — authoritative read from the TV via
-        #     artModeControl, refreshed every IP_ART_MODE_REFRESH_INTERVAL.
-        #     Used when the user has paired this TV via the options flow.
-        #     When the TV is on, this distinguishes Art Mode from normal
-        #     viewing locally — without depending on the art_api WebSocket
-        #     events that go silent on power-off.
+        #  1. IP Control cache (Phase 2) — authoritative combined read
+        #     (powerControl + artModeControl) refreshed every
+        #     IP_ART_MODE_REFRESH_INTERVAL when the user has paired this TV
+        #     via the options flow. It MUST win over the device-info
+        #     PowerState check below: 2024+ Frame models (e.g. QE55LS03DA)
+        #     report PowerState='standby' over REST WHILE actively displaying
+        #     art, so trusting 'standby' first forces art_mode_status to
+        #     'off' whenever Art Mode is on. The cache is safe against the
+        #     opposite mistake because _refresh_ip_art_mode reads the IP
+        #     Control power state first and stores False when the TV reports
+        #     'powerOff'.
+        #  2. device_info PowerState='standby' (Phase 1) — for unpaired TVs,
+        #     definitive when the device-info REST poll reports the TV as
+        #     fully off.
         #  3. async Art API (art.py) — preferred when active. Once
         #     disable_art_thread() is called, _ws.artmode_status is frozen at
         #     its last value and is no longer updated when Art Mode changes.
@@ -1946,13 +1964,13 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             self.hass.data.get(DOMAIN, {}).get(self._entry_id, {}).get(DATA_ART_API)
         )
         device_power_state = self._get_device_spec("PowerState")
-        if device_power_state == "standby":
-            # TV is powered off — art mode cannot be active regardless of
-            # what art_api or the IP cache may report.
-            data[ATTR_ART_MODE_STATUS] = STATE_OFF
-        elif self._ip_art_mode is not None:
-            # IP Control authoritative read for a TV that is on.
+        if self._ip_art_mode is not None:
+            # IP Control authoritative read (power-state aware, see above).
             data[ATTR_ART_MODE_STATUS] = STATE_ON if self._ip_art_mode else STATE_OFF
+        elif device_power_state == "standby":
+            # TV is powered off — art mode cannot be active regardless of
+            # what art_api may report.
+            data[ATTR_ART_MODE_STATUS] = STATE_OFF
         elif art_api is not None and art_api.art_mode is not None:
             data.update(
                 {ATTR_ART_MODE_STATUS: STATE_ON if art_api.art_mode else STATE_OFF}

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -224,6 +224,10 @@ SCAN_INTERVAL = timedelta(seconds=5)
 # Phase 2: background poll period for the authoritative Art Mode state via
 # IP Control. Cheap LAN call (~50–100 ms over HTTPS:1516), low frequency.
 IP_ART_MODE_REFRESH_INTERVAL = timedelta(seconds=30)
+# Consecutive IP Control transport failures tolerated before the cached
+# art-mode value is considered stale and cleared (TV likely in deep standby
+# with port 1516 closed). 3 × 30s ≈ 90s worst-case staleness.
+IP_ART_MODE_MAX_FAILURES = 3
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -586,6 +590,10 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         self._ip_control_client: SamsungIPControl | None = None
         self._ip_control_token_cached: str | None = None
         self._ip_art_mode: bool | None = None
+        # Consecutive transport-failure count; the cache is cleared once it
+        # reaches IP_ART_MODE_MAX_FAILURES so a TV that stops answering on
+        # port 1516 (deep standby) cannot pin a stale "art mode on" forever.
+        self._ip_art_mode_failures = 0
         self._ip_art_mode_refresh_unsub: Callable[[], None] | None = None
 
         # upnp initialization
@@ -991,7 +999,9 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
           logged so the user knows to re-pair.
         - Any other transport / TLS error → keep the last known value, log at
           debug. Transient unreachability (TV in deep standby briefly closing
-          port 1516) should not invalidate a recent reading.
+          port 1516) should not invalidate a recent reading — but after
+          IP_ART_MODE_MAX_FAILURES consecutive failures the cache is cleared
+          so a TV that stays unreachable cannot pin a stale value forever.
         """
         client = self._get_ip_control_client()
         if client is None:
@@ -1000,6 +1010,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 "(no CONF_IP_CONTROL_TOKEN in entry.data) — skipping",
                 self._host,
             )
+            self._ip_art_mode_failures = 0
             if self._ip_art_mode is not None:
                 self._ip_art_mode = None
                 self.async_write_ha_state()
@@ -1020,18 +1031,39 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 ex,
             )
             self._notify_ip_control_token_problem()
+            self._ip_art_mode_failures = 0
             if self._ip_art_mode is not None:
                 self._ip_art_mode = None
                 self.async_write_ha_state()
             return
         except SamsungIPControlError as ex:
-            _LOGGER.debug(
-                "IP Control art-mode read for %s failed (%s); keeping last value",
-                self._host,
-                ex,
-            )
+            self._ip_art_mode_failures += 1
+            if (
+                self._ip_art_mode_failures >= IP_ART_MODE_MAX_FAILURES
+                and self._ip_art_mode is not None
+            ):
+                _LOGGER.debug(
+                    "IP Control art-mode read for %s failed %d times in a row "
+                    "(%s); clearing stale cached value (%s)",
+                    self._host,
+                    self._ip_art_mode_failures,
+                    ex,
+                    self._ip_art_mode,
+                )
+                self._ip_art_mode = None
+                self.async_write_ha_state()
+            else:
+                _LOGGER.debug(
+                    "IP Control art-mode read for %s failed (%s); keeping last "
+                    "value (failure %d/%d)",
+                    self._host,
+                    ex,
+                    self._ip_art_mode_failures,
+                    IP_ART_MODE_MAX_FAILURES,
+                )
             return
         # A successful read means the token is valid again.
+        self._ip_art_mode_failures = 0
         self._clear_ip_control_token_problem()
         if value != self._ip_art_mode:
             _LOGGER.debug(

--- a/custom_components/samsungtv_smart/number.py
+++ b/custom_components/samsungtv_smart/number.py
@@ -169,21 +169,21 @@ class SamsungTVArtNumberBase(RestoreNumber):
         if state is None:
             return False
 
-        # Art Mode brightness/color temp are only meaningful (and readable) when
-        # the TV is actually in Art Mode.  The media_player state is "on" both
-        # for normal TV use and Art Mode; we use the "art_mode" attribute that
-        # the sensor/media_player exposes to distinguish them.
-        # Fall back to just checking "on" so we still poll when art_mode attr
-        # is absent (e.g. older firmware or attribute not yet populated).
+        # Art Mode brightness/color temp are only meaningful (and readable)
+        # when the TV is actually in Art Mode. In this integration a Frame TV
+        # displaying art reports media_player state "off" with the
+        # "art_mode_status" attribute set to "on" (HA convention) — so the
+        # attribute is the authoritative signal, checked BEFORE the state.
+        if state.attributes.get("art_mode_status") == "on":
+            return True
+
         if state.state in ("off", "unavailable", "unknown"):
             return False
 
-        art_mode_attr = state.attributes.get("art_mode")
-        if art_mode_attr is not None:
-            return bool(art_mode_attr)
-
-        # art_mode attribute not present — TV is on, allow polling
-        return True
+        # TV is on (normal viewing) — art values are not readable, but allow
+        # polling when the attribute is absent entirely (e.g. older firmware
+        # or attribute not yet populated) so we don't go permanently blind.
+        return "art_mode_status" not in state.attributes
 
 
 # ══════════════════════════════════════════════════════════════════════════

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -31,6 +31,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
+    UpdateFailed,
 )
 
 from . import async_get_samsungtv_api_key
@@ -346,21 +347,19 @@ class FrameArtCoordinator(DataUpdateCoordinator):
         # Check if we're in backoff period (after multiple connection failures)
         if self._backoff_until is not None:
             if time.time() < self._backoff_until:
-                # Still in backoff period, skip update
+                # Still in backoff period, skip update. Raise UpdateFailed so
+                # last_update_success goes False and the sensor reports HA's
+                # real "unavailable" semantics (the entity keeps its previous
+                # data), instead of publishing the literal string
+                # "unavailable" as a state while claiming to be available.
+                remaining = self._backoff_until - time.time()
                 _LOGGER.debug(
                     "Frame Art: Skipping update due to connection backoff (%.0fs remaining)",
-                    self._backoff_until - time.time(),
+                    remaining,
                 )
-                # Return minimal data during backoff
-                return {
-                    "art_mode": "unavailable",
-                    "current_artwork": None,
-                    "artwork_count": None,
-                    "slideshow_status": None,
-                    "api_version": None,
-                    "current_thumbnail_url": None,
-                    "tv_powered_off": False,
-                }
+                raise UpdateFailed(
+                    f"Art channel in connection backoff ({remaining:.0f}s remaining)"
+                )
             else:
                 # Backoff period expired, reset and try again
                 _LOGGER.info("Frame Art: Backoff period expired, resuming updates")
@@ -454,9 +453,18 @@ class FrameArtCoordinator(DataUpdateCoordinator):
                 self._thumbnail_backoff_until = None
                 self._thumbnail_failures = 0
 
-            if (
-                not thumbnail_in_backoff
-                and content_id
+            if not self._thumbnail_fetch_enabled:
+                # Automatic fetching disabled via the enable_thumbnail_fetch
+                # service — honor the flag (it is also surfaced in the
+                # sensor's thumbnail_auto_fetch attribute).
+                if content_id:
+                    _LOGGER.debug(
+                        "Frame Art: Thumbnail auto-fetch disabled, skipping %s",
+                        content_id,
+                    )
+            elif (
+                content_id
+                and not thumbnail_in_backoff
                 and (
                     content_id != self._last_content_id
                     or not self._has_current_thumbnail()

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -637,7 +637,13 @@ class FrameArtCoordinator(DataUpdateCoordinator):
                         # SmartThings cloud error) — not a power statement;
                         # the direct art API fallback will determine the
                         # actual state. Only a real "off" is powered off.
-                        return state.state == "off"
+                        if state.state != "off":
+                            return False
+                        # A Frame TV displaying art ALSO reports state "off"
+                        # (HA convention: off + art_mode_status attribute).
+                        # Only treat it as powered off when art mode is not
+                        # active, mirroring FrameArtModeSwitch._is_tv_on.
+                        return state.attributes.get("art_mode_status") != "on"
                     break
         except Exception as ex:
             _LOGGER.debug("Could not check media_player power state: %s", ex)

--- a/custom_components/samsungtv_smart/switch.py
+++ b/custom_components/samsungtv_smart/switch.py
@@ -426,9 +426,13 @@ class FrameArtModeSwitch(SwitchEntity):
                         self.async_write_ha_state()
                         _LOGGER.info("Art Mode turned ON for %s", self._device_name)
 
-                        # Wait for TV to confirm, then refresh state
+                        # Wait for TV to confirm, then refresh state.
+                        # async_update() only mutates attributes — publish
+                        # the refreshed state so the UI is corrected if the
+                        # TV ended up differing from the optimistic write.
                         await asyncio.sleep(2)
                         await self.async_update()
+                        self.async_write_ha_state()
                         return  # Success, exit
                     else:
                         # set_artmode returned None/False — this can happen when
@@ -515,9 +519,13 @@ class FrameArtModeSwitch(SwitchEntity):
                         self.async_write_ha_state()
                         _LOGGER.info("Art Mode turned OFF for %s", self._device_name)
 
-                        # Wait for TV to confirm, then refresh state
+                        # Wait for TV to confirm, then refresh state.
+                        # async_update() only mutates attributes — publish
+                        # the refreshed state so the UI is corrected if the
+                        # TV ended up differing from the optimistic write.
                         await asyncio.sleep(2)
                         await self.async_update()
+                        self.async_write_ha_state()
                         return  # Success, exit
                     else:
                         _LOGGER.debug(
@@ -731,15 +739,17 @@ class SamsungTVPowerSwitch(SwitchEntity):
         return None
 
     def _get_ip_control(self) -> SamsungIPControl | None:
-        """Return an IP Control client if this TV is paired, else None.
+        """Return an IP Control client if paired AND enabled, else None.
 
         The token is read live from entry.data so that pairing (done via the
-        options flow) takes effect immediately, with no reload required.
+        options flow) takes effect immediately, with no reload required. The
+        channel must also be enabled in the options, consistent with every
+        other IP Control consumer (media_player, art mode switch, button).
         """
         if not self._host:
             return None
         token = self._entry.data.get(CONF_IP_CONTROL_TOKEN)
-        if not token:
+        if not token or not self._entry.options.get(CONF_ENABLE_IP_CONTROL, True):
             return None
         if self._ip_control is None or self._ip_control_token != token:
             self._ip_control = SamsungIPControl(self.hass, self._host, token=token)


### PR DESCRIPTION
## Summary

Fixes the Art Mode desync on 2024+ Frame TVs (switches/sensor stuck "off" after a reboot until manually toggled), plus the correctness issues found in a full review of the 8.0.0b26 code.

## 1. Art Mode stuck "off" on 2024+ Frame TVs (`4684ce9`)

Log evidence from a QE55LS03DA: the REST device-info poll reports `PowerState='standby'` **while** IP Control reads `artModeOn=True` on the same 6-minute window — on these models, Art Mode active ⇒ `PowerState='standby'`. Since `extra_state_attributes` trusted `standby` before the IP Control cache, `art_mode_status` was forced to `off` whenever Art Mode was on, leaving the power switch, the art mode switch and the Frame Art sensor stuck until manually toggled (PR #27 point 1, still present after #28 which only fixed the `unavailable` case).

- `media_player`: `_refresh_ip_art_mode` now reads the IP Control **power state first** (`powerControl` correctly reports `powerOn` in Art Mode / `powerOff` when really off) and stores `False` on `powerOff` — making the cache safe to trust unconditionally. `extra_state_attributes` now prefers the cache over the `PowerState='standby'` heuristic. Unpaired TVs keep the old behaviour.
- `sensor`: `FrameArtCoordinator._is_tv_powered_off` no longer treats media_player state `off` as powered off when `art_mode_status` is `on` (a Frame displaying art reports `off` by HA convention), mirroring `FrameArtModeSwitch._is_tv_on`. Without this the Frame Art sensor stayed "off" even with the fix above.

## 2. Companion fix: stale-cache expiry (`d675d00`)

With the cache now authoritative, a TV that stops answering on port 1516 (deep standby) must not pin a stale "art mode on": the cached value is cleared after 3 consecutive transport failures (~90s at the 30s refresh interval). Single transient failures still keep the last reading.

## 3. Code-review fixes (`00302c4`)

Full correctness review of b26 found:

- **`samsungws.stop_poll()` guard inverted** (high): only shut down when the ping thread was *already dead* → every entry reload leaked the ping thread and its WebSocket client threads, which kept reconnecting to the art-app channel in parallel with the new instance — silently recreating the multi-client condition #27 eliminated.
- **`number._is_tv_in_art_mode()` broken** (high): blocked polling when media_player was `off` (which is precisely the Art Mode state) and read a nonexistent `art_mode` attribute → brightness/color-temperature never refreshed in Art Mode and polled during normal viewing instead.
- **`art_get_brightness` service always errored** (`dict * 10` TypeError on every successful read); value now extracted like `number.py` does. Same extraction for `art_get_color_temperature` which returned the raw dict.
- **Power switch ignored `CONF_ENABLE_IP_CONTROL`** — now consistent with every other IP Control consumer.
- **`enable_thumbnail_fetch` service had no effect** — the flag was settable and displayed but never enforced.
- Art mode switch: state now published after the post-toggle refresh (UI corrected when the TV ends up differing from the optimistic write).
- Frame Art sensor: raises `UpdateFailed` during art-channel backoff instead of publishing the literal string `"unavailable"` as a state while claiming to be available.
- OAuth: `_async_refresh_oauth_token` waits on the shared refresh lock instead of sleeping a fixed 0.5s (real refreshes take longer, leaving the cycle on a stale token).
- Eager IP art-mode refresh task tracked and cancelled on entity removal (avoids `async_write_ha_state()` after removal).

## Testing

- All modified files compile; propagation chain verified end-to-end: IP refresh (30s) → `art_mode_status` → art mode switch + power switch + Frame Art sensor resync without manual toggling.
- Needs live validation on a 2024+ Frame (cc @potatosalad): after a reboot into Art Mode, `art_mode_status` should now track within ~30s.

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_