### PR TITLE
Fix: REST client now honors configured port + self-heals on failure

### DIFF
--- a/custom_components/samsungtv_smart/api/samsungws.py
+++ b/custom_components/samsungtv_smart/api/samsungws.py
@@ -34,7 +34,7 @@ import subprocess
 import sys
 from threading import Lock, Thread
 import time
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import urlencode, urljoin
 import uuid
 
@@ -211,25 +211,67 @@ class SamsungTVAsyncRest:
         self._port = port
         self._session = session
         self._timeout = None if timeout == 0 else timeout
+        self._port_callback: Callable[[int], None] | None = None
+
+    def register_port_callback(self, func: Callable[[int], None]) -> None:
+        """Register a callback invoked when the working REST port changes.
+
+        Mirrors api.art's port self-heal: lets the caller persist the
+        learned port (entry.data) so a misconfigured/changed port doesn't
+        keep failing on every restart.
+        """
+        self._port_callback = func
+
+    def _learn_port(self, port: int) -> None:
+        """Switch to the alternate port and report it via the callback."""
+        self._port = port
+        if self._port_callback is not None:
+            self._port_callback(port)
+
+    async def _rest_request_once(
+        self, target: str, method: str, port: int
+    ) -> dict[str, Any]:
+        """Perform a single async rest request against a specific port."""
+        url = _format_rest_url(self._host, target, port)
+        if method == "POST":
+            req = self._session.post(url, timeout=self._timeout, verify_ssl=False)
+        elif method == "PUT":
+            req = self._session.put(url, timeout=self._timeout, verify_ssl=False)
+        elif method == "DELETE":
+            req = self._session.delete(url, timeout=self._timeout, verify_ssl=False)
+        else:
+            req = self._session.get(url, timeout=self._timeout, verify_ssl=False)
+        async with req as resp:
+            return _process_api_response(await resp.text())
 
     async def _rest_request(self, target: str, method: str = "GET") -> dict[str, Any]:
-        """Perform async rest request."""
-        url = _format_rest_url(self._host, target, self._port)
+        """Perform async rest request.
+
+        Tries the configured port first, then falls back to the other REST
+        port (8001/8002) on a connection failure — some firmwares (e.g.
+        2024+ Frame) only serve the REST API on 8002, while older sets may
+        only answer on 8001. On a successful fallback the working port is
+        learned for subsequent calls and persisted via register_port_callback.
+        """
         try:
-            if method == "POST":
-                req = self._session.post(url, timeout=self._timeout, verify_ssl=False)
-            elif method == "PUT":
-                req = self._session.put(url, timeout=self._timeout, verify_ssl=False)
-            elif method == "DELETE":
-                req = self._session.delete(url, timeout=self._timeout, verify_ssl=False)
-            else:
-                req = self._session.get(url, timeout=self._timeout, verify_ssl=False)
-            async with req as resp:
-                return _process_api_response(await resp.text())
-        except aiohttp.ClientConnectionError as ex:
-            raise HttpApiError(
-                "TV unreachable or feature not supported on this model."
-            ) from ex
+            return await self._rest_request_once(target, method, self._port)
+        except aiohttp.ClientConnectionError:
+            alternate_port = 8001 if self._port == 8002 else 8002
+            try:
+                result = await self._rest_request_once(target, method, alternate_port)
+            except aiohttp.ClientConnectionError as ex:
+                raise HttpApiError(
+                    "TV unreachable or feature not supported on this model."
+                ) from ex
+            self._log.warning(
+                "REST request for %s failed on port %s, succeeded on %s "
+                "-- switching to it",
+                self._host,
+                self._port,
+                alternate_port,
+            )
+            self._learn_port(alternate_port)
+            return result
 
     async def async_rest_device_info(self) -> dict[str, Any]:
         """Get device info using rest api call."""

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -581,7 +581,9 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             host=self._host,
             session=session,
             timeout=DEFAULT_TIMEOUT,
+            port=config.get(CONF_PORT, DEFAULT_PORT),
         )
+        self._rest_api.register_port_callback(self._persist_art_port)
 
         # Frame Art API - use shared instance if available, otherwise create new one
         shared_art_api = entry_data.get(DATA_ART_API) if entry_data else None


### PR DESCRIPTION
## Summary
Fixes a real bug found while investigating issue #40: `SamsungTVAsyncRest` (the REST client used for device-info/power-state reads and app launch/status) **ignored `CONF_PORT` entirely** and always defaulted to 8001, regardless of what the user set under Reconfigure → Connection.

- `media_player.py` now passes the configured port into `SamsungTVAsyncRest`.
- `SamsungTVAsyncRest` gains the same runtime port self-heal already used by the Art channel (#62): on a connection failure it retries the other REST port (8001↔8002), and on success switches to it and persists the working port to `entry.data` via the existing `_persist_art_port` callback (reused — it already writes generically to `CONF_PORT`).

## Context
A user testing 8.1 reported that setting the Connection port to 8001 on an older (2020) Frame broke power-state reads and Art Mode set, while 8002 worked. That TV's REST API only answers on 8002. This fix means a wrong/changed port now heals itself instead of leaving those reads broken until a manual reconfigure.

## Test plan
- [x] `py_compile` / `black --check` / `flake8` clean
- [ ] Manual: deliberately set the wrong REST port on a TV and confirm power-state read recovers and the working port gets persisted

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_