### PR TITLE
Docs: close phase 1 — sync README & release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode su
   - [SmartThings Authentication](#smartthings-authentication)
   - [Integration Setup](#integration-setup)
   - [Options](#options)
+  - [Reconfigure](#reconfigure)
 - [Entities](#entities)
 - [Services](#services)
   - [Standard TV Services](#standard-tv-services)
@@ -239,10 +240,24 @@ After initial setup, click **Configure** on the integration card to access these
 | **Sync turn on/off** | Optional entity to mirror TV power state |
 | **External power entity** | Use an external sensor to determine power state |
 | **Toggle Art Mode** | Toggle Art Mode when turning on a Frame TV that is already in Art Mode |
-| **Enable IP Control** | Use the local JSON-RPC channel (port 1516) for reliable power on/off without SmartThings (shown only once the TV is paired for IP Control) |
-| **Enable IP Control Art Mode** | Use IP Control to read and switch Art Mode. **Off by default — leave it off unless you know your firmware handles it.** ⚠️ Can break Art Mode entirely and may need a factory reset to recover (seen on QE55LS03D fw 2123). See [IP Control reports Art Mode "on" when it isn't](#ip-control-reports-art-mode-on-when-it-isnt) |
 | **Ping port** | Port used to detect TV presence |
 | **WS name** | Name shown on the TV when pairing (default: `[Home Assistant]`) |
+
+> **IP Control moved.** Pairing and the *Enable IP Control* / *Enable IP Control Art Mode* toggles are no longer in this Options screen — they now live under **Reconfigure → IP Control** (see [Reconfigure](#reconfigure) below).
+
+---
+
+### Reconfigure
+
+To change connection or credentials after setup, open **Settings → Devices & Services → Samsung TV Smart → Reconfigure**. The flow is split into three clear sections so you only touch what you need:
+
+| Section | What it changes |
+|---|---|
+| **Connection** | TV IP address and WebSocket port (8001, or 8002 for SSL-only TVs). Use **8001** unless your TV only answers on **8002**. The integration also falls back between the two ports automatically at runtime if a firmware update filters the configured one. |
+| **Authentication** | The auth method (OAuth2 / Personal Access Token / SmartThings link). For OAuth2, selecting it starts the login flow immediately. |
+| **IP Control** | Pair the local JSON-RPC channel (port 1516) and, once paired, toggle **Enable IP Control** (reliable power on/off without SmartThings) and **Enable IP Control Art Mode** (⚠️ off by default — see the warning below). To pair, check *Pair now* with the TV **ON and in normal viewing (not Art Mode)** and accept the on-screen prompt. |
+
+> ⚠️ **Do not enable *Enable IP Control Art Mode*** unless you know your firmware handles it — it can break Art Mode entirely and may need a factory reset to recover (seen on QE55LS03D fw 2123). See [IP Control reports Art Mode "on" when it isn't](#ip-control-reports-art-mode-on-when-it-isnt).
 
 ---
 
@@ -612,10 +627,10 @@ This typically appears **after a TV factory reset and re-pairing** of the IP Con
 
 **Workarounds, in order of preference:**
 
-1. **Disable Art Mode over IP Control.** In the integration options, turn **Enable IP Control Art Mode** off (this is the default). Art Mode detection and switching then fall back to the WebSocket / Frame Art channel, which is unaffected. Power on/off over IP Control (**Enable IP Control** / the *IP Control* power-on method) keeps working — only the Art Mode path is disabled.
+1. **Disable Art Mode over IP Control.** Under **Reconfigure → IP Control**, turn **Enable IP Control Art Mode** off (this is the default). Art Mode detection and switching then fall back to the WebSocket / Frame Art channel, which is unaffected. Power on/off over IP Control (**Enable IP Control** / the *IP Control* power-on method) keeps working — only the Art Mode path is disabled.
 2. **Factory reset the TV.** If you need IP Control for Art Mode and the flag is wedged, the only known way to clear the stuck `artModeControl` flag on the TV side is a **factory reset of the TV** (Settings → General → Reset), followed by re-pairing. There is no remote/API command that unsticks it.
 
-Once a firmware update reports `artModeControl` correctly again, you can re-enable **Enable IP Control Art Mode** in the options.
+Once a firmware update reports `artModeControl` correctly again, you can re-enable **Enable IP Control Art Mode** under **Reconfigure → IP Control**.
 
 ---
 

--- a/RELEASE_NOTES_8.0.0.md
+++ b/RELEASE_NOTES_8.0.0.md
@@ -47,7 +47,7 @@ with each channel independently selectable and resilient to a bad credential.
 
 ## IP Control (new channel — JSON-RPC, port 1516)
 
-- **Pairing** from the integration options (TV must be ON and in normal
+- **Pairing** from **Reconfigure → IP Control** (TV must be ON and in normal
   viewing, not Art Mode). The access token is stored per entry and **survives
   TV reboots** (no re-pairing needed afterwards).
 - **Power on/off** and **reboot** over a channel that is independent of the
@@ -59,8 +59,9 @@ with each channel independently selectable and resilient to a bad credential.
 - **Art Mode set** now goes through IP Control **first**, falling back to the
   WebSocket only on failure — avoiding the WebSocket path that could become
   unresponsive.
-- **Enable/disable toggle** in the options: turn the whole IP Control channel
-  off without un-pairing (hides the reboot button and stops IP Control polling).
+- **Enable/disable toggle** under **Reconfigure → IP Control**: turn the whole
+  IP Control channel off without un-pairing (hides the reboot button and stops
+  IP Control polling).
 - **Power-on method**: "IP Control" can be selected as the power-on method,
   available even without SmartThings, with WOL as automatic fallback.
 - Robust error handling: the firmware's flat `-32700` "Parse error" (returned
@@ -101,6 +102,32 @@ with each channel independently selectable and resilient to a bad credential.
   (`slideshow` vs `auto_rotation`), accepting custom durations.
 - Bundled `folder-gallery-card` for the art gallery frontend.
 
+## Reliability & consolidation
+
+A round of stabilization fixes on top of the three-channel rework:
+
+- **Reconfigure flow restructured** into three clear sections — **Connection**,
+  **Authentication** and **IP Control** — instead of one cramped form. IP Control
+  pairing and toggles moved here from the Options screen.
+- **Port selection fixed** in Reconfigure: choosing 8001/8002 was always
+  rejected (a type-coercion bug); both ports now validate correctly.
+- **Art Mode self-heals on a port change**: the Art channel now falls back
+  between **8001 and 8002 at runtime** (like the main WebSocket already did) and
+  persists the working port, so a firmware update that filters the configured
+  port no longer leaves Art Mode unreachable until a manual reconfigure.
+- **Art Mode motion settings** (sensitivity / timer) decoded correctly — the
+  TV reports `valid_values` as a JSON-encoded string, which was previously
+  exploded into one option per character.
+- **Orphan thumbnail cleanup** now runs even when the TV reports an empty
+  artwork list (e.g. after a factory reset), instead of leaving stale local
+  thumbnails behind.
+- **Per-TV log prefixes**: Frame Art, SmartThings and coordinator log lines are
+  now prefixed with the TV's host (`[192.168.x.y]`), matching the WebSocket and
+  media-player logs, so multi-TV setups are readable.
+- **Brightness / colour-temperature capability detection is now persisted**
+  across restarts, so the one-off probe (and its timeout cost) is not re-paid on
+  every start.
+
 ## Localization
 
 - All UI strings (config, options, IP Control pairing, the new toggle and the
@@ -121,8 +148,8 @@ with each channel independently selectable and resilient to a bad credential.
   default** — see the warning above.
 - The reboot/IP-Control recovery of an unresponsive ("zombie") Art WebSocket is
   implemented but **not yet confirmed empirically** in that exact state.
-- Brightness / colour-temperature capability flags are re-detected on every
-  start (not yet persisted).
+- The runtime **Art channel port fallback** (8001↔8002) is implemented but not
+  yet confirmed on a TV that actually drops its configured port.
 - The three power-on-method labels are currently English-only in all locales.
 
 ---


### PR DESCRIPTION
## Summary
Closes out **phase 1** (consolidation & reliability) by syncing the docs with the changes that landed in #59–#64.

- **README**
  - IP Control pairing and the *Enable IP Control* / *Enable IP Control Art Mode* toggles moved out of the Options table into a new **Reconfigure** subsection documenting the three sections (Connection / Authentication / IP Control).
  - Updated the two troubleshooting references that still pointed at "integration options".
  - Added the Reconfigure entry to the table of contents.
- **RELEASE_NOTES_8.0.0.md**
  - New **Reliability & consolidation** section: Reconfigure restructure, port-selection fix, Art channel runtime port fallback (8001↔8002), motion-settings decode fix, orphan thumbnail cleanup, per-TV log prefixes, persisted brightness/colour-temp capability detection.
  - Refreshed the IP Control pairing/toggle location.
  - Updated **Known limitations**: dropped the now-fixed "capability flags re-detected on every start"; added the runtime port fallback as not-yet-field-confirmed.

## Test plan
- Docs only — no code changes. Rendered headings/anchors checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_