### PR TITLE
Make Art Mode switch refresh every 5s (match SmartThings cadence)

### DIFF
--- a/custom_components/samsungtv_smart/switch.py
+++ b/custom_components/samsungtv_smart/switch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 import logging
 from typing import Any
 
@@ -47,6 +48,15 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Poll the switch entities every 5s so the Art Mode / power switches track the
+# TV as responsively as the SmartThings cloud poll. async_update only reads the
+# media_player's already-published art_mode_status attribute (no extra TV
+# network call in the normal case), so the short interval is cheap. Without
+# this override Home Assistant falls back to its 30s default scan interval,
+# which is what made the Art Mode switch feel sluggish on TVs where IP Control
+# is disabled (no faster push path).
+SCAN_INTERVAL = timedelta(seconds=5)
 
 COMPONENT_MAIN = "main"  # SmartThings component
 


### PR DESCRIPTION
Follow-up to #33: the Art Mode switch felt sluggish (~30s to sync) on TVs where IP Control is disabled.

## Root cause

On a TV with IP Control disabled there is no fast push path for Art Mode state, and `switch.py` defined no `SCAN_INTERVAL`, so Home Assistant polled the switch at its **30s default**. SmartThings, by comparison, polls every 5s — hence the perceived lag.

(Log note: the apparent on/off "flapping" in the diagnostic logs was actually **two different Frame TVs** interleaved — 192.168.1.161 in Art Mode → `on`, 192.168.1.31 on a normal input → `off` — not one switch oscillating.)

## Changes

- `switch.py` — add `SCAN_INTERVAL = timedelta(seconds=5)` (`e03609e`). `async_update` only re-reads the media_player's already-published `art_mode_status` attribute (no extra TV network call in the normal case), so the short interval is cheap.
- `media_player.py` — lower `IP_ART_MODE_REFRESH_INTERVAL` from 30s to 5s (`1057f35`) so the IP Control art-mode cache (when enabled) tracks at the same cadence.

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_