### PR TITLE
Fix Art Mode toggle/select regressions and show artwork as media image

### DIFF
--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -172,6 +172,11 @@ from .token_notify import (
 )
 
 ATTR_ART_MODE_STATUS = "art_mode_status"
+
+# Media title shown when the Frame is displaying Art Mode. SmartThings reports
+# the "running app" as "art" in that case; we surface a friendly title and use
+# the currently displayed artwork (current.jpg) as the media image.
+ART_MODE_MEDIA_TITLE = "Art Mode"
 ATTR_IP_ADDRESS = "ip_address"
 ATTR_PICTURE_MODE = "picture_mode"
 ATTR_PICTURE_MODE_LIST = "picture_mode_list"
@@ -1899,13 +1904,32 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         )
 
         remote_access = False
-        if (media_image_url := await self._local_media_image(new_media_title)) is None:
+        if new_media_title == ART_MODE_MEDIA_TITLE:
+            # Use the currently displayed artwork as the media image, maintained
+            # by the Frame Art coordinator at www/frame_art/<entry>/current.jpg.
+            media_image_url = self._art_mode_media_image()
+        elif (
+            media_image_url := await self._local_media_image(new_media_title)
+        ) is None:
             media_image_url = await self._logo.async_find_match(new_media_title)
             remote_access = media_image_url is not None
 
         self._attr_media_title = new_media_title
         self._attr_media_image_url = media_image_url
         self._attr_media_image_remotely_accessible = remote_access
+
+    def _art_mode_media_image(self) -> str | None:
+        """Return the local URL of the current artwork, if available.
+
+        The Frame Art coordinator downloads the currently displayed artwork to
+        ``www/frame_art/<entry_id>/current.jpg`` and exposes it at the matching
+        ``/local/...`` URL. We reuse it as the media image while in Art Mode so
+        the media_player card shows the artwork instead of a generic logo.
+        """
+        rel_path = os.path.join("frame_art", self._entry_id, "current.jpg")
+        if os.path.isfile(self.hass.config.path("www", rel_path)):
+            return f"/local/{rel_path.replace(os.sep, '/')}"
+        return None
 
     def _get_new_media_title(self):
         """Get the current media title."""
@@ -1928,6 +1952,12 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                     return None
 
                 if (run_app := self._st.channel_name) and run_app != "":
+                    # On a Frame TV, SmartThings reports the "running app" as
+                    # "art" while Art Mode is displayed. That is not a real app
+                    # — surface it as Art Mode (the artwork image is set as the
+                    # media image in _update_media).
+                    if run_app.lower() == "art":
+                        return ART_MODE_MEDIA_TITLE
                     # the channel name holds the running app ID
                     # regardless of the self._cloud_source value
                     # if the app ID is in the configured apps but is not running_app,
@@ -2879,6 +2909,39 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         Returns:
             bool: True if TV is ready in Art Mode, False if failed
         """
+        # Fast path: if the TV is already in Art Mode, there is nothing to do.
+        # A Frame in Art Mode reports media_player state OFF, so we must NOT
+        # treat state==OFF as "powered off" without checking art mode first —
+        # otherwise async_turn_on() would send KEY_POWER and toggle the panel
+        # OUT of Art Mode. The art_mode_status attribute (IP Control cache or
+        # WebSocket art channel) is the authoritative signal here.
+        if self.extra_state_attributes.get(ATTR_ART_MODE_STATUS) == STATE_ON:
+            _LOGGER.debug("Frame Art: already in Art Mode, ready")
+            return True
+
+        # Prefer the reliable IP Control path to enter Art Mode when paired:
+        # the explicit artModeOn command moves the panel even on TVs whose
+        # WebSocket art channel is unresponsive ("zombie") or whose
+        # set_artmode times out. Power on first (returns into the last state)
+        # then force Art Mode on.
+        ip_client = self._get_ip_control_client()
+        if ip_client is not None:
+            try:
+                if self.state == MediaPlayerState.OFF:
+                    if await ip_client.async_get_power_state() == "powerOff":
+                        await ip_client.async_power_on()
+                        await asyncio.sleep(3)
+                await ip_client.async_set_art_mode_on()
+                await asyncio.sleep(2)
+                _LOGGER.debug("Frame Art: Art Mode activated via IP Control")
+                return True
+            except SamsungIPControlError as ex:
+                _LOGGER.debug(
+                    "Frame Art: IP Control art-mode activation failed (%s); "
+                    "falling back to WebSocket",
+                    ex,
+                )
+
         # Check if TV is off, turn it on if needed
         if self.state == MediaPlayerState.OFF:
             _LOGGER.info("Frame Art: TV is off, turning it on first...")

--- a/custom_components/samsungtv_smart/switch.py
+++ b/custom_components/samsungtv_smart/switch.py
@@ -36,7 +36,6 @@ from .const import (
     AUTH_METHOD_OAUTH,
     CONF_AUTH_METHOD,
     CONF_ENABLE_IP_CONTROL,
-    CONF_IP_CONTROL_ART_MODE,
     CONF_IP_CONTROL_TOKEN,
     CONF_IS_FRAME_TV,
     CONF_WS_NAME,
@@ -222,11 +221,16 @@ class FrameArtModeSwitch(SwitchEntity):
         any IP Control failure (not paired, transport, auth) we fall back to the
         WebSocket so behaviour is never worse than before. The caller verifies
         the resulting state afterwards.
+
+        Note: this writing path is gated only by ``CONF_ENABLE_IP_CONTROL``
+        (inside ``_get_ip_control``), NOT by ``CONF_IP_CONTROL_ART_MODE``. The
+        latter only disables the *read* path (the ``artModeControl`` getter,
+        which can wedge "on" on some firmwares). Issuing the explicit
+        ``artModeOn``/``artModeOff`` command is reliable even on those TVs, so
+        we keep using it for switching.
         """
         client = self._get_ip_control()
-        if client is not None and self._entry.options.get(
-            CONF_IP_CONTROL_ART_MODE, False
-        ):
+        if client is not None:
             try:
                 if turn_on:
                     await client.async_set_art_mode_on()


### PR DESCRIPTION
Fixes three Art Mode issues reported on b33, found by analysing the TV logs.

## 1. Art Mode toggle ON fails after a toggle OFF (regression from #30)

#30 gated **both** reading and writing of Art Mode behind `CONF_IP_CONTROL_ART_MODE` (default off). But the wedge bug only affects the **read** path (the `artModeControl` getter). The explicit `artModeOn`/`artModeOff` **command** is reliable even on affected firmwares. With it gated off, the switch fell back to the WebSocket `set_artmode`, which returns `None` → toggle ON failed.

- `switch._set_artmode` now always uses IP Control to **set** Art Mode when paired/enabled (`CONF_ENABLE_IP_CONTROL`), independent of `CONF_IP_CONTROL_ART_MODE` (which now only disables the IP Control *detection* read).

## 2. `art_select_image` no longer works

`_ensure_art_mode_ready` treated `state == OFF` as "TV off" and called `async_turn_on()`, which on a Frame sends `KEY_POWER` and toggles **out** of Art Mode, then tried to re-enable it over the (unreliable) WebSocket.

- Short-circuit when already in Art Mode (`art_mode_status == on`).
- Otherwise power on + enter Art Mode via **IP Control** (reliable), WebSocket fallback retained.

## 3. `App 'art' not found in any app list`

SmartThings reports the running app as `art` while displaying Art Mode.

- Surface it as an **"Art Mode"** media title and use the currently displayed artwork (`www/frame_art/<entry>/current.jpg`, maintained by the Frame Art coordinator) as the media image, instead of trying to resolve a non-existent app id.

## Notes

Only the IP Control **read/detection** stays gated by `CONF_IP_CONTROL_ART_MODE` (default off), as added in #30. Writing/switching and power on/off over IP Control are always available when enabled.

If the WebSocket art channel is a "zombie", `select_image` itself (WebSocket transport) can still fail — separate transport issue, not addressed here.

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_