### PR TITLE
fix: wake panel from Art Mode before switching HDMI source

### DIFF
--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -2772,12 +2772,22 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
         if self._source_list and source in self._source_list:
             source_key = self._source_list[source]
+            if self._art_mode_is_on():
+                # The panel ignores HDMI/source-switch keys while in Art
+                # Mode (confirmed by Preston: the TV stayed on the previous
+                # source and art_mode_status never changed). KEY_HOME wakes
+                # it first, matching the manual home+source workaround.
+                await self.async_send_command("KEY_HOME")
+                await asyncio.sleep(KEYPRESS_DEFAULT_DELAY)
             if not await self._async_send_keys(source_key):
                 return
         elif self._source_list and (resolved := self._resolve_source_by_id(source)):
             # Accept technical IDs (e.g. "HDMI3") in addition to display names
             source_key = resolved[1]
             source = resolved[0]  # Use display name for state
+            if self._art_mode_is_on():
+                await self.async_send_command("KEY_HOME")
+                await asyncio.sleep(KEYPRESS_DEFAULT_DELAY)
             if not await self._async_send_keys(source_key):
                 return
         elif self._app_list and source in self._app_list:


### PR DESCRIPTION
## Problem

Preston reported (#40): switching source to HDMI/PC while the TV was in Art Mode left `art_mode_status` stuck "on" in HA, and the actual source change silently failed on the TV. Switching to Netflix (an app) worked correctly. He noted "source itself doesn't work on any of the TVs when in art mode," and found a manual workaround: pressing Home then Source wakes the panel first.

## Root cause

2024+ Frame panels ignore HDMI/source-switch key commands while the panel is in Art Mode. `async_select_source` already has a wake/clear path for app launches (via `self._running_app`), but the HDMI/source-list branches just sent the source key directly and optimistically wrote the new source — so HA showed the new source selected while the TV's panel never actually left Art Mode.

## Fix

`async_select_source` now sends `KEY_HOME` (with the standard key delay) to wake the panel first when `self._art_mode_is_on()` is true, before sending the actual source key — for both the `source_list` and resolve-by-id paths. Matches the manual workaround Preston already found.

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_