### PR TITLE
[v8][2/n] Document Samsung Ex-Link protocol internals

### DIFF
--- a/notes/QN55LS03FAFXZA/EXLINK_DECOMPILED.md
+++ b/notes/QN55LS03FAFXZA/EXLINK_DECOMPILED.md
@@ -1,0 +1,447 @@
+# Samsung ExLink / RS-232 Decompile
+
+Device: Samsung QN55LS03FAFXZA
+Samsung support: https://www.samsung.com/us/support/downloads/?model=N0003009&modelCode=QN55LS03FAFXZA
+Documented: 2026-06-18
+Firmware: T-PTMFAKUC-0090-1296.8
+Tizen: 9.0.0
+Linux: 5.4.261 armv7l
+
+## Sources
+
+Live OS state:
+
+- `/proc/cmdline`
+- `/proc/tty/drivers`
+- `/proc/consoles`
+- `/sys/class/tty/*`
+- `/sys/firmware/devicetree/base`
+- `systemctl status`
+- `gdbus introspect --system`
+
+Pulled from the TV:
+
+- `/usr/bin/TIFADaemon_L`
+- `/usr/lib/libIUARTService.so`
+- `/usr/bin/TIFSDaemon`
+- `/usr/bin/automation-helper`
+- `/usr/bin/vddebugmenu`
+- `/prd/usr/bin/kfactoryd`
+- `/prd/usr/bin/kfactoryd.sh`
+- `/usr/lib/modules/5.4.261/kernel/kfactory_drv.ko`
+- `/lib/modules/linux/kernel/kfactory_drv.ko`
+- `/usr/lib/systemd/system/org.tizen.tv.automation-service.service`
+- `/usr/lib/systemd/system/org.tizen.tv.automation-service.path`
+- `/usr/lib/systemd/system/org.tizen.tv.factory-service.service`
+- `/usr/lib/systemd/system/dlogutil.service`
+- `/prd/etc/HyperUART/huart0_ipsetting.sh`
+- `/prd/etc/HyperUART/huart_lib.sh`
+- `/prd/etc/HyperUART/sdbd_start.sh`
+- `/usr/lib/udev/rules.d/60-serial.rules`
+
+## Short Answer
+
+Yes, the operating system has an ExLink / RS-232 handling stack.
+
+The main responder is:
+
+- service: `org.tizen.tv.automation-service`
+- process: `/usr/bin/TIFADaemon_L`
+- D-Bus object: `/TIFacAutoObj`
+- D-Bus interface: `org.tizen.tv.automationservice`
+- unit: `/usr/lib/systemd/system/org.tizen.tv.automation-service.service`
+- activation path: `/usr/lib/systemd/system/org.tizen.tv.automation-service.path`
+- trigger file: `/tmp/AFTER_PRODUCTION`
+
+On this TV, the service was active as root. It exports methods for Ex-UART, RS-232 ACKs, serial source packet length, baud-rate changes, RJP data, and SS/EP/RJP protocol reads.
+
+There does not appear to be a separate `exlinkd` daemon or TCP listener. The OS interface is D-Bus plus native UART devices.
+
+## Runtime Services
+
+| Unit / Process | Runs As | Purpose |
+| --- | --- | --- |
+| `org.tizen.tv.automation-service.service` -> `/usr/bin/TIFADaemon_L` | root | Main Ex-UART / RS-232 / automation protocol daemon. Owns `org.tizen.tv.automation-service` on the system bus. |
+| `org.tizen.tv.factory-service.service` -> `/usr/bin/TIFSDaemon` | root | Factory service. Imports Ex-UART client APIs and factory power/jack controls, but is not the primary byte-stream handler. |
+| `/prd/usr/bin/kfactoryd` | root | Bridges factory userspace to `/dev/kfactory`. Not the ExLink byte-stream daemon. |
+| `dlogutil.service` -> `/usr/bin/print_dlog.sh` | root | Sends logs to the tty console path. Debug/console plumbing, not ExLink protocol handling. |
+
+## Kernel And Device Clues
+
+`/proc/cmdline` contains:
+
+```text
+console=ttyS3,115200N8 rs232=1 model=4kframe
+```
+
+`/proc/consoles` reports:
+
+```text
+ttyS3 -W- (EC p ) 204:67
+```
+
+Serial drivers:
+
+| Driver | Device Prefix | Notes |
+| --- | --- | --- |
+| `sdp-uart2` | `/dev/ttyS*` | Samsung platform UARTs. |
+| `sdp-uart2` | `/dev/ttySD*` | Additional Samsung platform serial device range. |
+| `usbserial` / `cp210x` | `/dev/ttyUSB*` | Silicon Labs CP2102N USB-to-UART. |
+
+Observed serial devices:
+
+| Device | Driver / Source | Notes |
+| --- | --- | --- |
+| `/dev/ttyS0` | `sdp-uart2` | Platform UART. |
+| `/dev/ttyS1` | `sdp-uart2` | Platform UART. |
+| `/dev/ttyS2` | `sdp-uart2` | Device tree describes `serial@00550F00` as `CEC interface with OCBox using ttyS2`. |
+| `/dev/ttyS3` | `sdp-uart2` | Kernel console from `console=ttyS3,115200N8`. |
+| `/dev/ttySD0` | `sdp-uart2` | Additional Samsung serial device. |
+| `/dev/ttyUSB0` | `cp210x` | Silicon Labs CP2102N USB-to-UART. Symlinked as `/dev/ttyIOT`. |
+
+The pulled automation binary references this device-tree path:
+
+```text
+/proc/device-tree/factory/samsung,ex-link_uart
+```
+
+That exact node was not present on this live firmware. The binary falls back through platform APIs such as `ppi_link_uart_get_node`, so the ExLink UART path is probably resolved by platform/power-control code rather than by that literal node on this model.
+
+## Automation D-Bus API
+
+Live introspection:
+
+```text
+bus:       org.tizen.tv.automation-service
+object:    /TIFacAutoObj
+interface: org.tizen.tv.automationservice
+```
+
+Methods:
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `SendRS232Ack` | `in i pType, in i pLen, in au pData, out (i) ret` | Sends an RS-232 ACK-style response. |
+| `SendMessageByExUart` | `in i pLen, in au pData, out (i) ret` | Sends raw bytes through the Ex-UART path. |
+| `ExecuteCommand` | `in i data0, in i data1, out (i) ret` | Generic automation command. |
+| `ExecuteCommandWithData` | `in i data0, in i data1, in au data, in i len, out (i) ret` | Generic automation command with byte payload. |
+| `GetSsProtocolData` | `out au data, out (i) ret` | Reads SS protocol data. |
+| `GetEpProtocolData` | `out au data, out (i) ret` | Reads EP protocol data. |
+| `CloseExUart` | `out (i) ret` | Closes the Ex-UART path. |
+| `ChangeBaudRateExUart` | `in i bdrate, out (i) ret` | Changes Ex-UART baud-rate enum/value. |
+| `ChangePacketLengthSerialSource` | `in i len, out (i) ret` | Changes expected packet length for serial-source mode. |
+| `SendRjpData` | `in i pLen, in au pData, out (i) ret` | Sends RJP protocol data. |
+| `GetRjpProtocolData` | `out au data, out (i) ret` | Reads RJP protocol data. |
+
+Signals:
+
+| Signal | Signature | Notes |
+| --- | --- | --- |
+| `ep_handler` | `s ep_description` | EP protocol callback. |
+| `ss_handler` | `s ss_description` | Serial-source protocol callback. |
+| `rjp_handler` | `s rjp_description` | RJP protocol callback. |
+
+## On-Wire FAnet Frames
+
+The UART parser in `FAnetParserBase::IsData` does not parse ASCII Samsung Ex-Link strings. It parses a binary factory automation protocol.
+
+General frame:
+
+```text
+1f HH OP DATA... XX
+```
+
+Where:
+
+- `1f` is the start byte.
+- `HH = ((data_len & 0x1f) << 3) | msg_type`.
+- `OP` is the command/opcode byte.
+- `DATA` is `data_len` bytes.
+- `XX = HH xor OP xor DATA[0] xor ... xor DATA[n-1]`.
+
+Parser constraints recovered from `FAnetParserBase::IsData`:
+
+- Total parsed frame size is `(HH >> 3) + 4`.
+- `OP` must be `<= 0xfd`; `0xfe` and `0xff` are rejected.
+- `data_len` must be non-zero.
+- Inbound frames reject `msg_type` values with bit 2 set. Use `msg_type = 0` for commands.
+- Normal one-byte command frames are therefore:
+
+```text
+1f 08 OP DATA XX
+```
+
+Example frame builder:
+
+```text
+frame(op, data) = [1f, 08, op, data, 08 xor op xor data]
+```
+
+Examples:
+
+| Operation | Bytes to write |
+| --- | --- |
+| Set picture mode: Dynamic (`OP=40`, `DATA=03`) | `1f 08 40 03 4b` |
+| Set picture mode: Standard (`OP=40`, `DATA=04`) | `1f 08 40 04 4c` |
+| Energy saving off (`OP=2e`, `DATA=00`) | `1f 08 2e 00 26` |
+| Energy saving high (`OP=2e`, `DATA=03`) | `1f 08 2e 03 25` |
+| Read option/version line set (`OP=24`, `DATA=00`) | `1f 08 24 00 2c` |
+| Read AVOC backlight through EPA path (`OP=d1`, `DATA=08`) | `1f 08 d1 08 d1` |
+| Factory UART mode off-ish (`OP=83`, `DATA=00`) | `1f 08 83 00 8b` |
+| Factory UART mode / baud path (`OP=83`, `DATA=01`) | `1f 08 83 01 8a` |
+| Factory UART mode / baud path (`OP=83`, `DATA=02`) | `1f 08 83 02 89` |
+| Panel factory-in mode (`OP=d3`, `DATA=01`) | `1f 08 d3 01 da` |
+
+The examples above are binary byte sequences, not ASCII hex strings.
+
+## Response Frames
+
+Outbound response frames are built by `FAnetInspectionBase::t_SendMessage`.
+
+| Message Type | Builder | Meaning |
+| --- | --- | --- |
+| `1` | `t_SendAckMsg` | ACK. Usually sends one data byte, often `02`. |
+| `2` | `t_SendData` | Data response. |
+| `3` | `t_SendInfoData` | Info response. |
+| `4` | `t_SendSkipCode` | Skip-code response. |
+| `5` | `t_SendErrorCode` | Error response. |
+| `6` | `t_SendReturnMsg` | Result/return response. |
+
+For a one-byte return response, `HH = (1 << 3) | 6 = 0x0e`.
+
+Example success return for opcode `40`:
+
+```text
+1f 0e 40 01 4f
+```
+
+Example failure/false return for opcode `40`:
+
+```text
+1f 0e 40 00 4e
+```
+
+## Main Command Opcodes
+
+The primary dispatcher is `FAnetInspection::t_ProcessAutoRemocon`. It logs:
+
+```text
+AR Start ClientType[%d] OpCode[0x%02X][0x%02X]
+```
+
+The first logged byte is `OP`; the second is the first data byte.
+
+| OP | DATA | Handler | Effect |
+| --- | --- | --- | --- |
+| `15` | `01` | factory reset path | Calls the same internal helper used by `m_ExecuteFactoryReset`. Destructive. |
+| `1e` | `01`, `02` | `m_ExecutePortlandTest` | Portland motor test. `02` displays result. |
+| `24` | `00` or line number | `m_ExecuteOptionReading` | Reads `factory_get_version_info`. `00` sends all parsed lines; non-zero sends one line. |
+| `2e` | `00`-`04` | `m_ExecuteEnergySaving` | Calls `avoc_set_energy_saving`. `00/04` off, `01` low, `02` medium, `03` high. |
+| `2f` | any | `t_SendTvViewerKey` | Sends TV viewer key `discrete=disc_hdmi1`. |
+| `35` | `01` | `m_ExecuteTConDownload` | Sets factory parameter `0x86b`, checks it, displays OK/NG. |
+| `40` | `00`, `01`, `03`, `04`, `05`, `08`, `09`, `0a`, `0b` | `t_ExecuteMovieMode` | Picture-mode/factory-WB path. Calls `avoc_set_picture_mode`, `avoc_reset_picture`, and sometimes `ppi_ve_set_condition`. |
+| `61` | `00`-`06` | `t_ExecuteFactory` | Factory serial/projector control. Sets factory params `0x212`, `0x311`, `0x16`; data `06` displays `USB Serial : Projector` if supported. |
+| `72` | `01`-`06`, `10`, `11`, `a0`-`aa` | `m_ExecuteLocalDimming` | Local dimming tests and factory-item writes. |
+| `76` | `05`, `06` | `m_ExecuteCheckTconStatus` | `05` OLED off-sensing, `06` fast off-sensing. |
+| `7a` | byte | `t_ExecuteWIFIStaticConnecting` | Stores Wi-Fi/static byte 0. |
+| `7c` | byte | `t_ExecuteWIFIStaticConnecting` | Stores Wi-Fi/static byte 1. |
+| `7d` | byte | `t_ExecuteWIFIStaticConnecting` | Stores Wi-Fi/static byte 2. |
+| `7e` | byte | `t_ExecuteWIFIStaticConnecting` | Stores Wi-Fi/static byte 3. |
+| `7f` | byte | `t_ExecuteWIFIStaticConnecting` | Stores Wi-Fi/static byte 4, then may enter production mode when all bytes are present. |
+| `82` | `00`, `01`, `02`, `03`, `12`, `f0` | `m_ExecuteFastBootInProduction` | Fast-boot production flag, query, reboot, production-mode transition, or poweroff. Destructive for `03`, `12`, `f0`. |
+| `83` | `00`-`03` | `t_ExecuteFactory` | Factory UART/RS-232 mode. Sets factory param `0x16`; `01` changes baud enum `0`, `02` changes baud enum `1` after recreating/closing path. |
+| `88` | `00`-`04` | `t_ExecuteVFProcessLine` | VF/PBA process-line modes. Data `01` sets PBA-test condition; `04` disables OSD and sends an internal message. |
+| `d1` | `01`-`0d` | `m_ExecuteEPATest` | EPA/factory/AVOC read path. See EPA table below. |
+| `d3` | `00`, `01`, `02` | `m_ExecutePanelFactoryMode` | Factory-in/out mode. Calls `ppi_ve_set_condition`, `avoc_reset_picture`, or `avoc_set_factory_out`. |
+| `e3` | byte | `t_ExecuteBTPairing` | Bluetooth pairing/MAC-byte staging if BT is supported. |
+| `e4` | byte | Wi-Fi byte staging | Stores `t_WiFiInfo[4]`, marks byte present. |
+| `e5` | any | `m_ExecuteMediaBoxFuncTest` | Explicitly returns Not Support. |
+| `ed` | `02`, `04`, `09`, `0b` | `m_ExecuteSwAutoUpdate` | MICOM firmware upgrade, SWU flag, sub-OTP update/reboot, or LD firmware update. Destructive. |
+| `f0`-`f8` | byte | `t_ExecuteBTPairing` | Bluetooth pairing/MAC-byte staging. |
+| `f9` | byte | `t_ExecuteWIFIConnecting` | Stores Wi-Fi byte 0. |
+| `fa` | byte | `t_ExecuteWIFIConnecting` | Stores Wi-Fi byte 1. |
+| `fb` | byte | `t_ExecuteWIFIConnecting` | Stores Wi-Fi byte 2, then may enter production mode when all bytes are present. |
+| `fc` | byte | `t_ExecuteWIFIConnecting` | Routed to Wi-Fi handler; decompiled handler does not store a new byte for this opcode. |
+| `fd` | any | success-only branch | Disables OSD path and returns success. Exact external purpose unclear. |
+
+## EPA Read Subcommands
+
+`OP=d1` is the clearest useful read path.
+
+| DATA | Function |
+| --- | --- |
+| `01` | `factory_get_eerc_version` |
+| `02` | `factory_get_data(0x6f)` |
+| `03` | `factory_get_data(0x515)` |
+| `04`, `0c` | `factory_get_data(0x516)` |
+| `05`, `0d` | `factory_get_data(0x6a7)` |
+| `06` | `factory_get_str_data(0x2390)` |
+| `07` | `avoc_get_contrast(0, ..., AVOC_SAVE)` |
+| `08` | `avoc_get_backlight(0, ..., AVOC_SAVE)` |
+| `09` | `avoc_get_brightness(0, ..., AVOC_SAVE)` |
+| `0a` | `avoc_get_motion_lighting(0, ...)` |
+| `0b` | `avoc_get_eco_sensor(0, AVOC_SAVE, ...)` |
+
+So the binary ExLink/FAnet way to read backlight is:
+
+```text
+1f 08 d1 08 d1
+```
+
+No direct `avoc_set_backlight` command was found in this UART parser. `avoc_set_backlight` is imported by the daemon, but the recovered ExLink/FAnet auto-remocon dispatch exposes `avoc_get_backlight` through `OP=d1, DATA=08`, not a matching setter.
+
+## Other Subprotocols
+
+`CAutoAVControlBase::IsData` accepts a separate 7-byte inner AV-control packet:
+
+```text
+08 22 B2 B3 B4 B5 CC
+```
+
+Where:
+
+```text
+CC = -(08 + 22 + B2 + B3 + B4 + B5) & ff
+```
+
+When valid, the daemon:
+
+- forwards `B2 B3 B4 B5` to the registered AV-control callback;
+- sends ACK bytes `03 0c f1` through `FAnetClient::SendMessage`.
+
+`RJPProtocolControl::IsData` accepts RJP data only when hotel mode is enabled. The first packet must start:
+
+```text
+02 00 cb ...
+```
+
+The buffered RJP size is calculated as:
+
+```text
+size = buffer[3] + 6
+```
+
+It also has a loopback-test check for an RJP packet with byte `3 == 04` and the following little-endian word `a5 a6 a7 a8`.
+
+## Native Symbols
+
+`/usr/bin/TIFADaemon_L` contains the actual ExLink/RS-232 implementation. Important symbols and strings include:
+
+| Symbol / String | Meaning |
+| --- | --- |
+| `IFAnetUtil::GetUartPath(char*)` | Resolves the UART device used by the automation stack. |
+| `FAnetUartClientBase::m_OpenUart(char const*, FAnetBaudRate_e)` | Opens the UART. |
+| `FAnetUartClientBase::m_CloseUart()` | Closes the UART. |
+| `FAnetUartClientBase::ChangeBaudrate(FAnetBaudRate_e)` | Changes UART baud rate. |
+| `FAnetUartClientBase::m_ReceiveData(unsigned char*, int*)` | Receives UART data. |
+| `FAnetUartClientBase::t_SendMessage(unsigned char*, int, FAnetMessageArgs_s)` | Sends UART data. |
+| `FAnetUartClientBase::t_check_micom_serial_mode()` | Checks MICOM serial mode. |
+| `FAnetParser`, `FAnetParserBase` | Parses FAnet / automation serial packets. |
+| `FAnetInspection`, `FAnetInspectionBase` | Factory inspection command handling. |
+| `RJPProtocolControl` | RJP protocol handling. |
+| `CAutoAVControlBase` | Automation AV control path. |
+| `IRInput`, `IRInputBase` | Auto remote / IR input path. |
+| `factory_set_rs232jack` | Factory API for RS-232 jack selection/config. |
+| `ppi_powercontrol_diag_set_uart_port_type` | Platform power-control UART mode selection. |
+| `ppi_link_uart_get_node` | Platform API to resolve the link UART node. |
+| `ppi_link_uart_select_mb_uart` | Platform API to select main-board UART routing. |
+| `avoc_set_backlight`, `avoc_get_backlight` | Automation stack can reach AVOC backlight functions. |
+
+Useful log strings from `TIFADaemon_L`:
+
+```text
+GetUartPath
+failed to get uart node [%d]
+GetUartPath success %s
+*** GetUartPath FAILURE ***
+Uart: siRs232Jack[%d]
+rs232
+rs232=%d
+micom_serial_mode = %d
+Dev[%s] BaudRate[%s]
+ChangeBaudrate Done m_DevicePath[%s] mUartHandle[%d]
+RS232:%d, USB Serial:%d
+RS232 change from FANET to UART[%d], ret = %d
+```
+
+## Client Library
+
+`/usr/lib/libIUARTService.so` is a client/wrapper library for the automation-service D-Bus API.
+
+Important strings:
+
+```text
+org.tizen.tv.automation-service
+org.tizen.tv.automationservice
+SendMessageByExUart
+SendRS232Ack
+CloseExUart
+ChangeBaudRateExUart
+ChangePacketLengthSerialSource
+automation_register_callback_serial_source
+automation_unregister_callback_serial_source
+automation_register_callback_rjp_protocol
+automation_register_callback_ep_protocol
+```
+
+This means native code can talk to the ExLink stack through the library instead of constructing D-Bus messages manually.
+
+## Factory Service Relationship
+
+`/usr/bin/TIFSDaemon` owns:
+
+```text
+org.tizen.tv.factory-service
+/TIFacSerObj
+org.tizen.tv.factoryservice
+```
+
+It exposes many generic factory methods such as `GetItem`, `SetParameter`, `Executes`, and `GetSerialNo`.
+
+Relevant ExLink/serial imports in `TIFSDaemon`:
+
+```text
+automation_send_message_by_ex_uart
+automation_close_ex_uart
+ppi_powercontrol_set_exlink_onoff
+ppi_powercontrol_diag_set_uart_port_type
+ppi_link_uart_get_node
+ppi_link_uart_select_mb_uart
+ppi_link_ops_test_uart_loopback
+```
+
+Interpretation: factory-service can configure or call into the Ex-UART path, but the primary responder/parser is automation-service.
+
+## HyperUART
+
+The TV also has HyperUART scripts under `/prd/etc/HyperUART`.
+
+They configure a `huart0` network interface in the `192.168.250.x` range and can start `sdbd` for Samsung debug-over-UART workflows.
+
+This appears to be a Samsung engineering/debug transport. It is adjacent UART infrastructure, but not the ExLink / RS-232 application protocol handler described above.
+
+## Likely Stack
+
+```text
+ExLink / RS-232 connector
+  -> One Connect / MICOM / link UART routing
+  -> Samsung sdp-uart2 tty device
+  -> /usr/bin/TIFADaemon_L
+  -> FAnetUartClientBase
+  -> FAnetParser / RJPProtocolControl / CAutoAVControlBase
+  -> org.tizen.tv.automation-service D-Bus API
+  -> native clients through libIUARTService.so
+```
+
+## What Is Still Unknown
+
+- The exact physical tty node used for the ExLink connector was not proven from open file descriptors, because root-owned daemon file descriptors were not readable from the available shell.
+- The binary references `/proc/device-tree/factory/samsung,ex-link_uart`, but that node is absent on this firmware.
+- The strongest live clues are `rs232=1`, the automation-service D-Bus API, `FAnetUartClientBase`, `factory_set_rs232jack`, `ppi_link_uart_get_node`, and the One Connect `ttyS2` device-tree description.
+- The exact FAnet/ExLink packet grammar and command IDs require deeper decompilation of `FAnetParserBase`, `FAnetInspectionBase`, and the `ExecuteCommand*` handlers.
+
+## Bottom Line
+
+The ExLink / RS-232 feature is real on this TV and is handled by root userspace code.
+
+The main component is `/usr/bin/TIFADaemon_L`, reachable over system D-Bus as `org.tizen.tv.automation-service` at `/TIFacAutoObj`. It exposes raw Ex-UART send/close/baud methods and protocol-specific SS/EP/RJP methods. Factory-service and kfactory are supporting/control paths, not the main serial protocol endpoint.

--- a/notes/QN55LS03FAFXZA/PORTS.md
+++ b/notes/QN55LS03FAFXZA/PORTS.md
@@ -1,0 +1,145 @@
+# TV Port Owners / Internal Behavior
+
+TV binaries examined:
+
+- `/usr/bin/msf-server`
+- `/usr/bin/remote-server`
+- `/opt/usr/apps/com.samsung.tv.remoteless/bin/remoteless`
+- `/usr/apps/com.samsung.tv.multiscreen/bin/MultiScreen.dll`
+
+Live state seen on TV:
+
+- `owner 4894 /usr/bin/msf-server`
+- `owner 2006 /usr/bin/remote-server`
+- `owner 747 /opt/usr/apps/com.samsung.tv.remoteless/bin/remoteless`
+- `owner 2316 /usr/apps/com.samsung.tv.multiscreen/bin/MultiScreen.dll ...`
+- `/proc/net/tcp`: `0.0.0.0:8001`, `0.0.0.0:8002`, `0.0.0.0:1516`
+- no `1515` listener
+
+`sdk` cannot read `/proc/<owner-pid>/fd` or `/proc/<owner-pid>/maps`; `netstat -p` also hides PIDs. So listener inode -> PID is blocked without root or an owner-UID helper.
+
+## 8001 / 8002
+
+Owner: `/usr/bin/msf-server`.
+
+Why:
+
+- service unit runs `/usr/bin/msf-server` as `owner`, after `remote-server.service`
+- binary imports `libwebsockets.so.19`
+- strings contain `8001`, `8002`, and `can't create vhost for '8002' port`
+- TLS files: `/usr/share/msf-server/certificates/server_crt.pem`, `server_key.pem`, `ca_crt.pem`
+- mDNS advertises `:8001/api/v2/` and `:8001/ms/1.0/`
+
+What it exposes:
+
+- REST:
+  - `/api/v2/`
+  - `/ms/1.0/device/info/update`
+  - `/ms/1.0/device/discovery`
+  - `/api/v2/applications/11091000000`
+  - `/api/v2/applications/`
+  - `/api/v2/webapplication/`
+  - `/api/v2/webapplication/data`
+  - `/remoteControl/`, `/remoteControl/ime/`, `/remoteControl/touchEnable/`, `/remoteControl/voiceStatus/`, `/remoteControl/imeInput/`, etc.
+- WebSocket:
+  - `/api/v2/channels/samsung.remote.control`
+  - `/api/v2/channels/samsung.gamepad.control`
+  - `/api/v2/channels/samsung.default.media.player`
+- auth/pairing:
+  - `token`, `token_check`, `CheckACLPairing`, `ms.channel.unauthorized`
+- actions:
+  - `remote_control_send_key_event`
+  - `remote_control_send_commit_string`
+  - `VirtualKey_Send_KeyCode`
+  - `VirtualMouse_Send_Move`
+  - gamepad via `/dev/uinput`
+  - app launch/install/stop through `application.*` commands
+
+## remote-server
+
+Owner: `/usr/bin/remote-server`.
+
+It is the backend/orchestrator, not the direct 8001/8002 server.
+
+Direct binds found in disassembly:
+
+- `socket(AF_UNIX, SOCK_STREAM, 0)` + `bind()` + `listen()` on `/tmp/pcs`
+- `socket(AF_UNIX, SOCK_STREAM, 0)` + `bind()` + `listen()` on `/tmp/msf`
+
+No direct TCP bind for 1516 was found in this executable.
+
+What it does:
+
+- DIAL/app control:
+  - registers WebConv services `/ws/apps` and `/ws/app`
+  - handles app list, app info, app launch, app stop, app install
+  - uses WAS launcher APIs
+- UPnP/RCR:
+  - calls `asf_upnp::framework_core::ConfigureServers(7678, 1900, 0, false)`
+  - embeds `Samsung DTV RCR` XML
+  - embeds `/RCR/control/dial`, `/RCR/event/dial`
+  - embeds UPnP action `SendKeyCode`
+- pairing/auth:
+  - `REMOTE_ACL_LIST`, `DEVICE_AUTH_LIST`
+  - token read/write/check
+  - RDM access UX callbacks
+- bridge to msf:
+  - local socket `/tmp/msf`
+  - calls `http://127.0.0.1:8001/ms/1.0/device/info/update`
+  - calls `http://127.0.0.1:8001/remoteControl/...`
+
+## remoteless
+
+Owner: `/opt/usr/apps/com.samsung.tv.remoteless/bin/remoteless`.
+
+Not a TCP server candidate.
+
+Why:
+
+- imports Bluetooth/GATT, `remote_input_*`, `VirtualKey_*`, `VirtualMouse_*`
+- no useful socket/listen/bind/http server strings
+- service is gated by Bluetooth mobile remote feature flags
+
+What it does:
+
+- BLE mobile remote scanning/register/power-on
+- iOS/Android direct power control
+- uses `/opt/usr/home/owner/apps_rw/com.samsung.tv.remoteless/data/mobile_registered`
+- sends key/text/mouse through `remote_input_*` and `autoinput`
+
+## MultiScreen.dll
+
+Owner: `com.samsung.tv.multiscreen` app.
+
+Not a TCP server candidate from pulled metadata/strings.
+
+It is a .NET in-house app using CoBA/ScreenOnScreen/TVService/Bixby/Tizen APIs for MultiView/UI state.
+
+## 1516
+
+Known:
+
+- listener exists: `0.0.0.0:1516`, UID `5001`/`owner`
+- `1515` is absent
+- TV-shell request to `https://<TV_LAN_IP>:1516/` returns `Server: Samsung IP Control Server/1.0`
+- TLS cert subject/issuer is `CN = Samsung IP Control G2`
+
+Owner:
+
+- process: `owner 4268 /opt/usr/apps/com.samsung.tv.mde-framework/bin/mde-framework`
+- package: `com.samsung.tv.mde-framework`
+- component: `svcapp`
+- manifest DB says `Onboot: 1`, `Autorestart: 1`
+
+Implementation:
+
+- `mde-framework` directly links `libmde-protocol-ipcontrol.so`
+- `libmde-protocol-ipcontrol.so` contains `CreateIPControlPlugin`, `IPControlCore`, `ServerManager`, `JSONRPCParser`, the JSON-RPC method table, and access-token handling
+- `libmde-protocol-ipcontrol.so` loads `/usr/apps/org.tizen.ipcontrol/libipcontrol-http-server.so`
+- `libipcontrol-http-server.so` implements the Boost.Asio/OpenSSL HTTPS listener and contains the exact `Samsung IP Control Server/1.0` banner
+
+Adjacent:
+
+- `sddp.service` runs `/usr/apps/org.tizen.sddp/bin/SDDP`, gated by the same `convergence.ipcontrol.service_available` feature flag, but it is discovery/advertising, not the HTTPS JSON-RPC server
+- `remote-server` directly binds only `/tmp/pcs` and `/tmp/msf`
+- `remote-server` UPnP framework config is `7678` + `1900`, not `1516`

--- a/notes/QN55LS03FAFXZA/RPC_INTERNALS.md
+++ b/notes/QN55LS03FAFXZA/RPC_INTERNALS.md
@@ -1,0 +1,461 @@
+# RPC / WebSocket Internals
+
+Goal: explain message handlers, not just URL paths.
+
+Sources:
+
+- observed client behavior from Samsung TV integrations such as `ha-samsungtv-smart`
+- TV binaries/packages:
+  - `/usr/bin/msf-server`
+  - `/usr/bin/remote-server`
+  - `/opt/usr/apps/com.samsung.tv.remoteless/bin/remoteless`
+  - `/usr/apps/com.samsung.tv.multiscreen/bin/MultiScreen.dll`
+  - `/opt/usr/apps/com.samsung.tv.mde-framework/bin/mde-framework`
+  - `/opt/usr/apps/org.tizen.art-app/bin/ArtApp.dll`
+  - `/opt/usr/apps/org.tizen.art-app/bin/ArtDataManagement.dll`
+  - `/usr/apps/org.tizen.ipcontrol/libipcontrol-http-server.so`
+  - `/opt/usr/apps/com.samsung.tv.mde-framework/lib/libmde-protocol-ipcontrol.so`
+
+## Big Picture
+
+`msf-server` is the public MultiScreen/WebSocket daemon for 8001/8002.
+
+`remote-server` is the backend/orchestrator. It does not directly bind 8001/8002 and its direct binds are Unix sockets:
+
+- `/tmp/pcs`
+- `/tmp/msf`
+
+`msf-server` receives public WebSocket/REST messages, then calls local/internal backend commands in `remote-server` for app launch/install/ACL/etc.
+
+`remoteless` is BLE/mobile remote. Not the 8001/8002/1516 protocol server.
+
+`MultiScreen.dll` is MultiView/UI app glue. Not the 8001/8002/1516 protocol server.
+
+## MSF WebSocket Envelope
+
+The public WebSocket JSON shape is:
+
+```json
+{
+  "id": "optional-client-id",
+  "method": "ms.remote.control | ms.channel.emit | ms.application.get | ...",
+  "params": {}
+}
+```
+
+Embedded `msf-server` method/event strings:
+
+- `ms.remote.control`
+- `ms.voice.control`
+- `ms.channel.emit`
+- `ms.application.get`
+- `ms.application.start`
+- `ms.application.stop`
+- `ms.application.install`
+- `ms.webapplication.get`
+- `ms.webapplication.start`
+- `ms.webapplication.stop`
+- `ms.gamepad.control`
+- `ms.ocf.data`
+
+Embedded channel lifecycle/error events:
+
+- `ms.channel.connect`
+- `ms.channel.ready`
+- `ms.channel.clientConnect`
+- `ms.channel.clientDisconnect`
+- `ms.channel.disconnect`
+- `ms.channel.timeOut`
+- `ms.channel.unauthorized`
+- `ms.error`
+
+`ms.channel.emit` is the generic relay:
+
+- expects `params.event`
+- expects `params.to` when targeted; binary logs `params.to is not string!`
+- routes/broadcasts to channel clients by id or `host`
+- rejects custom events beginning with `ms.`: binary string says `Usage of \`ms.\` in custom event is not allowed.`
+
+## Remote Control Channel
+
+Public channel:
+
+- `/api/v2/channels/samsung.remote.control`
+
+Incoming method:
+
+- `ms.remote.control`
+
+Main dispatch key:
+
+- `params.TypeOfRemote`
+
+Embedded `TypeOfRemote` values:
+
+- `SendRemoteKey`
+- `SendInputString`
+- `SendInputEnd`
+- `CreateTouchDevice`
+- `DestroyTouchDevice`
+- `ProcessTouchDevice`
+- `ProcessMouseDevice`
+- `SendGamepadKey`
+- `SendGamepadMove`
+
+Known client payloads, matching binary strings:
+
+```json
+{
+  "method": "ms.remote.control",
+  "params": {
+    "Cmd": "Click",
+    "DataOfCmd": "KEY_HOME",
+    "Option": "false",
+    "TypeOfRemote": "SendRemoteKey"
+  }
+}
+```
+
+`Cmd` for `SendRemoteKey` maps to press type:
+
+- `Click`
+- `Press`
+- `Release`
+
+Implementation evidence:
+
+- calls `remote_control_send_key_event`
+- log string: `SendRemoteKey called keycode = %d, type = %d`
+- includes a huge `KEY_*` string table: `KEY_HOME`, `KEY_POWER`, `KEY_HDMI`, `KEY_VOLUP`, `KEY_VOLDOWN`, `KEY_MULTI_VIEW`, `KEY_AMBIENT`, etc.
+
+Text input payload:
+
+```json
+{
+  "method": "ms.remote.control",
+  "params": {
+    "Cmd": "<base64 text>",
+    "DataOfCmd": "base64",
+    "TypeOfRemote": "SendInputString"
+  }
+}
+```
+
+Then:
+
+```json
+{
+  "method": "ms.remote.control",
+  "params": {
+    "TypeOfRemote": "SendInputEnd"
+  }
+}
+```
+
+Implementation evidence:
+
+- calls `remote_control_send_commit_string`
+- has IME callbacks:
+  - `remote_control_text_updated_callback_set`
+  - `remote_control_entry_metadata_callback_set`
+  - `remote_control_focus_in_callback_set`
+  - `remote_control_focus_out_callback_set`
+
+Mouse payload:
+
+```json
+{
+  "method": "ms.remote.control",
+  "params": {
+    "Cmd": "Move",
+    "Position": { "x": 100, "y": 100, "Time": "0" },
+    "TypeOfRemote": "ProcessMouseDevice"
+  }
+}
+```
+
+Embedded mouse command strings:
+
+- `Move`
+- `LeftClick`
+- `LeftPress`
+- `LeftRelease`
+- `RightClick`
+
+Implementation evidence:
+
+- calls `VirtualMouse_Send_Move`
+- calls `VirtualMouse_Send_Button_Event`
+- calls `autoinput_virtualmouse_generate_mouse_scroll`
+
+## Server-Originated Remote Events
+
+`msf-server` emits/understands these remote-state events:
+
+- `ms.remote.touchEnable`
+- `ms.remote.touchDisable`
+- `ms.remote.imeStart`
+- `ms.remote.imeUpdate`
+- `ms.remote.imeDone`
+- `ms.remote.imeEnd`
+- `ms.remote.mbrlayout`
+- `ms.remote.numberpad`
+- `ms.voiceApp.hide`
+- `ms.voiceApp.recording`
+- `ms.voiceApp.processing`
+- `ms.voiceApp.standby`
+- `ed.edenTV.update`
+
+Associated REST handlers in the same daemon update/broadcast these states:
+
+- `/remoteControl/ime/`
+- `/remoteControl/imeInput/`
+- `/remoteControl/touchEnable/`
+- `/remoteControl/voiceStatus/`
+- `/remoteControl/edenMobile/`
+- `/remoteControl/RcrToMobile/`
+- `/remoteControl/virtualRemote/`
+- `/remoteControl/mbrInfo/`
+
+## Application Control
+
+There are two layers.
+
+Public WebSocket methods in `msf-server`:
+
+- `ms.application.get`
+- `ms.application.start`
+- `ms.application.stop`
+- `ms.application.install`
+
+Public REST endpoints in `msf-server` are wrappers around the same idea:
+
+- `GET /api/v2/applications/<id>`
+- `POST /api/v2/applications/<id>`
+- `DELETE /api/v2/applications/<id>`
+- `PUT /api/v2/applications/<id>`
+
+Internal backend commands passed to `remote-server` over `/tmp/msf`:
+
+- `application.getApplication`
+- `application.launchApplication`
+- `application.stopApplication`
+- `application.installApplication`
+- `application.aclPairing`
+- `application.getImeText`
+- `application.setRemoteNumbers`
+- `application.getCastingAppsInfo`
+- `application.urlVerification`
+
+`remote-server` contains matching backend handlers:
+
+- `DoGetApplication`
+- `DoLaunchApplication`
+- `DoStopApplication`
+- `DoInstallApplication`
+- `DoACLPairing`
+- `ParseJSON`
+- `PacketParse`
+
+So app control flow is:
+
+```text
+client -> msf-server public WS/REST -> /tmp/msf -> remote-server MSFServer::ParseJSON -> WAS/app launcher APIs
+```
+
+Home Assistant also sends this older Eden-style launch event:
+
+```json
+{
+  "method": "ms.channel.emit",
+  "params": {
+    "event": "ed.apps.launch",
+    "to": "host",
+    "data": {
+      "action_type": "DEEP_LINK | NATIVE_LAUNCH",
+      "appId": "...",
+      "metaTag": "..."
+    }
+  }
+}
+```
+
+Note: literal `ed.apps.launch` was not found in the examined TV binaries. The lower-level application strings above are present. Treat `ed.apps.launch` as an observed client-facing Eden/MSF convention, not a direct string hit in `msf-server`.
+
+## Installed App List
+
+Home Assistant requests:
+
+```json
+{
+  "method": "ms.channel.emit",
+  "params": {
+    "event": "ed.installedApp.get",
+    "to": "host"
+  }
+}
+```
+
+Binary evidence:
+
+- `remote-server` contains `CONNECT_INSTALLEDAPP`
+- `msf-server`/`remote-server` contain the application backend commands above
+
+But the literal `ed.installedApp.get` was not found in the examined TV binaries. This may be generated by Eden/app framework code or by another package.
+
+## Gamepad Channel
+
+Public channel:
+
+- `/api/v2/channels/samsung.gamepad.control`
+
+Embedded strings:
+
+- `ms.gamepad.control`
+- `gamepad_key`
+- `gamepad_abs`
+- `gamepad_left`
+- `gamepad_right`
+- `CreateGamepadDevice`
+- `DestroyGamepadDevice`
+- `/dev/uinput`
+
+Implementation evidence:
+
+- creates a virtual input/gamepad device
+- logs gamepad key events
+- writes via uinput
+
+## Generic / Dynamic Channels
+
+Hard-coded channel strings in `msf-server`:
+
+- `/api/v2/channels/samsung.remote.control`
+- `/api/v2/channels/samsung.gamepad.control`
+- `/api/v2/channels/samsung.default.media.player`
+- `/api/v2/channels/com.samsung.wallservice`
+- `/api/v2/channels/com.samsung.tv.ambient`
+- `/api/v2/channels/com.samsung.tv.ambient.contentapp`
+- `/api/v2/channels/com.samsung.tv.mobilebff`
+- `/api/v2/channels/com.samsung.edgeblending-service`
+- `/api/v2/channels/com.samsung.virtualmicservice`
+
+`/api/v2/channels/com.samsung.art-app` is used externally, but that literal was not found in `msf-server`. Explanation from the Art app decompile: `org.tizen.art-app` registers SmartView/MSF channel `com.samsung.art-app` itself, and `msf-server` provides generic channel routing.
+
+## Art App Channel
+
+Observed externally; the channel/event routing is confirmed by decompiling `/opt/usr/apps/org.tizen.art-app/bin/ArtDataManagement.dll`:
+
+- channel: `/api/v2/channels/com.samsung.art-app`
+- outer method: `ms.channel.emit`
+- outer event: `art_app_request`
+- response event: `d2d_service_message`
+- inner payload is a JSON string in `params.data`
+
+Request shape:
+
+```json
+{
+  "method": "ms.channel.emit",
+  "params": {
+    "event": "art_app_request",
+    "to": "host",
+    "data": "{\"request\":\"get_artmode_status\",\"id\":\"...\",\"request_id\":\"...\"}"
+  }
+}
+```
+
+Client-observed inner requests include:
+
+- `get_api_version`
+- `api_version`
+- `get_content_list`
+- `get_current_artwork`
+- `get_thumbnail_list`
+- `get_thumbnail`
+- `select_image`
+- `get_artmode_status`
+- `set_artmode_status`
+- `change_favorite`
+- `get_photo_filter_list`
+- `set_photo_filter`
+- `get_matte_list`
+- `change_matte`
+- `get_artmode_settings`
+- `get_brightness`
+- `set_brightness`
+- `get_color_temperature`
+- `set_color_temperature`
+- `get_auto_rotation_status`
+- `set_auto_rotation_status`
+- `get_slideshow_status`
+- `set_slideshow_status`
+- `send_image`
+- `delete_image_list`
+
+Observed inner response/broadcast events:
+
+- `artmode_status`
+- `art_mode_changed`
+- `go_to_standby`
+- `wakeup`
+- `brightness`
+- `color_temperature`
+- `favorite_changed`
+- `error`
+
+Important internal finding:
+
+- the Art request strings are not in `msf-server`, `remote-server`, `remoteless`, or `MultiScreen.dll`
+- the real inner request table is in `/opt/usr/apps/org.tizen.art-app/bin/ArtDataManagement.dll`
+- `msf-server` owns the WebSocket transport; the Art app owns `art_app_request` parsing and `d2d_service_message` responses
+- see `WEBSOCKET_DECOMPILED.md` for the full Art request/event catalogue
+
+## 1516 JSON-RPC
+
+Full decompile-backed catalogue: `IPCONTROL_DECOMPILED.md`.
+
+Short version:
+
+- live process: `owner ... /opt/usr/apps/com.samsung.tv.mde-framework/bin/mde-framework`
+- package: `com.samsung.tv.mde-framework`, `Onboot: 1`, `Autorestart: 1`
+- library chain:
+  - `mde-framework`
+  - links `libmde-protocol-ipcontrol.so`
+  - dlopens `/usr/apps/org.tizen.ipcontrol/libipcontrol-http-server.so`
+- port logic: `GetTVYear() < 20 ? 1515 : 1516`
+- this TV: `0.0.0.0:1516`
+- banner: `Server: Samsung IP Control Server/1.0`
+- TLS cert subject/issuer: `CN = Samsung IP Control G2`
+
+HTTP transport:
+
+- POST only
+- HTTP/1.0 or HTTP/1.1 only
+- no URL route dispatch found; target path is effectively ignored
+- required headers: `Content-Type: application/json`, `Accept: application/json`, `Host`, `Content-Length`
+- chunked POST is explicitly unsupported
+- no WebSocket implementation in this server
+
+JSON-RPC:
+
+- body must parse as JSON
+- `jsonrpc` must be `"2.0"`
+- `createAccessToken` is the token bootstrap method
+- every other method requires `params.AccessToken`
+- token auth is tied to peer MAC/auth-list checks
+- set-vs-get is decided by params: only `AccessToken` means get; any extra param means set
+
+Normal-TV method maps from decompile:
+
+- open/expert map: `volumeUpDnControl`, `channelUpDnControl`, `muteControl`, `powerControl`, `artModeControl`, `directAccessControl`, `firstScreenAppControl`, `remoteKeyControl`, `getVideoStates`, `getTVStates`, `multiviewControl`, `displayRotatorControl`, `getDeviceInformation`, plus expert-picture controls such as `backlightControl`, `peakBrightnessControl`, `colorSpace.ColorControl`, `gameModeControl`, etc.
+- none-ambient map: `directVolumeControl`, `inputSourceControl`, `directChannelControl`, `pictureModeControl`, `pictureSizeControl`, `soundModeControl`, `speakerSelectControl`, `externalSpeakerControl`, `USBSourceControl`, `brightnessControl`, `contrastControl`, `sharpnessControl`, `colorControl`, `tintControl`
+- wall map: `ambientControl`, `getBoxStates`, `getCabinetGroupIds`, `getCabinetStates`
+- HTV-only and AV/soundbar-only maps also exist; see the dedicated note.
+
+Important corrections:
+
+- `RVUSourceControl` and `ambientModeControl` are not exact strings in this library.
+- `ambientControl` is present.
+- `getAccessToken` and `removeAccessToken` are parser helpers, not public JSON-RPC methods.
+- same module has UPnP description/event code, but `IPControlServiceHelper::dispatchAction()` always returns invalid action; it only event-publishes `IPControlState`.

--- a/notes/QN55LS03FAFXZA/WEBSOCKET_DECOMPILED.md
+++ b/notes/QN55LS03FAFXZA/WEBSOCKET_DECOMPILED.md
@@ -1,0 +1,359 @@
+# Samsung 8001/8002 WebSocket Decompile
+
+Device: `QN55LS03FAFXZA`
+
+Samsung support: https://www.samsung.com/us/support/downloads/?model=N0003009&modelCode=QN55LS03FAFXZA
+
+Documented: `2026-06-18`
+
+Firmware: `T-PTMFAKUC-0090-1296.8`
+
+Tizen: `9.0.0`
+
+Linux: `5.4.261 armv7l`
+
+## Sources
+
+- `/usr/bin/msf-server`
+- `/usr/bin/remote-server`
+- `/opt/usr/apps/org.tizen.art-app/tizen-manifest.xml`
+- `/opt/usr/apps/org.tizen.art-app/bin/ArtApp.dll`
+- `/opt/usr/apps/org.tizen.art-app/bin/ArtDataManagement.dll`
+- `/opt/usr/apps/com.samsung.tv.coba.art/tizen-manifest.xml`
+- `/opt/usr/apps/com.samsung.tv.home.art/tizen-manifest.xml`
+- `/usr/apps/com.samsung.tv.wizard.art/tizen-manifest.xml`
+
+## Port Owners
+
+`8001` and `8002` are served by `/usr/bin/msf-server`.
+
+`msf-server` is the public HTTP/WebSocket daemon. `remote-server` is the local backend bridge for remote/app-control operations over `/tmp/msf`; it does not directly bind `8001`/`8002`.
+
+`8001` is the normal HTTP/WebSocket endpoint. `8002` is the TLS WebSocket endpoint using the same MSF channel model.
+
+## Generic MSF WebSocket
+
+Connect to:
+
+```text
+ws://<tv>:8001/api/v2/channels/<channel>
+wss://<tv>:8002/api/v2/channels/<channel>
+```
+
+Common outer request:
+
+```json
+{
+  "method": "ms.channel.emit",
+  "params": {
+    "event": "some_event",
+    "to": "host",
+    "data": "payload"
+  }
+}
+```
+
+`msf-server` rejects custom events beginning with `ms.`. `params.event` must be a string. `params.to` must be a string when present.
+
+### Generic Methods
+
+| Method | Params | Backend / notes |
+|---|---|---|
+| `ms.channel.emit` | `event`, optional `to`, optional `data` | Generic channel event relay. Used by Art app. |
+| `ms.remote.control` | `TypeOfRemote`, `Cmd`, `DataOfCmd`, `Option`, optional `Position` | Virtual remote input. |
+| `ms.voice.control` | voice payload | Voice state/control path; strings show `ms.voiceApp.*` events. |
+| `ms.gamepad.control` | gamepad key/abs/move data | Uses `/dev/uinput`; creates/destroys virtual gamepad. |
+| `ms.application.get` | app id / app query | Delegates to `remote-server` command `application.getApplication`. |
+| `ms.application.start` | app id, optional launch/deeplink data | Delegates to `application.launchApplication`. |
+| `ms.application.stop` | app id | Delegates to `application.stopApplication`. |
+| `ms.application.install` | app id / install metadata | Delegates to `application.installApplication`. |
+| `ms.webapplication.get` | web app id/query | Web app variant of application get. |
+| `ms.webapplication.start` | web app id/launch data | Web app launch. |
+| `ms.webapplication.stop` | web app id | Web app stop. |
+| `ms.ocf.data` | OCF data payload | Generic OCF bridge. |
+| `channel.ping` / `ms:channel.ping` | none seen | Channel keepalive/ping strings. |
+
+### Generic Channels
+
+Hard-coded public channel strings in `msf-server`:
+
+| Channel |
+|---|
+| `samsung.remote.control` |
+| `samsung.gamepad.control` |
+| `samsung.default.media.player` |
+| `com.samsung.wallservice` |
+| `com.samsung.tv.ambient` |
+| `com.samsung.tv.ambient.contentapp` |
+| `com.samsung.tv.mobilebff` |
+| `com.samsung.edgeblending-service` |
+| `com.samsung.virtualmicservice` |
+
+`com.samsung.art-app` is registered by the Art app through the SmartView/MSF local service API, not hard-coded in `msf-server`.
+
+### Generic Events
+
+| Event | Direction | Notes |
+|---|---|---|
+| `ms.channel.connect` | server -> client | Channel connect. |
+| `ms.channel.ready` | server -> client | Host/channel ready. |
+| `ms.channel.clientConnect` | server -> client | Another client joined. |
+| `ms.channel.clientDisconnect` | server -> client | Client left. |
+| `ms.channel.disconnect` | server -> client | Channel disconnect. |
+| `ms.channel.timeOut` | server -> client | Channel timeout. |
+| `ms.channel.unauthorized` | server -> client | Pairing/auth failure. |
+| `ms.error` | server -> client | Generic MSF error. |
+| `ms.remote.touchEnable` / `ms.remote.touchDisable` | server -> client | Touch remote state. |
+| `ms.remote.imeStart` / `ms.remote.imeUpdate` / `ms.remote.imeDone` / `ms.remote.imeEnd` | server -> client | IME text input state. |
+| `ms.remote.mbrlayout` / `ms.remote.numberpad` | server -> client | Remote UI overlays. |
+| `ms.voiceApp.hide` / `recording` / `processing` / `standby` | server -> client | Voice UI state. |
+| `ed.edenTV.update` | server -> client | Eden/Home update event. |
+
+### Remote Control Params
+
+`ms.remote.control` dispatches mostly by `params.TypeOfRemote`:
+
+| `TypeOfRemote` | Params / values | Effect |
+|---|---|---|
+| `SendRemoteKey` | `Cmd`: `Click`, `Press`, `Release`; `DataOfCmd`: `KEY_*`; `Option`: usually `"false"` | Calls `remote_control_send_key_event` / `VirtualKey_Send_KeyCode`. |
+| `SendInputString` | `Cmd`: text/base64; `DataOfCmd`: often `base64` | Commits IME text through `remote_control_send_commit_string`. |
+| `SendInputEnd` | none required | Ends IME input. |
+| `CreateTouchDevice` | touch metadata | Creates virtual touch device. |
+| `DestroyTouchDevice` | none seen | Destroys virtual touch device. |
+| `ProcessTouchDevice` | touch coordinates/state | Touch input. |
+| `ProcessMouseDevice` | `Cmd`: `Move`, `LeftClick`, `LeftPress`, `LeftRelease`, `RightClick`; `Position`: `x`, `y`, `Time` | Virtual mouse move/button/scroll. |
+| `SendGamepadKey` | gamepad key fields | Gamepad key event. |
+| `SendGamepadMove` | gamepad abs/move fields | Gamepad axis/move event. |
+
+`msf-server` embeds a huge `KEY_*` table, including `KEY_HOME`, `KEY_POWER`, `KEY_HDMI`, `KEY_VOLUP`, `KEY_VOLDOWN`, `KEY_CHUP`, `KEY_CHDOWN`, `KEY_AMBIENT`, `KEY_MULTI_VIEW`, `KEY_ROTATE_PANEL`, and many more.
+
+## Art App Channel
+
+Art app package: `/opt/usr/apps/org.tizen.art-app`, version `3.50.104`.
+
+The Art app registers MSF channel `com.samsung.art-app` from `ArtDataManagement.dll`.
+
+Outer request:
+
+```json
+{
+  "method": "ms.channel.emit",
+  "params": {
+    "event": "art_app_request",
+    "to": "host",
+    "data": "{\"request\":\"api_version\",\"id\":\"...\",\"request_id\":\"...\"}"
+  }
+}
+```
+
+Outer response event:
+
+```text
+d2d_service_message
+```
+
+The response `data` is a JSON string. Most direct responses contain:
+
+```json
+{
+  "event": "<request name>",
+  "request_id": "<same request_id>"
+}
+```
+
+If `request_id` is missing, the app sets `request_id` to the entire incoming JSON string. Always send one.
+
+Errors use:
+
+```json
+{
+  "event": "error",
+  "request_id": "...",
+  "request_data": "{original request json}",
+  "error_code": "-7"
+}
+```
+
+Error code enum:
+
+| Code | Name |
+|---:|---|
+| `-14` | `INSUFFICIENT_SYSTEM_SPACE` |
+| `-13` | `PREVIEW_NOT_STARTED` |
+| `-12` | `CHECKOUT_IN_PROGRESS` |
+| `-11` | `INSUFFICIENT_SPACE` |
+| `-10` | `TEMPORARILY_UNAVAILABLE` |
+| `-9` | `NOT_SUPPORTED_API` |
+| `-8` | `SSO_REQUIRED` |
+| `-7` | `INVALID_PARAMETER` |
+| `-6` | `REQUEST_PARSE_FAIL` |
+| `-5` | `DB_ERROR` |
+| `-4` | `FILE_NOT_FOUND` |
+| `-3` | `NO_MEMORY` |
+| `-2` | `NO_PERMISSION` |
+| `-1` | `SYSTEM_FAIL` |
+| `0` | `NO_ERROR` |
+
+### Art Requests
+
+These request names are in `MobileCommandFactory`.
+
+| Request | Params | Response fields / notes |
+|---|---|---|
+| `api_version` | none | `version`: `5.0.1.0`. |
+| `bl_auto_wall_pattern` | `key` | Ambient/Blueline wallpaper helper. Responds `stat`, `key`, plus ambient info. |
+| `bl_image` | `type`, `key`, `fileid`, optional `duration`, `pattern_type`, `install_type`, `wall_color`, `pattern_color` | Downloads/sets Blueline image. Responds `stat`. |
+| `bl_marker` | `key` | Ambient/Blueline marker helper. Responds `stat`, `key`, plus ambient info. |
+| `buy_content` | `content_id` | Starts purchase checkout. Errors include `SSO_REQUIRED`, `CHECKOUT_IN_PROGRESS`. |
+| `change_favorite` | `content_id`, `status`: `on`/`off` | Responds `content_id`, `status`; may broadcast `favorite_changed`. |
+| `change_matte` | `content_id`, `matte_id`, optional `portrait_matte_id` | Responds changed matte ids. |
+| `current_app` | none | Responds `stat: ok`, plus `current_app_id`, `ambient_mode`. |
+| `delete_image_list` | `content_id_list`: array | Responds `content_id_list`; may broadcast `image_deleted`. |
+| `enabled_routine` | `routine`: array of objects with `routine_id` | Responds `stat: ok`, plus ambient info. |
+| `get_art_picture_mode` | none | Responds `art_picture_mode`. |
+| `get_artmode_settings` | none | Responds `data`: JSON string list of setting objects. Includes `brightness`, `color_temperature`, `motion_sensitivity`, `motion_timer`, `brightness_sensor_setting` where supported, each with `value`, `min`, `max` or `valid_values`. |
+| `get_artmode_status` | none | Responds `value`: `on`/`off`. |
+| `get_content_list` | `category_id` | Responds `content_list`: JSON string list with `content_id`, `category_id`, `slideshow`, and for photos `matte_id`, `portrait_matte_id`, `width`, `height`, `image_date`, `content_type`. |
+| `get_content_matte_list` | `category_id`, optional `sub_category_id` | Responds `content_matte_list`: JSON string list of `content_id`, `matte_id`, `portrait_matte_id`. |
+| `get_current_artwork` | none | Responds `content_id`, `matte_id`, `portrait_matte_id`, `category_id`, `content_type` (`ambient`, `myphoto`, `artstore`, `na`). |
+| `get_current_rotation` | none | Responds `current_rotation_status`: `1` landscape, `2` portrait. |
+| `get_device_info` | none | Responds `current_rotation_status`, `support_brightness_sensor`, `support_motion_sensor`, `resolution_type`, `support_color_tone`, `tv_flash_size`, `support_myshelf`, `server_sync_state`, `support_subscription_hub`. |
+| `get_matte_list` | none | Responds `matte_type_list` and `matte_color_list` as JSON strings. Color entries contain `color`, `R`, `G`, `B`. |
+| `get_photo_filter_list` | none | Responds `filter_list`: JSON string list of objects with `filter_id`. |
+| `get_slideshow_status` | none | Responds `value`, `category_id`, `sub_category_id`, `current_content_id`, `type`, `content_list`. `value: off` when disabled; otherwise interval minutes. |
+| `get_sso_login_status` | none | Responds `is_logged_in`: `Yes`/`No`. |
+| `get_subscription_list` | none | Responds `rsp`; requires SSO. |
+| `get_subscription_user_list` | none | Responds `rsp`; requires SSO. |
+| `routine_available_app_list` | none | Responds `routine_app`: JSON string/list of routine app ids. |
+| `reset_brightness` | none | Responds `brightness_value`. |
+| `select_image` | `content_id`, `category_id`, optional `sub_category_id`, `show`: bool | Responds `content_id`, `category_id`, `sub_category_id`, `matte_id`, `portrait_matte_id`, `is_shown`: `Yes`/`No`; broadcasts `image_selected`. |
+| `set_art_picture_mode` | `art_picture_mode`: number | Responds `value`. |
+| `set_artmode_status` | `value`: `on`/`off` | Responds `status`; may broadcast `art_mode_changed`. |
+| `set_bl_adjustment` | `function`: `brightness` or `colortone`; `value`: number | Ambient/Blueline setting. Responds `stat`. |
+| `set_brightness` | `value`: number | Responds `value`. |
+| `set_brightness_sensor_setting` | `value`: string/number accepted by ScreenManager | Responds `value`. |
+| `set_color_temperature` | `value`: number | Responds `value`. |
+| `set_motion_sensitivity` | `value`: supported sensitivity string/number | Responds `value`. |
+| `set_motion_timer` | `value`: `off`, `always`, `5`, `15`, `30`, `60`, `120`, `180`, `240` depending model mode | Responds `value`. |
+| `set_photo_filter` | `content_id`, `filter_id` | Responds `content_id` on success. |
+| `set_slideshow_status` | `value`, `category_id`, `sub_category_id`, `type`: `slideshow` or `shuffleslideshow` | Responds same fields; `value: off` disables. |
+| `start_preview` | `content_id`, `category_id`, optional `sub_category_id`, `matte_id`, `portrait_matte_id` | Starts preview flow; broadcasts `preview_started`; errors include `INVALID_PARAMETER`, `REQUEST_PARSE_FAIL`, `TEMPORARILY_UNAVAILABLE`. |
+| `stop_preview` | none | Stops preview flow; broadcasts `preview_stopped`. |
+| `subscribe` | `subscribe_id` | Starts subscription checkout; requires SSO. |
+| `tv_information` | none | Responds `stat`, `lang`, `countrycode`, `modelid`, `firmcode`, `resolution`, `smartTVclient`, `DUID`, `color_sensor`, `lifeStyleType`. |
+| `unsubscribe` | none seen in parser | Starts unsubscribe/cancel flow; requires SSO. |
+| `update_ambient_frame` | `type`, `wallpaperid` | Ambient frame/wallpaper update. Responds `stat`. |
+| `update_ambient_setting` | any of `brightness`, `colortone`, `saturation`, `color_r`, `color_g`, `color_b`, `auto_brightness` | Sets ambient picture settings. Responds `stat: ok`. |
+| `update_ambient_wallpaper` | `type`, `wallpaperid`, optional Blueline fields `duration`, `pattern_type`, `install_type`, `wall_color`, `pattern_color` | Updates ambient wallpaper. Responds `stat`. |
+| `update_routine` | `routine_id` | Updates/launches ambient routine. Responds `stat`. |
+| `update_template_config` | `template_app_id`, `template_config_id`, optional `content_info` | Updates ambient template config. Responds `stat`, `previous_app_id`, `current_app_id`. |
+
+### Art Content-Sharing Requests
+
+These are in `MobileDefine.CossList`; they first create a D2D content-sharing channel using `conn_info`.
+
+| Request | Params | Response / behavior |
+|---|---|---|
+| `get_thumbnail_list` | `content_id_list`, `conn_info`: object/string with `connection_id`, `d2d_mode`, etc. | Responds `content_id`, `file_type`, `content_list`, `conn_info`, then streams/copies thumbnail data over the D2D content-sharing channel. |
+| `get_photo_filter_thumbnail_list` | `filter_id_list`, `conn_info` | Responds `conn_info`, then streams/copies filter thumbnails. |
+| `send_image` | `file_size`, `file_type`, `matte_id`, `portrait_matte_id`, optional `image_date`, `conn_info` | First responds `ready_to_use` with `conn_info`; after transfer responds `content_id`, matte ids, `width`, `height`; broadcasts `image_added`. |
+| `preview_image` | `file_size`, `matte_id`, `portrait_matte_id`, `conn_info` | First responds `ready_to_use`; then previews transferred image. |
+| `send_image_list` | `file_size`, `content_list`, `conn_info` | Multi-image upload. Broadcasts `image_of_list_added` per item and `image_list_added` at completion. |
+| `send_image_list_with_launch` | same as `send_image_list` | Launches Art app loading screen first if needed, then behaves like multi-image upload. |
+| `cancel_image_list` | `request_id` of active COSS request | Cancels active list upload; responds `event: cancel_image_list`. |
+
+### Art Broadcast Events
+
+All are published as `d2d_service_message` on `com.samsung.art-app`.
+
+| Inner `event` | Fields |
+|---|---|
+| `notify.reset_my_photo` | `stat` |
+| `art_mode_changed` | `status` |
+| `image_added` | `content_id`, `category_id`, `matte_id`, `portrait_matte_id`, `width`, `height` |
+| `image_selected` | `content_id`, `matte_id`, `portrait_matte_id`, `is_shown` |
+| `image_deleted` | `content_id` |
+| `matte_changed` | `content_id`, `matte_id`, `portrait_matte_id` |
+| `buy_checkout_finished` | `content_id`, `status` |
+| `preview_started` | none |
+| `preview_stopped` | none |
+| `subscription_checkout_finished` | `subscription_id`, `status` |
+| `subscription_changed` | `is_subscribed` |
+| `sso_login_status_changed` | `is_logged_in` |
+| `go_to_standby` | none |
+| `wakeup` | none |
+| `recently_set_updated` | `recently_set_list` |
+| `favorite_changed` | `content_id`, `status` |
+| `slideshow_image_changed` | `current_content_id`, `type` |
+| `slideshow_changed` | `value`, `category_id`, `sub_category_id`, `type` |
+| `purchased_information_updated` | none |
+| `rotation_changed` | `current_rotation_status` |
+| `image_list_added` | `content_list` |
+| `image_of_list_added` | `file_name`, `content_id` |
+| `notify.sync_server` | `status`: `start`/`finish` |
+
+## Important Absences On This Firmware
+
+These appear in external clients or compatibility code, but are not present in the decompiled `MobileCommandFactory` or `CossList` for this TV firmware:
+
+| Request | Decompile finding |
+|---|---|
+| `get_api_version` | Not mapped. Use `api_version`. |
+| `get_brightness` | Not mapped. Use `get_artmode_settings` and read item `brightness`. |
+| `get_color_temperature` | Not mapped. Use `get_artmode_settings` and read item `color_temperature`. |
+| `get_thumbnail` | Not mapped. Use `get_thumbnail_list` COSS path. |
+| `get_auto_rotation_status` / `set_auto_rotation_status` | Not mapped. Use `get_slideshow_status` / `set_slideshow_status`. |
+
+## Minimal Examples
+
+Art API version:
+
+```json
+{
+  "method": "ms.channel.emit",
+  "params": {
+    "event": "art_app_request",
+    "to": "host",
+    "data": "{\"request\":\"api_version\",\"id\":\"1\",\"request_id\":\"1\"}"
+  }
+}
+```
+
+Get Art Mode settings, including brightness and color temperature:
+
+```json
+{
+  "method": "ms.channel.emit",
+  "params": {
+    "event": "art_app_request",
+    "to": "host",
+    "data": "{\"request\":\"get_artmode_settings\",\"id\":\"2\",\"request_id\":\"2\"}"
+  }
+}
+```
+
+Set Art Mode brightness:
+
+```json
+{
+  "method": "ms.channel.emit",
+  "params": {
+    "event": "art_app_request",
+    "to": "host",
+    "data": "{\"request\":\"set_brightness\",\"value\":5,\"id\":\"3\",\"request_id\":\"3\"}"
+  }
+}
+```
+
+Set slideshow:
+
+```json
+{
+  "method": "ms.channel.emit",
+  "params": {
+    "event": "art_app_request",
+    "to": "host",
+    "data": "{\"request\":\"set_slideshow_status\",\"value\":\"30\",\"category_id\":\"MY-C0002\",\"sub_category_id\":\"\",\"type\":\"slideshow\",\"id\":\"4\",\"request_id\":\"4\"}"
+  }
+}
+```

--- a/notes/QN55LS03FAFXZA/WEBSOCKET_DECOMPILED.md
+++ b/notes/QN55LS03FAFXZA/WEBSOCKET_DECOMPILED.md
@@ -22,6 +22,11 @@ Linux: `5.4.261 armv7l`
 - `/opt/usr/apps/com.samsung.tv.coba.art/tizen-manifest.xml`
 - `/opt/usr/apps/com.samsung.tv.home.art/tizen-manifest.xml`
 - `/usr/apps/com.samsung.tv.wizard.art/tizen-manifest.xml`
+- `/opt/usr/apps/mobilebff/tizen-manifest.xml`
+- `/opt/usr/apps/mobilebff/bin/MobileBFF.dll`
+- `/opt/usr/apps/mobilebff/bin/MobileBFF.Gateway.dll`
+- `/opt/usr/apps/mobilebff/bin/MobileBFF.Domain.dll`
+- `/opt/usr/apps/mobilebff/bin/MobileBFF.External.dll`
 
 ## Port Owners
 
@@ -90,6 +95,8 @@ Hard-coded public channel strings in `msf-server`:
 | `com.samsung.virtualmicservice` |
 
 `com.samsung.art-app` is registered by the Art app through the SmartView/MSF local service API, not hard-coded in `msf-server`.
+
+`com.samsung.tv.mobilebff` is both listed by `msf-server` and registered by the MobileBFF app through the SmartView/MSF local service API.
 
 ### Generic Events
 
@@ -291,6 +298,96 @@ All are published as `d2d_service_message` on `com.samsung.art-app`.
 | `image_list_added` | `content_list` |
 | `image_of_list_added` | `file_name`, `content_id` |
 | `notify.sync_server` | `status`: `start`/`finish` |
+
+## MobileBFF Channel
+
+MobileBFF package: `/opt/usr/apps/mobilebff`.
+
+The app registers MSF channel `com.samsung.tv.mobilebff` from `MobileBFF.Gateway.dll`.
+
+Outer request:
+
+```json
+{
+  "method": "ms.channel.emit",
+  "params": {
+    "event": "/sec/tv/appdata/mobilebff",
+    "to": "host",
+    "data": "{\"version\":\"0.2\",\"id\":\"get.apptiles\",\"seqId\":\"1\",\"params\":{}}"
+  }
+}
+```
+
+Inner request fields are `version`, `id`, `seqId`, and `params`. Responses are published on `/sec/tv/appdata/mobilebff`; direct request responses go back to the client, while status/update/vconf notifications are broadcast.
+
+### MobileBFF Requests
+
+| `id` | Params | Functionality |
+|---|---|---|
+| `ask.service.status` | none | Broadcasts `notify.service.status` with `status`: `ready` or `abnormal`. |
+| `get.RotatorSupport` | none | Rotation accessory support probe. |
+| `get.aitech.enable` | none | Reads `db/aitech/enable`. |
+| `get.aitech.support` | none | Reads `com.samsung/featureconf/ai_tech.support`. |
+| `get.apptile.functions` | `requestId` | Gets function tiles for an app/source tile. |
+| `get.apptile.previews` | `requestId` | Gets preview tiles for an app/source tile. |
+| `get.apptiles` | none | Gets app tiles from Eden/launcher IPC. |
+| `get.dataForAmbient` | `targetPkgId` | Gets ambient/NFT preview data for one target package. |
+| `get.dataForAmbient.Apps` | `entry_count`, `key_names` | Gets ambient/NFT preview data for multiple target apps. |
+| `get.extsources` | none | Gets external source tiles. |
+| `get.gamepad.support` | none | Reports gamepad launch/support data. |
+| `get.icon` | `requestId` | Gets an icon/resource for a tile. |
+| `get.multiview.saved.tiles` | none | Gets saved Multi View tiles/modes. |
+| `get.recent.apptiles` | none | Gets recent app tiles. |
+| `get.recommended.apptiles` | none | Gets recommended app tiles. |
+| `get.settings.data` | none | Gets quick-setting data from Eden/launcher IPC. |
+| `get.system.info.bool` | `key` | Reads `system_info.GetCustomBoolean(key)`. |
+| `get.system.info.int` | `key` | Reads `system_info.GetCustomInt(key)`. |
+| `get.system.info.string` | `key` | Reads `system_info.GetCustomString(key)`. |
+| `get.system.info.values` | `entry_count`, `key_names` | Bulk custom system-info read. `key_names` entries include key/type data. |
+| `get.systemInfo.getValue.bool` | `key` | Reads `system_info.GetBoolean((SystemInfoKeye)int.Parse(key))`. |
+| `get.systemInfo.getValue.int` | `key` | Reads `system_info.GetInt((SystemInfoKeye)int.Parse(key))`. |
+| `get.systemInfo.getValue.string` | `key` | Reads `system_info.GetString((SystemInfoKeye)int.Parse(key))`. |
+| `launch.app` | `requestId` | Launches/selects an app tile. |
+| `launch.appForAmbient` | `targetAppId`, `action_play_url` | Launches ambient/NFT app preview flow. |
+| `launch.extsource` | `requestId` | Launches/selects an external source tile. |
+| `launch.function` | `requestId` | Launches a function tile. |
+| `launch.multiview.tile` | `requestId` | Launches a saved Multi View mode. |
+| `launch.preview` | `requestId` | Launches a preview tile. |
+| `req_launch.gamepad.support` | `action`, `aeskey` | Starts gamepad-support flow. |
+| `request.files` | `content_info`, `fileList` | Starts MobileBFF file/content transfer path. |
+| `request.isAppInstalled` | `requestId` | Checks whether an app is installed. |
+| `request.vconf.info.bool` | `key` | Reads a vconf bool key and registers for change broadcasts. |
+| `request.vconf.info.int` | `key` | Reads a vconf int key and registers for change broadcasts. |
+| `request.vconf.info.string` | `key` | Reads a vconf string key and registers for change broadcasts. |
+| `set.aitech.enable` | `value` | Writes `db/aitech/enable`. |
+| `set.lux.value` | `value` | Writes `memory/sensor/mobile/illumination`, then launches projector-setting handling. |
+| `set.settings.data` | `id`, `title`, `subTitle` | Selects/sets quick-setting item data through Eden/launcher IPC. |
+
+### MobileBFF Broadcasts
+
+| Broadcast `id` | Data | Trigger |
+|---|---|---|
+| `notify.service.status` | `status`: `ready` / `abnormal` | Client connect, `ask.service.status`, or service readiness change. |
+| `notify.update` | `reqMessage`: `get.apptiles`, `get.extsources`, `get.settings.data` | App/source/quick-setting updates. |
+| `event.setting.update` | `updateElement` | Follow-up quick-setting layer data. |
+| `request.vconf.info.bool` / `int` / `string` | `response`: `key`, `value` | Initial vconf read and later vconf change notifications. |
+
+## Other App Responders Checked
+
+Confirmed app-level MSF responders on this firmware:
+
+- `/opt/usr/apps/org.tizen.art-app` registers `com.samsung.art-app`.
+- `/opt/usr/apps/mobilebff` registers `com.samsung.tv.mobilebff`.
+
+Checked candidates without an app-level `CreateChannel`/message-listener pattern in the pulled code:
+
+- `/usr/apps/com.samsung.tv.ambient-support`
+- `/usr/apps/com.samsung.tv.multiscreen`
+- `/usr/apps/com.samsung.tv.coba.mobilebff`
+- `/usr/apps/com.samsung.tv.coba.multiscreen`
+- `/usr/apps/relumino-service`
+
+The remaining hard-coded `msf-server` channel names (`com.samsung.wallservice`, `com.samsung.tv.ambient`, `com.samsung.tv.ambient.contentapp`, `com.samsung.edgeblending-service`, `com.samsung.virtualmicservice`, `samsung.default.media.player`) look reserved or feature-gated from the pulled artifacts, not separately confirmed app responders.
 
 ## Important Absences On This Firmware
 


### PR DESCRIPTION
## Summary

More notes on top of TheFab21/ha-samsungtv-smart#51

Adds decompile notes for Samsung Ex-Link / RS-232 behavior on the 2025 Frame:

- identifies `TIFADaemon_L` / `org.tizen.tv.automation-service` as the main Ex-UART responder
- documents the live D-Bus API for raw Ex-UART sends, ACKs, baud changes, and SS/EP/RJP reads
- captures the recovered binary FAnet frame format, response framing, command opcodes, and EPA read subcommands
- notes how factory-service, kfactory, HyperUART, and UART devices fit around the Ex-Link stack

## Potential follow-ups

- Potentially useful if someone wanted to connect an esp32 device over RS-232 to the One Connect Box Ex-Link 3.5mm plug.
- Potentially more reliable for power-on, power-off, etc.
- Potentially useful for remote factory reset.
- Otherwise, JSON-RPC and websockets appear to be much more feature-rich.