### PR TITLE
fix: corroborate art_mode with SmartThings when local signal says off

### DIFF
--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -2038,6 +2038,12 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             features |= MediaPlayerEntityFeature.SELECT_SOUND_MODE
         return features
 
+    def _smartthings_reports_art(self) -> bool:
+        """Return True if the SmartThings cloud reports the running app as art."""
+        if not self._st or self._st.state == STStatus.STATE_OFF:
+            return False
+        return (self._st.channel_name or "").lower() == "art"
+
     def _art_mode_is_on(self) -> bool | None:
         """Return the authoritative local Art Mode state, or None if unknown.
 
@@ -2046,8 +2052,19 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         full rationale):
           1. IP Control cache (power-state aware) — wins when this TV is paired
           2. device_info PowerState='standby' — TV fully off, art cannot be on
-          3. async Art API cache — kept live by art-channel WebSocket events
+          3. async Art API cache — kept live by art-channel WebSocket events,
+             corroborated by SmartThings: on TVs without IP Control, the art
+             WebSocket channel can latch onto a False reading (e.g. a
+             go_to_standby-like transition) and never receive a follow-up
+             event confirming the panel actually came back on. If SmartThings
+             (which independently polls the TV) already reports the running
+             app as "art", trust that over a local False.
+             Trade-off: SmartThings itself lags ~30-45s on every transition,
+             so on a genuine exit from Art Mode this can keep reporting "on"
+             for up to that long, until SmartThings catches up.
           4. legacy WS artmode_status — fallback before the async API has a value
+          5. SmartThings alone — covers the case where the async API has no
+             value at all yet (e.g. right after HA startup)
         """
         if self._ip_art_mode is not None:
             return self._ip_art_mode
@@ -2057,9 +2074,13 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             self.hass.data.get(DOMAIN, {}).get(self._entry_id, {}).get(DATA_ART_API)
         )
         if art_api is not None and art_api.art_mode is not None:
+            if not art_api.art_mode and self._smartthings_reports_art():
+                return True
             return art_api.art_mode
         if self._ws.artmode_status != ArtModeStatus.Unsupported:
             return self._ws.artmode_status == ArtModeStatus.On
+        if self._smartthings_reports_art():
+            return True
         return None
 
     @property


### PR DESCRIPTION
## Problem

Even after #42 (stop forcing art_mode=False on go_to_standby) and #43 (title trusts local signal), the Art Mode switch still got stuck "off" on a 2024 Frame with IP Control disabled, after Netflix → Art Mode. The media_player title correctly showed "Art Mode" (via the SmartThings branch in `_get_new_media_title`), proving SmartThings already knew Art Mode was active — but `art_api.art_mode` (the local async Art API cache) stayed False.

## Root cause

On TVs without IP Control paired, `art_api.art_mode` is priority-3 in `_art_mode_is_on()`. It is only updated by WebSocket events (`artmode_status`, `art_mode_changed`) from the TV's art channel. If the TV's art channel reports (or previously latched) a False reading and never sends a follow-up event confirming the panel actually returned to Art Mode, the cache never self-corrects — there is no periodic poll to fall back on.

## Fix

Use SmartThings as corroboration: if the local cache says off but SmartThings independently reports the running app as `"art"`, trust SmartThings.

**Trade-off (deliberate):** SmartThings lags ~30-45s on every transition. So on a genuine exit from Art Mode, the switch may keep reporting "on" for up to that long until SmartThings catches up. This was discussed and accepted as preferable to leaving the false-negative uncorrected indefinitely.

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_