### PR TITLE
Log per-TV warning when polling exceeds the scan interval

### DIFF
--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -1822,6 +1822,21 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
     async def async_update(self):
         """Update state of device."""
+        start_time = time.monotonic()
+        try:
+            await self._async_update()
+        finally:
+            elapsed = time.monotonic() - start_time
+            if elapsed > SCAN_INTERVAL.total_seconds():
+                self._log.warning(
+                    "%s - Update took %.1fs, longer than the %.0fs scan interval",
+                    self.entity_id,
+                    elapsed,
+                    SCAN_INTERVAL.total_seconds(),
+                )
+
+    async def _async_update(self):
+        """Perform the actual state update."""
 
         # Refresh OAuth token if needed (before any SmartThings API call)
         if self._auth_method == AUTH_METHOD_OAUTH:


### PR DESCRIPTION
Fixes #70.

Home Assistant's core "Updating samsungtv_smart media_player took longer than the scheduled update interval" warning only names the platform, not the specific entity — useless to identify the slow TV in a multi-TV setup.

`async_update` now times its own execution and, if it exceeds `SCAN_INTERVAL` (5s), logs a warning tagged with the TV's host via the existing `_DeviceLoggerAdapter`, e.g.:

```
WARNING ... [192.168.x.x] media_player.downstairstv - Update took 6.2s, longer than the 5s scan interval
```

This lets multi-TV users correlate HA's generic core warning with the specific TV that was slow, without needing debug logging enabled.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_