### PR TITLE
Fix orphan thumbnail cleanup skipped when artwork list is empty

### DIFF
--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -3587,19 +3587,11 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 # Get all artworks
                 artwork_list = await self._art_api.available()
 
-            if not artwork_list:
-                result = {
-                    "service": "art_get_thumbnails_batch",
-                    "success": False,
-                    "message": "No artworks found",
-                    "downloaded": 0,
-                    "skipped": 0,
-                    "failed": 0,
-                }
-                self._store_art_result(result)
-                return result
-
-            # Build set of valid content IDs
+            # Build set of valid content IDs (empty set if the TV reports no
+            # artworks at all for this filter, e.g. after a factory reset wipes
+            # all personal photos -- that's a legitimate signal that every
+            # locally cached file for this category is now an orphan, not a
+            # reason to skip cleanup).
             valid_content_ids = {
                 artwork.get("content_id")
                 for artwork in artwork_list
@@ -3612,6 +3604,20 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 removed_files = await self._cleanup_orphan_thumbnails(
                     valid_content_ids, favorites_only, personal_only, category_id
                 )
+
+            if not artwork_list:
+                result = {
+                    "service": "art_get_thumbnails_batch",
+                    "success": False,
+                    "message": "No artworks found",
+                    "downloaded": 0,
+                    "skipped": 0,
+                    "failed": 0,
+                    "removed": len(removed_files),
+                    "removed_list": removed_files,
+                }
+                self._store_art_result(result)
+                return result
 
             # Download thumbnails with progress tracking
             downloaded = []


### PR DESCRIPTION
## Summary
- `art_get_thumbnails_batch` returned early with "No artworks found" whenever the filtered artwork list came back empty (e.g. `personal_only=true` after a TV factory reset wipes all personal photos), *before* reaching the `cleanup_orphans` step.
- Result: local thumbnails for that category were never cleaned up even with `cleanup_orphans: true`, leaving stale files (e.g. 18 `MY_F00xx.jpg` files after a factory reset that removed all personal photos from the TV).
- Fix: build `valid_content_ids` and run the orphan cleanup before the empty-list early return — an empty list from the TV is a legitimate "everything local is orphaned" signal for that category, not a reason to skip cleanup.

## Test plan
- [x] `py_compile` clean
- [x] `black --check` clean
- [x] `flake8` clean
- [ ] Confirm `personal_only` cleanup actually removes stale local files after a TV-side wipe


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_