### PR TITLE
Publish art_mode_status immediately on art-channel transitions

### DIFF
--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -980,7 +980,15 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         callback fires from the art receive loop (the event loop), so
         scheduling a task is safe; ``_refresh_ip_art_mode`` no-ops for TVs that
         are not IP-paired.
+
+        On TVs without IP Control, ``art_api.art_mode`` (read directly by
+        ``extra_state_attributes``) was just updated by the same event, but
+        nothing publishes that change until the next polled update — up to
+        ``SCAN_INTERVAL`` (5 s) later, and the Art Mode switch may poll in
+        between and read the stale value. Write state immediately so the new
+        ``art_mode_status`` is visible right away.
         """
+        self.async_write_ha_state()
         self.hass.async_create_task(self._refresh_ip_art_mode())
 
     async def _refresh_ip_art_mode(self, _now=None) -> None:


### PR DESCRIPTION
Follow-up to #35: even with the switch now polling every 5s, the Art Mode switch could briefly show the wrong state right after toggling Art Mode on a TV with IP Control disabled.

## Root cause

`extra_state_attributes` reads `art_api.art_mode`, which is updated immediately by the `art_mode_changed`/`go_to_standby` events from the async art channel. But nothing called `async_write_ha_state()` on the media_player when those events arrived — `_on_art_transition` only refreshed the IP Control cache, a no-op when IP Control is disabled. So the media_player's published `art_mode_status` attribute stayed stale until its next 5s poll, and the Art Mode switch (polling on its own 5s cycle) could read that stale value in between.

Confirmed in logs: `art_mode_changed: on` received at `12:49:37.731`, but the switch's poll at `12:49:42.108` still read `art_mode_status: off`.

## Fix

`media_player.py` — `_on_art_transition` now calls `self.async_write_ha_state()` immediately when an art-channel transition is received, publishing the updated `art_mode_status` right away instead of waiting for the next poll.

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_