### PR TITLE
Add option to disable IP Control for Art Mode (default off)

### DIFF
--- a/custom_components/samsungtv_smart/config_flow.py
+++ b/custom_components/samsungtv_smart/config_flow.py
@@ -66,6 +66,7 @@ from .const import (
     CONF_DUMP_APPS,
     CONF_ENABLE_IP_CONTROL,
     CONF_EXT_POWER_ENTITY,
+    CONF_IP_CONTROL_ART_MODE,
     CONF_IP_CONTROL_TOKEN,
     CONF_LOGO_OPTION,
     CONF_OAUTH_TOKEN,
@@ -1036,6 +1037,12 @@ class OptionsFlowHandler(OptionsFlow):
                 vol.Required(
                     CONF_ENABLE_IP_CONTROL,
                     default=options.get(CONF_ENABLE_IP_CONTROL, True),
+                )
+            ] = bool
+            opt_schema[
+                vol.Required(
+                    CONF_IP_CONTROL_ART_MODE,
+                    default=options.get(CONF_IP_CONTROL_ART_MODE, False),
                 )
             ] = bool
 

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -100,6 +100,14 @@ CONF_OAUTH_TOKEN = "oauth_token"
 # Presence of a token means the feature is paired/enabled for that TV.
 CONF_IP_CONTROL_TOKEN = "ip_control_token"
 CONF_ENABLE_IP_CONTROL = "enable_ip_control"
+# Whether IP Control's artModeControl/getTVStates are used for Art Mode
+# detection and switching. Disabled by default: some firmwares (e.g. after a
+# factory reset) leave artModeControl wedged "on" regardless of the actual
+# panel state, causing false art_mode_status readings. Power on/off via IP
+# Control (CONF_ENABLE_IP_CONTROL / CONF_POWER_ON_METHOD) is unaffected by
+# this setting. Re-enable once the TV's firmware reports artModeControl
+# correctly again.
+CONF_IP_CONTROL_ART_MODE = "ip_control_art_mode"
 
 # Authentication methods
 AUTH_METHOD_OAUTH = "oauth"

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -233,4 +233,9 @@ STD_APP_LIST = {
         "logo": "",
         "name": "Plex",
     },
+    "com.samsung.tv.csfs": {
+        "st_app_id": "",
+        "logo": "",
+        "name": "Smart Hub",
+    },
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -103,6 +103,7 @@ from .const import (
     CONF_DUMP_APPS,
     CONF_ENABLE_IP_CONTROL,
     CONF_EXT_POWER_ENTITY,
+    CONF_IP_CONTROL_ART_MODE,
     CONF_IP_CONTROL_TOKEN,
     CONF_LOGO_OPTION,
     CONF_OAUTH_TOKEN,
@@ -1005,12 +1006,13 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
           so a TV that stays unreachable cannot pin a stale value forever.
         """
         client = self._get_ip_control_client()
-        if client is None:
-            _LOGGER.debug(
-                "IP Control art-mode refresh for %s: not paired "
-                "(no CONF_IP_CONTROL_TOKEN in entry.data) — skipping",
-                self._host,
-            )
+        if client is None or not self._get_option(CONF_IP_CONTROL_ART_MODE, False):
+            if client is None:
+                _LOGGER.debug(
+                    "IP Control art-mode refresh for %s: not paired "
+                    "(no CONF_IP_CONTROL_TOKEN in entry.data) — skipping",
+                    self._host,
+                )
             self._ip_art_mode_failures = 0
             if self._ip_art_mode is not None:
                 self._ip_art_mode = None

--- a/custom_components/samsungtv_smart/strings.json
+++ b/custom_components/samsungtv_smart/strings.json
@@ -111,7 +111,8 @@
           "show_channel_number": "Show Channel Number",
           "power_on_method": "Power On Method",
           "show_adv_opt": "Show Advanced Options",
-          "enable_ip_control": "Enable IP Control"
+          "enable_ip_control": "Enable IP Control",
+          "ip_control_art_mode": "Enable IP Control Art Mode"
         }
       },
       "menu": {

--- a/custom_components/samsungtv_smart/switch.py
+++ b/custom_components/samsungtv_smart/switch.py
@@ -36,6 +36,7 @@ from .const import (
     AUTH_METHOD_OAUTH,
     CONF_AUTH_METHOD,
     CONF_ENABLE_IP_CONTROL,
+    CONF_IP_CONTROL_ART_MODE,
     CONF_IP_CONTROL_TOKEN,
     CONF_IS_FRAME_TV,
     CONF_WS_NAME,
@@ -223,7 +224,9 @@ class FrameArtModeSwitch(SwitchEntity):
         the resulting state afterwards.
         """
         client = self._get_ip_control()
-        if client is not None:
+        if client is not None and self._entry.options.get(
+            CONF_IP_CONTROL_ART_MODE, False
+        ):
             try:
                 if turn_on:
                     await client.async_set_art_mode_on()

--- a/custom_components/samsungtv_smart/translations/en.json
+++ b/custom_components/samsungtv_smart/translations/en.json
@@ -111,7 +111,8 @@
           "show_channel_number": "Show Channel Number",
           "power_on_method": "Power On Method",
           "show_adv_opt": "Show Advanced Options",
-          "enable_ip_control": "Enable IP Control"
+          "enable_ip_control": "Enable IP Control",
+          "ip_control_art_mode": "Enable IP Control Art Mode"
         }
       },
       "menu": {

--- a/custom_components/samsungtv_smart/translations/es.json
+++ b/custom_components/samsungtv_smart/translations/es.json
@@ -111,7 +111,8 @@
           "show_channel_number": "Mostrar número de canal",
           "power_on_method": "Método de encendido",
           "show_adv_opt": "Mostrar opciones avanzadas",
-          "enable_ip_control": "Activar IP Control"
+          "enable_ip_control": "Activar IP Control",
+          "ip_control_art_mode": "Activar Modo Arte por IP Control"
         }
       },
       "menu": {

--- a/custom_components/samsungtv_smart/translations/fr.json
+++ b/custom_components/samsungtv_smart/translations/fr.json
@@ -111,7 +111,8 @@
           "show_channel_number": "Afficher le numéro de chaîne",
           "power_on_method": "Méthode d'allumage",
           "show_adv_opt": "Afficher les options avancées",
-          "enable_ip_control": "Activer IP Control"
+          "enable_ip_control": "Activer IP Control",
+          "ip_control_art_mode": "Activer le Mode Art par IP Control"
         }
       },
       "menu": {

--- a/custom_components/samsungtv_smart/translations/hu.json
+++ b/custom_components/samsungtv_smart/translations/hu.json
@@ -111,7 +111,8 @@
           "show_channel_number": "Használja a SmartThings TV csatornaszám információt",
           "power_on_method": "A TV bekapcsolásához használt módszer",
           "show_adv_opt": "Opciók menü mutatása",
-          "enable_ip_control": "IP Control engedélyezése"
+          "enable_ip_control": "IP Control engedélyezése",
+          "ip_control_art_mode": "Art Mode engedélyezése IP Control-on keresztül"
         }
       },
       "menu": {

--- a/custom_components/samsungtv_smart/translations/it.json
+++ b/custom_components/samsungtv_smart/translations/it.json
@@ -111,7 +111,8 @@
           "show_channel_number": "Usa informazioni Numero Canale TV da SmartThings",
           "power_on_method": "Metodo usato per accendere la TV",
           "show_adv_opt": "Mostra menu opzioni",
-          "enable_ip_control": "Abilita IP Control"
+          "enable_ip_control": "Abilita IP Control",
+          "ip_control_art_mode": "Abilita Art Mode tramite IP Control"
         }
       },
       "menu": {

--- a/custom_components/samsungtv_smart/translations/pt-BR.json
+++ b/custom_components/samsungtv_smart/translations/pt-BR.json
@@ -111,7 +111,8 @@
           "show_channel_number": "Use as informações de número dos canais de TV SmartThings",
           "power_on_method": "Método usado para ligar a TV",
           "show_adv_opt": "Mostrar menu opções",
-          "enable_ip_control": "Ativar IP Control"
+          "enable_ip_control": "Ativar IP Control",
+          "ip_control_art_mode": "Ativar Modo Arte via IP Control"
         }
       },
       "menu": {


### PR DESCRIPTION
## Problem

On some firmwares (e.g. after a factory reset / re-pairing), the IP Control `artModeControl` getter wedges `on` permanently — it keeps returning `artModeOn` even when the panel shows a real input. This was confirmed directly with a standalone probe (outside HA):

```
artModeControl.artMode  = artModeOn      <- flag stuck "on"
getTVStates.pictureMode = Gen_327705     <- real (non-art) picture
inputSource             = HDMI3
=> VERDICT: NOT art (real input)
```

The result is false `art_mode_status: on` readings, with transient flips driven by the desync cross-check resetting whenever `getTVStates`/`pictureMode` is momentarily unavailable.

## Change

Add a new option `CONF_IP_CONTROL_ART_MODE` (`ip_control_art_mode`), **disabled by default**, that gates whether IP Control is used for Art Mode:

- `media_player.py` — `_refresh_ip_art_mode` no longer issues `artModeControl`/`getTVStates` when the option is off; `art_mode_status` falls back to the Art API (WebSocket) and `device_info.PowerState` sources.
- `switch.py` — `FrameArtModeSwitch._set_artmode` only uses IP Control for switching when the option is on, otherwise uses the existing WebSocket fallback.
- `config_flow.py` — toggle shown under "Enable IP Control" in the options form (only when the TV is paired).
- Translations added (en/es/fr/hu/it/pt-BR + strings.json).

**Power on/off via IP Control (`CONF_ENABLE_IP_CONTROL` / the `IPControl` power-on method) is unchanged.** Only the Art Mode path is affected.

Because the option defaults to `False`, updating restores the pre-IP-Control Art Mode behaviour. Once a firmware reports `artModeControl` correctly again, re-enabling is a single checkbox.

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_