### PR TITLE
Clarify IP Control -32002 errors as picture-mode-locked, not failures

### DIFF
--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -51,6 +51,13 @@ ERROR_UNAUTHORIZED = -32010
 # AccessToken is stale/unrecognized: a fresh pairing always clears it. Treated
 # as an auth error (re-pair required) when a token was actually sent.
 ERROR_PARSE_STALE_TOKEN = -32700
+# Generic "Server error". Observed for expert-picture controls (e.g.
+# colorToneControl) when the TV's current picture mode does not allow the
+# setting to be changed — Dynamic/HDR-dynamic modes drive color tone
+# automatically and reject manual writes, while Standard/Movie/Filmmaker
+# accept them. Not a transport or pairing problem: retrying after switching
+# picture mode succeeds.
+ERROR_SERVER = -32002
 
 # Art-mode desync guard: number of consecutive reads where the artModeControl
 # flag claims "on" while getTVStates.pictureMode shows a real (non-art) picture
@@ -66,6 +73,15 @@ class SamsungIPControlError(Exception):
 
 class SamsungIPControlAuthError(SamsungIPControlError):
     """The access token is missing, invalid or expired — re-pairing is required."""
+
+
+class SamsungIPControlModeLockedError(SamsungIPControlError):
+    """The control is rejected by the TV's current picture mode (code -32002).
+
+    Not a transport, pairing, or capability problem — the same request
+    succeeds once the TV is switched to a picture mode that allows manual
+    writes (e.g. Standard/Movie/Filmmaker rather than Dynamic/HDR-dynamic).
+    """
 
 
 class SamsungIPControl:
@@ -366,6 +382,13 @@ class SamsungIPControl:
             ):
                 raise SamsungIPControlAuthError(
                     f"token rejected (code {code}): {message} — re-pair required"
+                )
+            if code == ERROR_SERVER:
+                raise SamsungIPControlModeLockedError(
+                    f"TV returned error {code}: {message} — the current "
+                    "picture mode likely blocks this control (e.g. "
+                    "Dynamic/HDR-dynamic); switch to Standard/Movie/"
+                    "Filmmaker and retry"
                 )
             raise SamsungIPControlError(f"TV returned error {code}: {message}")
 

--- a/custom_components/samsungtv_smart/select.py
+++ b/custom_components/samsungtv_smart/select.py
@@ -21,6 +21,7 @@ from .api.ipcontrol import (
     SamsungIPControl,
     SamsungIPControlAuthError,
     SamsungIPControlError,
+    SamsungIPControlModeLockedError,
 )
 from .const import (
     AUTH_METHOD_OAUTH,
@@ -362,6 +363,13 @@ class SamsungTVIPControlColorToneSelect(SelectEntity):
             )
             raise HomeAssistantError(
                 f"IP Control token rejected while setting color tone: {ex}"
+            ) from ex
+        except SamsungIPControlModeLockedError as ex:
+            # Reversible TV-side state, not a pairing or capability problem —
+            # leave the entity available so the next attempt (after switching
+            # picture mode) can succeed without re-pairing.
+            raise HomeAssistantError(
+                f"Color tone can't be changed right now: {ex}"
             ) from ex
         except SamsungIPControlError as ex:
             self._mark_unavailable()


### PR DESCRIPTION
## Summary
- `colorToneControl` (and other expert-picture IP Control writes) return JSON-RPC error `-32002` when the TV's current picture mode drives the setting automatically (e.g. Dynamic/HDR-dynamic) and rejects manual writes.
- This was previously surfaced as a generic "Server error" and the color tone select entity was marked `unavailable`, even though the same write succeeds again once the picture mode is switched back to Standard/Movie/Filmmaker — confirmed from a real-world log where `-32002` appeared right after the TV's picture mode switched to `modeDynamicHDR`.
- Adds `SamsungIPControlModeLockedError` for code `-32002` with a clear message, and keeps the color tone entity available when it's raised (no need to re-pair, no spurious "entity unavailable" warnings on retry).

## Test plan
- [x] `py_compile`, `black --check`, `flake8` pass on the changed files
- [ ] Trigger `select.select_option` on the color tone entity while the TV is in Dynamic/HDR-dynamic picture mode and confirm the new error message appears and the entity stays available
- [ ] Confirm setting color tone still works normally in Standard/Movie/Filmmaker picture modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_