### PR TITLE
IP Control: read-only state sensors + power-off false-positive fix

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -15,6 +15,13 @@
   falls back between **8001 and 8002 at runtime** on a connection failure,
   persisting the working port — the same self-heal already in place for the
   Art channel (8.0.0) now also covers the REST/device-info path.
+- **Read-only state sensors** (`getTVStates` / `getVideoStates`): 12 new
+  diagnostic sensors expose the TV's current input source, picture mode, sound
+  mode, picture size, speaker select, mute and volume, plus the picture levels
+  (contrast, brightness, sharpness, color, tint). They are read-only — these
+  values are not settable over IP Control on consumer Frames — and share a
+  single coordinator (two JSON-RPC calls per poll for all 12). Gated behind IP
+  Control being paired and enabled; paused while the TV is off.
 
 ## Reliability & observability
 

--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -22,6 +22,13 @@
   values are not settable over IP Control on consumer Frames — and share a
   single coordinator (two JSON-RPC calls per poll for all 12). Gated behind IP
   Control being paired and enabled; paused while the TV is off.
+- **Power-off false-positive fix** (Art Mode / Power switches stuck "on"): when
+  IP Control is paired and enabled, a **safe power-only guard** now reads
+  `powerControl` on every refresh — even when the *Enable IP Control Art Mode*
+  option is off (the default). If the TV reports `powerOff`, `art_mode_status`
+  is forced off, overriding a frozen Art-channel WebSocket that kept reporting
+  `art='on'` after the TV was switched off. This never calls the firmware-risky
+  `artModeControl` method, so it is safe regardless of the Art Mode option.
 
 ## Reliability & observability
 

--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -30,6 +30,21 @@
   `art='on'` after the TV was switched off. This never calls the firmware-risky
   `artModeControl` method, so it is safe regardless of the Art Mode option.
 
+## Art Mode status — accuracy fixes
+
+- **Switches now use the authoritative Art Mode logic**: the `art_mode_status`
+  attribute (read by the Power and Frame Art switches) previously re-implemented
+  a reduced version of the detection that **ignored the IP Control cache and
+  the SmartThings power signal** — so a stale Art-channel WebSocket could pin
+  both switches "on" after the TV was powered off. It now delegates to the same
+  single source of truth as the media title and the `is_on` property.
+- **SmartThings cloud power-off fallback** (for TVs without IP Control): when
+  SmartThings reports the TV switched off, `art_mode_status` is forced off. The
+  Frame's `switch` capability reports `on` while displaying art and `off` only
+  when truly powered off, so this safely overrides a frozen art WebSocket.
+  (SmartThings lags ~30-45s, so it is best-effort; IP Control remains the
+  instant, authoritative path.)
+
 ## Reliability & observability
 
 - **Per-TV "slow update" warning**: when a poll cycle takes longer than the

--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -302,6 +302,28 @@ class SamsungIPControl:
             "serialNumber": str(result.get("serialNumber", "")),
         }
 
+    async def async_get_tv_states(self) -> dict[str, Any]:
+        """Return the TV's general state snapshot (read-only).
+
+        ``getTVStates`` reports, on a Frame 2024/2025:
+        ``speakerSelect, volume, mute, pictureSize, pictureMode, soundMode,
+        inputSource``. These are all read-only over IP Control on consumer
+        Frames (the matching setters return ``-32601 "Method not found"``), so
+        this is exposed only as diagnostic sensors. Setting these values must
+        go through SmartThings / the WebSocket.
+        """
+        return await self._async_request("getTVStates")
+
+    async def async_get_video_states(self) -> dict[str, Any]:
+        """Return the TV's picture-level snapshot (read-only).
+
+        ``getVideoStates`` reports ``contrast, sharpness, brightness, color,
+        tint`` on a Frame 2024/2025. As with :meth:`async_get_tv_states`, these
+        are read-only over IP Control on consumer Frames; only ``backlight`` is
+        settable (see :meth:`async_set_backlight`).
+        """
+        return await self._async_request("getVideoStates")
+
     # -- transport -----------------------------------------------------------
 
     async def _async_request(

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -1051,6 +1051,17 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         cache independent of the REST device-info ``PowerState``, which 2024+
         Frame models report as 'standby' WHILE actively displaying art.
 
+        Two operating modes depending on the ``CONF_IP_CONTROL_ART_MODE``
+        option (off by default for firmware safety):
+        - Option ON → full read: powerControl + artModeControl, caching the
+          real art state (True/False).
+        - Option OFF → SAFE power-only guard: only powerControl is read. When
+          it reports 'powerOff' the cache is pinned to ``False`` (the TV is off,
+          so art_mode_status must be off, overriding a frozen art-channel
+          WebSocket that keeps reporting 'on'); when it reports 'powerOn' the
+          cache is cleared to ``None`` so the other sources decide. This never
+          touches the firmware-risky artModeControl method.
+
         Failure handling:
         - No paired client (no token) → cache cleared to ``None``; the
           attribute falls through to the other (existing) sources.
@@ -1063,34 +1074,50 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
           so a TV that stays unreachable cannot pin a stale value forever.
         """
         client = self._get_ip_control_client()
-        if client is None or not self._get_option(CONF_IP_CONTROL_ART_MODE, False):
-            if client is None:
-                # Disambiguate the two reasons the client is unavailable so the
-                # cause is obvious in the logs (unpaired vs. disabled in options).
-                entry = self.hass.config_entries.async_get_entry(self._entry_id)
-                has_token = bool(entry and entry.data.get(CONF_IP_CONTROL_TOKEN))
-                if not has_token:
-                    reason = "not paired (no CONF_IP_CONTROL_TOKEN in entry.data)"
-                else:
-                    reason = "IP Control disabled in options (CONF_ENABLE_IP_CONTROL)"
-                self._log.debug(
-                    "IP Control art-mode refresh for %s: %s — skipping",
-                    self._host,
-                    reason,
-                )
+        if client is None:
+            # Un-paired, or the IP Control channel was disabled in options.
+            # Disambiguate the two reasons in the logs, drop any cached value
+            # and fall through to the other art-mode sources.
+            entry = self.hass.config_entries.async_get_entry(self._entry_id)
+            has_token = bool(entry and entry.data.get(CONF_IP_CONTROL_TOKEN))
+            if not has_token:
+                reason = "not paired (no CONF_IP_CONTROL_TOKEN in entry.data)"
+            else:
+                reason = "IP Control disabled in options (CONF_ENABLE_IP_CONTROL)"
+            self._log.debug(
+                "IP Control art-mode refresh for %s: %s — skipping",
+                self._host,
+                reason,
+            )
             self._ip_art_mode_failures = 0
             if self._ip_art_mode is not None:
                 self._ip_art_mode = None
                 self.async_write_ha_state()
             return
+        # Whether the user opted into the (firmware-risky) Art Mode reads via
+        # artModeControl. Even when this is OFF we still run a SAFE power-only
+        # guard below: powerControl is a harmless getter (the same one already
+        # used for the Power switch), so reading it lets us force art_mode off
+        # whenever the TV is genuinely powered off — without ever touching
+        # artModeControl. This fixes the stale-WebSocket false positive where a
+        # frozen art channel keeps reporting art='on' after the TV is off
+        # (observed on the default config, where CONF_IP_CONTROL_ART_MODE is
+        # off and nothing independently verified the WebSocket signal).
+        art_mode_enabled = self._get_option(CONF_IP_CONTROL_ART_MODE, False)
         try:
             power = await client.async_get_power_state()
             if power == "powerOff":
                 # TV is really off — art cannot be displayed. Don't query
                 # artModeControl: it would answer with the last mode.
                 value = False
-            else:
+            elif art_mode_enabled:
                 value = await client.async_get_art_mode()
+            else:
+                # Power-only guard: TV is on but the user hasn't enabled the
+                # art-mode reads, so we can't safely tell art from a real
+                # input. Defer to the other (WebSocket / SmartThings) sources
+                # by clearing the cache rather than pinning a value.
+                value = None
         except SamsungIPControlAuthError as ex:
             self._log.warning(
                 "IP Control art-mode read for %s: token rejected (%s) — "

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -2225,6 +2225,16 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             return self._ip_art_mode
         if self._get_device_spec("PowerState") == "standby":
             return False
+        # Cloud power-off fallback for TVs without IP Control. SmartThings
+        # reports the switch capability as 'on' while the Frame is in Art Mode
+        # and 'off' only when it is truly powered off, so STATE_OFF means the
+        # panel is off and a stale art-channel WebSocket (which can latch 'on'
+        # after a cloud/remote power-off it never witnessed) must not be
+        # trusted. Trade-off: SmartThings lags ~30-45s, so powering straight on
+        # into Art Mode may briefly read 'off' until the cloud catches up — far
+        # better than a permanently stuck 'on'.
+        if self._st is not None and self._st.state == STStatus.STATE_OFF:
+            return False
         art_api = (
             self.hass.data.get(DOMAIN, {}).get(self._entry_id, {}).get(DATA_ART_API)
         )
@@ -2243,58 +2253,19 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         """Return the optional state attributes."""
         data = {ATTR_IP_ADDRESS: self._host}
 
-        # Determine Art Mode status for state attributes.
-        #
-        # Priority order:
-        #  1. IP Control cache (Phase 2) — authoritative combined read
-        #     (powerControl + artModeControl) refreshed every
-        #     IP_ART_MODE_REFRESH_INTERVAL when the user has paired this TV
-        #     via the options flow. It MUST win over the device-info
-        #     PowerState check below: 2024+ Frame models (e.g. QE55LS03DA)
-        #     report PowerState='standby' over REST WHILE actively displaying
-        #     art, so trusting 'standby' first forces art_mode_status to
-        #     'off' whenever Art Mode is on. The cache is safe against the
-        #     opposite mistake because _refresh_ip_art_mode reads the IP
-        #     Control power state first and stores False when the TV reports
-        #     'powerOff'.
-        #  2. device_info PowerState='standby' (Phase 1) — for unpaired TVs,
-        #     definitive when the device-info REST poll reports the TV as
-        #     fully off.
-        #  3. async Art API (art.py) — preferred when active. Once
-        #     disable_art_thread() is called, _ws.artmode_status is frozen at
-        #     its last value and is no longer updated when Art Mode changes.
-        #     art_api.art_mode is kept live by WebSocket events
-        #     (artmode_status, art_mode_changed) received on the async art
-        #     channel.
-        #  4. _ws.artmode_status — fallback for the period before art_api has
-        #     received its first event (e.g. right after HA startup).
-        #
-        # IMPORTANT: art_api.art_mode goes STALE when the TV powers off — the
-        # art WebSocket disconnects and stops delivering events, so the cached
-        # value keeps reporting whatever was true just before power-off (often
-        # "on", because Art Mode is the last state of a Frame TV before
-        # standby). That stale "on" then leaks via art_mode_status into the
-        # Power switch and the Frame Art Mode switch (both treat
-        # media_player.state="off" + art_mode_status="on" as "TV physically on
-        # in Art Mode"), and both end up wrongly showing ON after a power-off.
-        # device_info's PowerState is polled every ~15s and reliably reports
-        # "standby" when the TV is truly off — use it as an authoritative
-        # override.
-        art_api = (
-            self.hass.data.get(DOMAIN, {}).get(self._entry_id, {}).get(DATA_ART_API)
-        )
-        device_power_state = self._get_device_spec("PowerState")
-        if device_power_state == "standby":
-            # TV is powered off — art mode cannot be active regardless of
-            # what art_api may have cached.
-            data[ATTR_ART_MODE_STATUS] = STATE_OFF
-        elif art_api is not None and art_api.art_mode is not None:
-            data.update(
-                {ATTR_ART_MODE_STATUS: STATE_ON if art_api.art_mode else STATE_OFF}
-            )
-        elif self._ws.artmode_status != ArtModeStatus.Unsupported:
-            status_on = self._ws.artmode_status == ArtModeStatus.On
-            data.update({ATTR_ART_MODE_STATUS: STATE_ON if status_on else STATE_OFF})
+        # Art Mode status: delegate to _art_mode_is_on(), the single source of
+        # truth (it layers IP Control cache → REST PowerState='standby' →
+        # SmartThings switch=off → async Art API → WS artmode_status →
+        # SmartThings-reports-art, with the running-app guard on top). This MUST
+        # be the same logic the media title and the is_on property use, so the
+        # Power / Frame Art switches that mirror this attribute stay consistent
+        # with everything else. Previously this block re-implemented a subset
+        # that ignored the IP Control cache and the SmartThings power signal,
+        # which let a stale art WebSocket pin the switches "on" after the TV was
+        # powered off.
+        art_status = self._art_mode_is_on()
+        if art_status is not None:
+            data[ATTR_ART_MODE_STATUS] = STATE_ON if art_status else STATE_OFF
         if self._st:
             picture_mode = self._st.picture_mode
             picture_mode_list = self._st.picture_mode_list

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
 import time
@@ -13,6 +14,7 @@ from pysmartthings import Attribute, Capability
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
+    SensorEntityDescription,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -23,6 +25,7 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_TOKEN,
     LIGHT_LUX,
+    EntityCategory,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -36,9 +39,16 @@ from homeassistant.helpers.update_coordinator import (
 
 from . import async_get_samsungtv_api_key
 from .api.art import SamsungTVAsyncArt, _DeviceLoggerAdapter
+from .api.ipcontrol import (
+    SamsungIPControl,
+    SamsungIPControlAuthError,
+    SamsungIPControlError,
+)
 from .const import (
     CONF_API_KEY,
     CONF_DEVICE_ID,
+    CONF_ENABLE_IP_CONTROL,
+    CONF_IP_CONTROL_TOKEN,
     CONF_IS_FRAME_TV,
     CONF_OAUTH_TOKEN,
     CONF_SLIDESHOW_API,
@@ -49,8 +59,131 @@ from .const import (
     DOMAIN,
     WS_PREFIX,
 )
+from .token_notify import METHOD_IP_CONTROL, clear_token_problem, notify_token_problem
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _ip_control_active(entry: ConfigEntry) -> bool:
+    """True when IP Control is paired AND enabled in the options."""
+    return bool(entry.data.get(CONF_IP_CONTROL_TOKEN)) and entry.options.get(
+        CONF_ENABLE_IP_CONTROL, True
+    )
+
+
+# Update interval for the read-only IP Control state sensors. Picture/sound
+# settings change slowly, so a relaxed cadence keeps JSON-RPC traffic light.
+IP_CONTROL_STATE_SCAN_INTERVAL = timedelta(seconds=30)
+
+
+@dataclass(frozen=True, kw_only=True)
+class SamsungIPControlSensorDescription(SensorEntityDescription):
+    """Describes an IP Control read-only state sensor.
+
+    ``source`` selects which JSON-RPC snapshot the value is read from:
+    ``"tv"`` for ``getTVStates`` or ``"video"`` for ``getVideoStates``.
+    """
+
+    source: str = "tv"
+
+
+# getTVStates / getVideoStates are READ-ONLY on consumer Frame TVs (the matching
+# setters return -32601 "Method not found"), so these are diagnostic sensors
+# only — setting these values must go through SmartThings / the WebSocket.
+IP_CONTROL_STATE_SENSORS: tuple[SamsungIPControlSensorDescription, ...] = (
+    # getTVStates
+    SamsungIPControlSensorDescription(
+        key="inputSource",
+        source="tv",
+        name="Input Source",
+        icon="mdi:import",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SamsungIPControlSensorDescription(
+        key="pictureMode",
+        source="tv",
+        name="Picture Mode",
+        icon="mdi:image-multiple-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SamsungIPControlSensorDescription(
+        key="soundMode",
+        source="tv",
+        name="Sound Mode",
+        icon="mdi:music-note",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SamsungIPControlSensorDescription(
+        key="pictureSize",
+        source="tv",
+        name="Picture Size",
+        icon="mdi:aspect-ratio",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SamsungIPControlSensorDescription(
+        key="speakerSelect",
+        source="tv",
+        name="Speaker Select",
+        icon="mdi:speaker",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SamsungIPControlSensorDescription(
+        key="mute",
+        source="tv",
+        name="Mute",
+        icon="mdi:volume-mute",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SamsungIPControlSensorDescription(
+        key="volume",
+        source="tv",
+        name="Volume",
+        icon="mdi:volume-high",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # getVideoStates
+    SamsungIPControlSensorDescription(
+        key="contrast",
+        source="video",
+        name="Contrast",
+        icon="mdi:contrast-box",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SamsungIPControlSensorDescription(
+        key="brightness",
+        source="video",
+        name="Brightness",
+        icon="mdi:brightness-6",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SamsungIPControlSensorDescription(
+        key="sharpness",
+        source="video",
+        name="Sharpness",
+        icon="mdi:blur",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SamsungIPControlSensorDescription(
+        key="color",
+        source="video",
+        name="Color",
+        icon="mdi:palette",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SamsungIPControlSensorDescription(
+        key="tint",
+        source="video",
+        name="Tint",
+        icon="mdi:invert-colors",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
 
 # Update interval for the Frame Art sensor (reduced for faster manual updates)
 SCAN_INTERVAL = timedelta(seconds=15)
@@ -308,6 +441,27 @@ async def async_setup_entry(
                 )
         except Exception as ex:
             _LOGGER.warning("Could not setup SmartThings sensors: %s", ex)
+
+    # Read-only IP Control state sensors (getTVStates / getVideoStates).
+    # Gated behind IP Control being paired AND enabled, sharing a single
+    # coordinator so each poll issues just two JSON-RPC calls for all 12.
+    if _ip_control_active(entry):
+        state_coordinator = IPControlStateCoordinator(hass, entry, host)
+        entities.extend(
+            IPControlStateSensor(
+                state_coordinator, entry, description, device_name, device_unique_id
+            )
+            for description in IP_CONTROL_STATE_SENSORS
+        )
+        hass.async_create_background_task(
+            state_coordinator.async_request_refresh(),
+            f"ip_control_state_initial_refresh_{entry.entry_id}",
+        )
+        _LOGGER.debug(
+            "IP Control state sensors created for %s (%d entities)",
+            device_name,
+            len(IP_CONTROL_STATE_SENSORS),
+        )
 
     if entities:
         async_add_entities(entities)
@@ -1742,3 +1896,121 @@ class SmartThingsBrightnessIntensitySensor(SensorEntity):
                 )
         except Exception as ex:
             _LOGGER.warning("Error updating brightness intensity sensor: %s", ex)
+
+
+class IPControlStateCoordinator(DataUpdateCoordinator):
+    """Polls getTVStates + getVideoStates over IP Control for the state sensors.
+
+    A single coordinator feeds all 12 read-only sensors, so each cycle issues
+    only two JSON-RPC calls (plus a cheap power-state check) regardless of how
+    many sensors are enabled. The TV is skipped while it is powered off, both
+    to avoid pointless traffic and because the picture-state getters return
+    stale values in standby.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        host: str,
+    ) -> None:
+        """Initialize the IP Control state coordinator."""
+        self._log = _DeviceLoggerAdapter(_LOGGER, {"host": host})
+        super().__init__(
+            hass,
+            self._log,
+            name=f"IP Control state {entry.title}",
+            update_interval=IP_CONTROL_STATE_SCAN_INTERVAL,
+        )
+        self._entry = entry
+        self._host = host
+        self._ip_control: SamsungIPControl | None = None
+        self._ip_control_token: str | None = None
+
+    def _device_title(self) -> str:
+        entry = self.hass.config_entries.async_get_entry(self._entry.entry_id)
+        return entry.title if entry else (self._host or "this Samsung TV")
+
+    def _get_ip_control(self) -> SamsungIPControl | None:
+        """Return a live IP Control client if paired AND enabled."""
+        entry = self.hass.config_entries.async_get_entry(self._entry.entry_id)
+        if entry is None or not _ip_control_active(entry):
+            self._ip_control = None
+            self._ip_control_token = None
+            return None
+        token = entry.data.get(CONF_IP_CONTROL_TOKEN)
+        if self._ip_control is None or self._ip_control_token != token:
+            self._ip_control = SamsungIPControl(self.hass, self._host, token=token)
+            self._ip_control_token = token
+        return self._ip_control
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch the TV and video state snapshots over IP Control."""
+        client = self._get_ip_control()
+        if client is None:
+            raise UpdateFailed("IP Control is not paired or is disabled")
+
+        try:
+            # Skip the snapshots while the TV is off: the getters would return
+            # stale values, and this avoids needless traffic to a sleeping TV.
+            if await client.async_get_power_state() == "powerOff":
+                raise UpdateFailed("TV is powered off")
+
+            tv_states = await client.async_get_tv_states()
+            video_states = await client.async_get_video_states()
+        except SamsungIPControlAuthError as ex:
+            notify_token_problem(
+                self.hass,
+                self._entry.entry_id,
+                METHOD_IP_CONTROL,
+                self._device_title(),
+            )
+            raise UpdateFailed(f"IP Control token rejected: {ex}") from ex
+        except SamsungIPControlError as ex:
+            raise UpdateFailed(f"IP Control state read failed: {ex}") from ex
+
+        clear_token_problem(self.hass, self._entry.entry_id, METHOD_IP_CONTROL)
+        return {"tv": tv_states, "video": video_states}
+
+
+class IPControlStateSensor(CoordinatorEntity, SensorEntity):
+    """Read-only sensor for one getTVStates / getVideoStates field."""
+
+    entity_description: SamsungIPControlSensorDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: IPControlStateCoordinator,
+        entry: ConfigEntry,
+        description: SamsungIPControlSensorDescription,
+        device_name: str,
+        device_unique_id: str,
+    ) -> None:
+        """Initialize the IP Control state sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._entry_id = entry.entry_id
+        self._device_name = device_name
+        self._device_unique_id = device_unique_id
+        self._attr_unique_id = f"{device_unique_id}_ip_control_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_unique_id)},
+            name=device_name,
+        )
+
+    @property
+    def native_value(self) -> Any | None:
+        """Return the value for this field from the coordinator snapshot."""
+        if not self.coordinator.data:
+            return None
+        snapshot = self.coordinator.data.get(self.entity_description.source, {})
+        return snapshot.get(self.entity_description.key)
+
+    @property
+    def available(self) -> bool:
+        """Available only while IP Control is active and the last poll worked."""
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        return bool(
+            entry and _ip_control_active(entry) and self.coordinator.last_update_success
+        )


### PR DESCRIPTION
## Summary

Two IP Control improvements for 8.1.0, both gated behind IP Control being paired and enabled.

### 1. 12 read-only diagnostic state sensors (`getTVStates` / `getVideoStates`)
- Exposes the TV's current **input source, picture mode, sound mode, picture size, speaker select, mute, volume** (from `getTVStates`) and the picture levels **contrast, brightness, sharpness, color, tint** (from `getVideoStates`).
- Read-only — these values are not settable over IP Control on consumer Frames.
- All 12 entities share a single coordinator (two JSON-RPC calls per 30s poll); polling is paused while the TV is off.
- Adds `async_get_tv_states()` / `async_get_video_states()` to the IP Control client.

### 2. Power-off false-positive fix (Art Mode / Power switches stuck "on")
Decouples a **safe power-only guard** from the firmware-risky *Enable IP Control Art Mode* option.

- **Root cause:** when `CONF_IP_CONTROL_ART_MODE` is off (the default), `_refresh_ip_art_mode` exited immediately — nothing independently verified the Art-channel WebSocket. A frozen WebSocket kept reporting `art='on'` after the TV was switched off, leaving both the Power and Art Mode switches stuck ON.
- **Fix:** when IP Control is paired and enabled, `powerControl` (a harmless getter, already used by the Power switch) is now read on every refresh even with the Art Mode option off. If the TV reports `powerOff`, `art_mode_status` is forced off.
- **Safety:** the risky `artModeControl` method is **never** called by this path, so the fix is safe regardless of the Art Mode option.

#### Empirical validation (TV `.161`)
`powerControl` reliably distinguishes both states, even in black-screen standby:

| TV state | `powerControl` |
|---|---|
| On (SmartHub) | `powerOn` |
| Off (black screen) | `powerOff` |

(Confirmed that `getTVStates.pictureMode` is **not** usable for power detection — it returns `"Ambient"` even when the TV is truly off — which is why `powerControl` must be the deciding signal.)

Related to issue #72.

## Notes
- `RELEASE_NOTES_8.1.0.md` updated for both changes.
- `py_compile`, `black` and `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_