### PR TITLE
fix: unescape HTML entities in device name/model (Device Info)

### DIFF
--- a/custom_components/samsungtv_smart/entity.py
+++ b/custom_components/samsungtv_smart/entity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 from typing import Any
 
 from homeassistant.const import (
@@ -30,9 +31,9 @@ class SamsungTVEntity(Entity):
         self._mac = config.get(CONF_MAC)
         self._attr_unique_id = config.get(CONF_ID, entry_id)
 
-        model = config.get(CONF_DEVICE_MODEL, "Samsung TV")
+        model = html.unescape(config.get(CONF_DEVICE_MODEL, "Samsung TV"))
         if dev_name := config.get(CONF_DEVICE_NAME):
-            model = f"{model} ({dev_name})"
+            model = f"{model} ({html.unescape(dev_name)})"
 
         self._attr_device_info = DeviceInfo(
             manufacturer="Samsung Electronics",


### PR DESCRIPTION
## Problem

Samsung TVs return their friendly name HTML-escaped via the HTTP device-info API (e.g. `32&quot; The Frame` instead of `32" The Frame`). This raw, escaped string is stored in the config entry and shown verbatim in Home Assistant's "Device Info" card, so the device model/name displays the literal `&quot;` instead of `"`.

## Fix

Apply `html.unescape()` to the model and device-name strings in `entity.py` at the point the `DeviceInfo` is built. Since `entity.py` runs on every entity creation, this fixes existing installs on the next Home Assistant restart — no re-pairing or re-setup needed.

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_