### PR TITLE
Push-refresh Frame Art sensor on content broadcasts

### DIFF
--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -139,8 +139,14 @@ class SamsungTVAsyncArt:
         # Fired (no args) when the async art channel reports a panel transition
         # (art_mode_changed / go_to_standby), so the caller can refresh its
         # authoritative state (e.g. the IP Control pictureMode read) at once
-        # instead of waiting for the next poll.
-        self._art_event_callback = None
+        # instead of waiting for the next poll. A list, not a single slot,
+        # because media_player.py and sensor.py each register their own.
+        self._art_event_callbacks: list = []
+        # Fired (no args) when the async art channel reports a content-state
+        # broadcast (image_selected / matte_changed / slideshow_changed /
+        # favorite_changed / rotation_changed), so a poll-based coordinator
+        # can refresh immediately instead of waiting for its next interval.
+        self._art_content_callbacks: list = []
         # Capability flag: True = TV supports get_thumbnail_list (pre-2024 TVs,
         # streams all thumbnails over a single socket connection — fast).
         # False = TV returns error -1 (2024-2025 Tizen), must use get_thumbnail
@@ -173,16 +179,38 @@ class SamsungTVAsyncArt:
         Signature: func() with no arguments. Fired when the async art channel
         reports art_mode_changed or go_to_standby, so the caller can confirm
         the panel state (e.g. via IP Control) without waiting for its own poll.
+        Multiple callers may register (media_player.py and sensor.py each do).
         """
-        self._art_event_callback = func
+        self._art_event_callbacks.append(func)
 
     def _fire_art_event(self) -> None:
-        """Notify the caller of a panel transition; never break the art loop."""
-        if self._art_event_callback is not None:
+        """Notify callers of a panel transition; never break the art loop."""
+        for callback in self._art_event_callbacks:
             try:
-                self._art_event_callback()
+                callback()
             except Exception:  # noqa: BLE001 - callback must not break the loop
                 self._log.debug("Art API: art-event callback raised", exc_info=True)
+
+    def register_art_content_callback(self, func) -> None:
+        """Register a callback fired when the on-screen content/state changes.
+
+        Signature: func() with no arguments. Fired on image_selected,
+        matte_changed, slideshow_changed, favorite_changed, or
+        rotation_changed broadcasts, so a poll-based coordinator (e.g. the
+        Frame Art sensor) can refresh right away instead of waiting up to
+        SCAN_INTERVAL for the change to show up.
+        """
+        self._art_content_callbacks.append(func)
+
+    def _fire_art_content_event(self) -> None:
+        """Notify callers of a content-state change; never break the art loop."""
+        for callback in self._art_content_callbacks:
+            try:
+                callback()
+            except Exception:  # noqa: BLE001 - callback must not break the loop
+                self._log.debug(
+                    "Art API: art-content callback raised", exc_info=True
+                )
 
     @property
     def _ws_url(self) -> str:
@@ -515,6 +543,16 @@ class SamsungTVAsyncArt:
             # screen. Leave self.art_mode untouched and let the event
             # callback trigger an authoritative re-check instead.
             self._fire_art_event()
+        elif sub_event in (
+            "image_selected",
+            "matte_changed",
+            "slideshow_changed",
+            "favorite_changed",
+            "rotation_changed",
+        ):
+            # Confirmed broadcasts (WEBSOCKET_DECOMPILED.md) for changes the
+            # Frame Art sensor otherwise only learns about on its next poll.
+            self._fire_art_content_event()
 
         # Check for error
         if sub_event == "error":

--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -208,9 +208,7 @@ class SamsungTVAsyncArt:
             try:
                 callback()
             except Exception:  # noqa: BLE001 - callback must not break the loop
-                self._log.debug(
-                    "Art API: art-content callback raised", exc_info=True
-                )
+                self._log.debug("Art API: art-content callback raised", exc_info=True)
 
     @property
     def _ws_url(self) -> str:

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -140,6 +140,12 @@ async def async_setup_entry(
 
         # Create the coordinator
         coordinator = FrameArtCoordinator(hass, art_api, entry)
+        # Refresh immediately on artwork/matte/slideshow/favorite/rotation
+        # broadcasts instead of waiting up to SCAN_INTERVAL for the change
+        # to be picked up by the next poll.
+        art_api.register_art_content_callback(
+            lambda: hass.async_create_task(coordinator.async_request_refresh())
+        )
 
         # Add Frame Art sensor
         entities.append(


### PR DESCRIPTION
Andrew's decompile notes (PR #51) confirm the art-app WebSocket broadcasts image_selected/matte_changed/slideshow_changed/ favorite_changed/rotation_changed events, which the Frame Art coordinator previously only learned about on its next 15s poll. Wire these into a new content-change callback and have the coordinator request an immediate refresh when they fire. Also switch the existing art-event callback from a single slot to a list, since both media_player.py and sensor.py now register one.


Claude-Session: https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2