### PR TITLE
fix: REST app launch broken on 2024 Frame (SSL-only port needs https)

### DIFF
--- a/custom_components/samsungtv_smart/api/samsungws.py
+++ b/custom_components/samsungtv_smart/api/samsungws.py
@@ -74,8 +74,14 @@ def _set_ws_logger_level(level: int = logging.CRITICAL) -> None:
 
 
 def _format_rest_url(host: str, append: str = "", port: int = 8001) -> str:
-    """Return URL used for rest commands."""
-    return f"http://{host}:{port}/api/v2/{append}"
+    """Return URL used for rest commands.
+
+    Newer (2024+) Frame TVs only expose the REST API on the SSL port (8002)
+    and reset the connection on a plain HTTP request, so the scheme has to
+    follow the port instead of being hardcoded to http.
+    """
+    scheme = "https" if port == 8002 else "http"
+    return f"{scheme}://{host}:{port}/api/v2/{append}"
 
 
 def gen_uuid() -> str:
@@ -507,15 +513,16 @@ class SamsungTVWS:
     def _rest_request(self, target, method="GET"):
         """Send a rest command using http protocol."""
         url = _format_rest_url(self.host, target, self.port)
+        verify = not self._is_ssl_connection()
         try:
             if method == "POST":
-                response = requests.post(url, timeout=self.timeout)
+                response = requests.post(url, timeout=self.timeout, verify=verify)
             elif method == "PUT":
-                response = requests.put(url, timeout=self.timeout)
+                response = requests.put(url, timeout=self.timeout, verify=verify)
             elif method == "DELETE":
-                response = requests.delete(url, timeout=self.timeout)
+                response = requests.delete(url, timeout=self.timeout, verify=verify)
             else:
-                response = requests.get(url, timeout=self.timeout)
+                response = requests.get(url, timeout=self.timeout, verify=verify)
         except requests.ConnectionError as exc:
             raise HttpApiError(
                 "TV unreachable or feature not supported on this model."


### PR DESCRIPTION
## Problem

Preston reported on #40 that 8b45 fixed app/channel buttons on his 2020 and 2021 TVs, but the 2024 Frame still fails, even after a power cycle and OAuth refresh:

```
File ".../api/samsungws.py", line 520, in _rest_request
    raise HttpApiError(
        "TV unreachable or feature not supported on this model."
    ) from exc
custom_components.samsungtv_smart.api.samsungws.HttpApiError: TV unreachable or feature not supported on this model.
```

caused by `requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))`.

## Root cause

`_format_rest_url()` always builds a `http://` URL:

```python
def _format_rest_url(host, append="", port=8001):
    return f"http://{host}:{port}/api/v2/{append}"
```

But 2024+ Frame TVs only expose the REST API on the SSL port (8002) and reset the connection on a plain HTTP request — the websocket connection already accounts for this via `_is_ssl_connection()` (`self.port == 8002`) to pick `ws`/`wss`, but the REST helper never did. This explains why 2020/2021 (plain HTTP, port 8001) work while the 2024 model (SSL-only, port 8002) does not. It's also consistent with the async REST client already passing `verify_ssl=False` — it was clearly written assuming https, just never wired up the scheme.

## Fix

- `_format_rest_url()` now picks `https` when `port == 8002`, `http` otherwise.
- The sync `_rest_request()` now passes `verify=not self._is_ssl_connection()` to `requests`, mirroring the async client's `verify_ssl=False` for the self-signed cert.

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_