### PR TITLE
docs: warn against IP Control Art Mode and refresh 8.0.0 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ After initial setup, click **Configure** on the integration card to access these
 | **External power entity** | Use an external sensor to determine power state |
 | **Toggle Art Mode** | Toggle Art Mode when turning on a Frame TV that is already in Art Mode |
 | **Enable IP Control** | Use the local JSON-RPC channel (port 1516) for reliable power on/off without SmartThings (shown only once the TV is paired for IP Control) |
-| **Enable IP Control Art Mode** | Use IP Control to read and switch Art Mode. **Off by default** — see [IP Control reports Art Mode "on" when it isn't](#ip-control-reports-art-mode-on-when-it-isnt) before enabling |
+| **Enable IP Control Art Mode** | Use IP Control to read and switch Art Mode. **Off by default — leave it off unless you know your firmware handles it.** ⚠️ Can break Art Mode entirely and may need a factory reset to recover (seen on QE55LS03D fw 2123). See [IP Control reports Art Mode "on" when it isn't](#ip-control-reports-art-mode-on-when-it-isnt) |
 | **Ping port** | Port used to detect TV presence |
 | **WS name** | Name shown on the TV when pairing (default: `[Home Assistant]`) |
 
@@ -602,6 +602,9 @@ SmartThings caches the picture mode value. This fork automatically sends a `refr
 When the TV wakes from standby (e.g. via an automation), the WebSocket connection needs a short time to re-establish before the Art API becomes available. This is normal — the integration will self-recover within a minute. If you experience consistent failures in morning automations, add a 60–90 second delay after the TV turns on before triggering Art Mode commands.
 
 ### IP Control reports Art Mode "on" when it isn't
+
+> [!WARNING]
+> **Do not enable *Enable IP Control Art Mode* unless you know your firmware handles it correctly.** On affected firmwares it can leave **Art Mode completely broken** (detection stuck/flickering, switching unreliable) — and the damage can persist at the TV level, requiring a **factory reset** to recover. This was observed on a **QE55LS03D with firmware 2123**. The option is **off by default**; leave it off and use the WebSocket / Frame Art path, which is unaffected. Power on/off over IP Control is a separate setting and is **not** impacted.
 
 On some Frame TVs the local IP Control (JSON-RPC, port 1516) `artModeControl` flag can **wedge "on"**: it keeps returning `artModeOn` even when the TV is on a real input (e.g. HDMI), so `art_mode_status` is reported as `on` permanently or flickers between `on` and `off`. The flag is wrong at the source — the same value is returned even when querying the TV directly, outside Home Assistant. The actual panel state in that situation is given by `getTVStates.pictureMode` (`Ambient` only while art is really on the panel).
 

--- a/RELEASE_NOTES_8.0.0.md
+++ b/RELEASE_NOTES_8.0.0.md
@@ -8,6 +8,17 @@
 (cloud), the local WebSocket, and the new **IP Control** channel (JSON-RPC) —
 with each channel independently selectable and resilient to a bad credential.
 
+> [!WARNING]
+> **Do not enable *Enable IP Control Art Mode*** unless you know your firmware
+> handles it correctly. On affected firmwares it can leave **Art Mode completely
+> broken** — detection stuck/flickering, switching unreliable — and the damage
+> can persist at the TV level, requiring a **factory reset** to recover. This was
+> observed on a **QE55LS03D with firmware 2123**. The option is **off by
+> default**; leave it off and let Art Mode run over the WebSocket / Frame Art
+> channel (unaffected). Power on/off over IP Control is a separate setting and is
+> **not** impacted. See *Troubleshooting → "IP Control reports Art Mode 'on' when
+> it isn't"* in the README.
+
 ---
 
 ## Highlights
@@ -75,8 +86,17 @@ with each channel independently selectable and resilient to a bad credential.
 
 ## Frame / Art Mode
 
-- Art Mode switch with retry and live state, now backed by the power-gated
-  IP Control read and the IP-Control-first set path.
+- Art Mode switch with retry and live state. By default it tracks Art Mode over
+  the WebSocket / Frame Art channel; IP Control read/switch is opt-in (see the
+  warning above).
+- **Responsive switch sync**: the Art Mode and power switches poll every 5 s
+  (matching the SmartThings cadence) instead of Home Assistant's 30 s default,
+  and `art_mode_status` is now published **immediately** on an art-channel
+  transition (`art_mode_changed` / `go_to_standby`) instead of waiting for the
+  next poll — the switch reflects a toggle within ~1 s.
+- The displayed artwork is surfaced as the media-player image (with cache
+  busting so the frontend reloads it when the picture changes), and the running
+  app `art` is shown as an **"Art Mode"** title.
 - Slideshow control routed automatically to the API the TV actually supports
   (`slideshow` vs `auto_rotation`), accepting custom durations.
 - Bundled `folder-gallery-card` for the art gallery frontend.
@@ -92,8 +112,13 @@ with each channel independently selectable and resilient to a bad credential.
 
 ## Known limitations / not yet validated
 
-- IP Control is confirmed on **Frame 2024/2025**. Older generations
-  (Tizen 5.5 / 6.0) are **not yet validated** — protocol differences possible.
+- IP Control **power/reboot** is confirmed on **Frame 2024/2025**. Older
+  generations (Tizen 5.5 / 6.0) are **not yet validated** — protocol differences
+  possible.
+- IP Control **Art Mode** (the *Enable IP Control Art Mode* option) is **not
+  safe on all firmwares**: it can wedge or break Art Mode entirely and may need
+  a factory reset to recover (seen on QE55LS03D fw 2123). It stays **off by
+  default** — see the warning above.
 - The reboot/IP-Control recovery of an unresponsive ("zombie") Art WebSocket is
   implemented but **not yet confirmed empirically** in that exact state.
 - Brightness / colour-temperature capability flags are re-detected on every


### PR DESCRIPTION
Updates `README.md` and `RELEASE_NOTES_8.0.0.md` as requested.

## Warning: IP Control Art Mode can break Art Mode

Adds a prominent `[!WARNING]` block (release notes + README troubleshooting section, plus the options table) that enabling **Enable IP Control Art Mode** can leave Art Mode **completely broken** on affected firmwares — detection stuck/flickering, switching unreliable — and the damage can persist at the TV level, requiring a **factory reset** to recover. Observed on a **QE55LS03D with firmware 2123**. The option stays off by default; power on/off over IP Control is unaffected.

## Release notes refresh

- Frame / Art Mode section now reflects that Art Mode tracks the WebSocket / Frame Art channel by default (IP Control read/switch is opt-in).
- Documents the recent sync fixes: switches poll every 5 s (matching SmartThings) instead of HA's 30 s default, and `art_mode_status` is published immediately on `art_mode_changed` / `go_to_standby`.
- Documents artwork as the media-player image (cache-busted) and the "Art Mode" title.
- Known limitations split IP Control power/reboot (validated on 2024/2025) from IP Control Art Mode (not safe on all firmwares).

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_