### PR TITLE
fix: Art Mode flaps on while an app is foreground (2024 Frame)

### DIFF
--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -2797,6 +2797,15 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         self._running_app = running_app
         self._source = source
 
+        # Reflect the new source on the card right away instead of waiting for
+        # the next scheduled poll (~SCAN_INTERVAL). Recompute the media title /
+        # image from the optimistic running_app and push the state; the Art
+        # Mode switch (a separate entity tracking our state changes) updates
+        # with it, so it no longer lingers on "Art Mode"/on for several seconds
+        # after launching an app.
+        await self._update_media()
+        self.async_write_ha_state()
+
     async def _async_select_source_delayed(self, source):
         """Select input source with delayed ST option."""
         if self._st:

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -2066,6 +2066,16 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
           5. SmartThings alone — covers the case where the async API has no
              value at all yet (e.g. right after HA startup)
         """
+        # A real app visibly in the foreground means the panel is showing that
+        # app, not artwork — whatever the art WebSocket channel claims. On 2024
+        # Frames that channel is unreliable: it emits spurious
+        # art_mode_changed='on' events while an app is actually on screen,
+        # which made the switch and media title flap back to "Art Mode" during
+        # normal app use. self._running_app is driven by the app's visibility
+        # flag, so it is DEFAULT_APP whenever no app is foreground (live TV or
+        # Art Mode) and the app id only while that app is genuinely visible.
+        if self._running_app not in (None, DEFAULT_APP):
+            return False
         if self._ip_art_mode is not None:
             return self._ip_art_mode
         if self._get_device_spec("PowerState") == "standby":

--- a/custom_components/samsungtv_smart/switch.py
+++ b/custom_components/samsungtv_smart/switch.py
@@ -659,6 +659,12 @@ class FrameArtModeSwitch(SwitchEntity):
         art_status = new_state.attributes.get("art_mode_status")
         if art_status == "on":
             self._attr_is_on = True
+        elif art_status == "off":
+            # Mirror the media_player's authoritative art_mode_status directly,
+            # including when the TV is ON but no longer in Art Mode (e.g. an app
+            # was just launched). Without this the switch kept its previous
+            # "on" value and lingered until its own poll.
+            self._attr_is_on = False
         elif new_state.state == STATE_OFF:
             self._attr_is_on = False
         elif new_state.state in ("unknown", "unavailable"):


### PR DESCRIPTION
## Problem

With art-channel debug now enabled, the logs reveal the TV emitting **spurious `art_mode_changed: 'on'` events while Netflix was genuinely the visible foreground app**:

```
09:01:45.800 art_mode_changed: off   → title=netflix ✓
09:02:24.877 art_mode_changed: on    → title flaps to "Art Mode" ✗ (Netflix still on screen)
09:03:01.403 art_mode_changed: off   → title=netflix ✓
09:03:44.062 art_mode_changed: on    → ...
```

This made both the Art Mode switch and the media_player title flap back to "Art Mode" during normal app use, even though `running app is: netflix` throughout. Confirms the 2024 Frame's art WebSocket channel is unreliable in *both* directions.

## Root cause

`_art_mode_is_on()` trusted the art-channel-driven `art_api.art_mode` (or, via #44, SmartThings) without checking whether a real app was actually on screen.

## Fix

Guard `_art_mode_is_on()` with `self._running_app`. That value is driven by the app's **visibility** flag (`_set_running_app` reads `result["visible"]`), so it is `DEFAULT_APP` whenever no app is foreground (live TV *or* Art Mode), and the app id only while that app is genuinely visible. A visibly foreground real app means the panel is showing that app, not artwork — so return False regardless of what the art channel claims.

This is a fast, local, reliable signal (the logs show it stayed `netflix` steadily while the art events flapped) and fixes both the switch and the title.

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_