### PR TITLE
fix: go_to_standby art event falsely forces art_mode_status off

### DIFF
--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -492,7 +492,17 @@ class SamsungTVAsyncArt:
             self.art_mode = data.get("status") == "on"
             self._fire_art_event()
         elif sub_event == "go_to_standby":
-            self.art_mode = False
+            # Ambiguous, not a definitive "art mode off": the panel also
+            # fires this when it dims for its own power-save sleep timer
+            # (e.g. no motion / low ambient light) while still considered
+            # "in Art Mode" by the TV and other status checks. The legacy
+            # sync WS handler (samsungws.py) already treats this event as
+            # ArtModeStatus.Unavailable rather than Off for the same reason.
+            # Forcing art_mode False here made it the priority-3 source for
+            # extra_state_attributes on TVs without IP Control paired,
+            # flipping art_mode_status to "off" while artwork was still on
+            # screen. Leave self.art_mode untouched and let the event
+            # callback trigger an authoritative re-check instead.
             self._fire_art_event()
 
         # Check for error


### PR DESCRIPTION
## Problem

User reported the Art Mode switch showing OFF while the media_player card title still read "Art Mode" with artwork visibly displayed and Power ON — a renewed version of an inconsistency previously thought fixed.

## Root cause

`art.py`'s async Art API handler forced `self.art_mode = False` on every `go_to_standby` event from the TV's art WebSocket channel. That event also fires when the Frame's panel merely dims for its own power-save sleep timer (e.g. low ambient light / no motion detected) while Art Mode is otherwise still considered active by the TV — it does not reliably mean "Art Mode is off".

The legacy synchronous WS handler (`samsungws.py`) already treats this same event as `ArtModeStatus.Unavailable` rather than `Off`, for the same reason.

For TVs without IP Control paired (this user's case — confirmed via logs that `CONF_ENABLE_IP_CONTROL` was disabled), `art_api.art_mode` is the priority-3 fallback source for the `art_mode_status` attribute that drives the switch. The forced `False` on `go_to_standby` flipped that attribute to "off" for extended periods while the TV kept showing artwork.

## Fix

Stop forcing `art_mode = False` on `go_to_standby`. Leave the cached value untouched and continue to fire the existing art-event callback, which already triggers an authoritative re-check via IP Control where available.

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_