### PR TITLE
CI: route pre-releases to per-version dev branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,24 @@ jobs:
       - name: "Determine target branch"
         id: detect
         run: |
-          # Pre-releases (betas, rc) target the dev branch v8-json-rpc.
           # Stable releases target master.
-          # Override via tag pattern as a safety net for ambiguous cases.
+          # Pre-releases (betas, rc) target the dev branch matching their
+          # version line: 8.0.x -> v8-json-rpc, 8.1.x -> v8.1-dev, etc.
+          # The branch is derived from the tag's major.minor so new dev
+          # lines (8.2, ...) keep working without editing this workflow,
+          # as long as the branch is named v<major>.<minor>-dev.
           TAG="${{ github.event.release.tag_name }}"
           IS_PRERELEASE="${{ github.event.release.prerelease }}"
-          if [[ "$IS_PRERELEASE" == "true" ]] || [[ "$TAG" =~ ^8\.0\.0[a-zA-Z] ]]; then
-            BRANCH="v8-json-rpc"
-          else
+          if [[ "$IS_PRERELEASE" != "true" ]]; then
             BRANCH="master"
+          elif [[ "$TAG" =~ ^8\.0\.0 ]]; then
+            # The 8.0 line predates the v<maj>.<min>-dev convention.
+            BRANCH="v8-json-rpc"
+          elif [[ "$TAG" =~ ^([0-9]+)\.([0-9]+)\. ]]; then
+            BRANCH="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}-dev"
+          else
+            echo "::error::Cannot derive a dev branch from tag '$TAG'"
+            exit 1
           fi
           echo "Release tag: $TAG (prerelease=$IS_PRERELEASE) -> target branch: $BRANCH"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
Make the release workflow's branch detection version-aware so 8.1 pre-releases land on `v8.1-dev` (the new phase-2 dev line) instead of `v8-json-rpc`.

The target dev branch is now derived from the tag's `major.minor` as `v<major>.<minor>-dev`:
- stable → `master`
- `8.0.0bNN` → `v8-json-rpc` (kept hardcoded; predates the naming convention)
- `8.1.0bNN` → `v8.1-dev`
- future `8.2.x` → `v8.2-dev` automatically, no workflow edit needed

## Why this targets master
The `on: release` workflow always runs from the **default branch** (`master`), so this routing change has no effect until it is merged here — it must land on `master` before the first 8.1 beta is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_