### PR TITLE
P1.4: learn TV model/firmware via IP Control getDeviceInformation

### DIFF
--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -288,6 +288,20 @@ class SamsungIPControl:
             raise SamsungIPControlError(f"unexpected colorTone response: {result!r}")
         return response_value
 
+    async def async_get_device_information(self) -> dict[str, str]:
+        """Return the TV's model, firmware version and serial number."""
+        result = await self._async_request("getDeviceInformation")
+        model_id = result.get("modelID")
+        if not isinstance(model_id, str):
+            raise SamsungIPControlError(
+                f"no modelID in getDeviceInformation response: {result!r}"
+            )
+        return {
+            "modelID": model_id,
+            "FWVersion": str(result.get("FWVersion", "")),
+            "serialNumber": str(result.get("serialNumber", "")),
+        }
+
     # -- transport -----------------------------------------------------------
 
     async def _async_request(

--- a/custom_components/samsungtv_smart/config_flow.py
+++ b/custom_components/samsungtv_smart/config_flow.py
@@ -67,6 +67,8 @@ from .const import (
     CONF_ENABLE_IP_CONTROL,
     CONF_EXT_POWER_ENTITY,
     CONF_IP_CONTROL_ART_MODE,
+    CONF_IP_CONTROL_FW_VERSION,
+    CONF_IP_CONTROL_MODEL_ID,
     CONF_IP_CONTROL_TOKEN,
     CONF_LOGO_OPTION,
     CONF_OAUTH_TOKEN,
@@ -822,9 +824,23 @@ class SamsungTVSmartOAuth2FlowHandler(
                     )
                     errors[CONF_BASE] = "ip_control_pair_failed"
                 else:
+                    data_updates: dict[str, Any] = {CONF_IP_CONTROL_TOKEN: token}
+                    try:
+                        device_info = await client.async_get_device_information()
+                    except SamsungIPControlError as ex:
+                        _LOGGER.debug(
+                            "IP Control getDeviceInformation failed for %s: %s",
+                            host,
+                            ex,
+                        )
+                    else:
+                        data_updates[CONF_IP_CONTROL_MODEL_ID] = device_info["modelID"]
+                        data_updates[CONF_IP_CONTROL_FW_VERSION] = device_info[
+                            "FWVersion"
+                        ]
                     return self.async_update_reload_and_abort(
                         entry,
-                        data_updates={CONF_IP_CONTROL_TOKEN: token},
+                        data_updates=data_updates,
                         reason="ip_control_pair_successful",
                     )
 

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -109,6 +109,14 @@ CONF_ENABLE_IP_CONTROL = "enable_ip_control"
 # correctly again.
 CONF_IP_CONTROL_ART_MODE = "ip_control_art_mode"
 
+# Device identity, learned once via IP Control's getDeviceInformation right
+# after pairing. Used to gate which model-dependent features/entities get
+# created (not every TV supports the same IP Control capability set).
+# Distinct from CONF_DEVICE_MODEL (the WS-discovered friendly model name):
+# modelID here is the raw internal code IP Control returns (e.g. "25_PTM_FTV").
+CONF_IP_CONTROL_MODEL_ID = "ip_control_model_id"
+CONF_IP_CONTROL_FW_VERSION = "ip_control_fw_version"
+
 # Authentication methods
 AUTH_METHOD_OAUTH = "oauth"
 AUTH_METHOD_PAT = "pat"


### PR DESCRIPTION
## Summary
- Add `SamsungIPControl.async_get_device_information()`, calling the documented `getDeviceInformation` JSON-RPC method (returns `modelID`, `serialNumber`, `FWVersion`).
- Call it once, right after a successful IP Control pairing (`async_step_reconfigure_ip_pair`), and persist `modelID`/`FWVersion` on the config entry as `CONF_IP_CONTROL_MODEL_ID` / `CONF_IP_CONTROL_FW_VERSION`.
- Failure to fetch device info is non-fatal (logged at debug) — pairing still succeeds even if this extra call fails.

This is phase-2 lot P1.4: capability gating groundwork. Future model-dependent entities (sliders for contrast/sharpness/brightness/tint, picture/sound mode, treatment switches) can read these persisted values to decide what to create, instead of guessing or probing every feature individually.

## Test plan
- [x] `py_compile` / `black --check` / `flake8` clean
- [ ] Manual: pair IP Control on a real TV, confirm `ip_control_model_id` / `ip_control_fw_version` appear in the config entry data after pairing


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_