### PR TITLE
Art channel WebSocket: zombie-socket recovery (heartbeat + stale art_mode invalidation)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -45,6 +45,22 @@
   (SmartThings lags ~30-45s, so it is best-effort; IP Control remains the
   instant, authoritative path.)
 
+## Art channel WebSocket — zombie-socket recovery
+
+- **Heartbeat / dead-connection detection**: the Art-channel WebSocket now opens
+  with an aiohttp `heartbeat` (20s). aiohttp sends periodic PINGs and tears the
+  socket down when no PONG comes back, so a "zombie" connection — one the TV
+  dropped without a clean TCP close (e.g. an abrupt power-off) — is now detected
+  and recycled automatically instead of staying half-open forever. Previously
+  such a socket only reconnected on the next user-triggered art request.
+- **Stale `art_mode` invalidation on disconnect**: when the receive loop exits
+  unexpectedly, the cached `art_mode` is reset to `None` (instead of keeping its
+  last, usually `"on"`, value). `art_mode_status` then falls through to the
+  independent power sources (IP Control / SmartThings / REST PowerState) while
+  the channel is down, and the real value is restored from the first event after
+  reconnect. This is the root-cause fix behind the power-off false positive the
+  power-only guards already mitigate.
+
 ## Reliability & observability
 
 - **Per-TV "slow update" warning**: when a poll cycle takes longer than the

--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -44,6 +44,14 @@ D2D_SERVICE_MESSAGE_EVENT = "d2d_service_message"
 MS_CHANNEL_CONNECT_EVENT = "ms.channel.connect"
 MS_CHANNEL_READY_EVENT = "ms.channel.ready"
 
+# aiohttp WebSocket heartbeat (seconds): aiohttp sends a PING this often and,
+# if no PONG comes back in time, raises ServerTimeoutError on the receive loop.
+# That is what kills a "zombie" socket — one the TV dropped without a TCP FIN
+# (e.g. an abrupt power-off) so it still looks open but delivers nothing and
+# would otherwise never reconnect. Kept above the 15s art coordinator poll so a
+# genuinely live-but-quiet channel is not torn down unnecessarily.
+ART_WS_HEARTBEAT = 20
+
 
 def _get_ssl_context() -> ssl.SSLContext:
     """Get SSL context for secure connections without blocking calls."""
@@ -382,6 +390,7 @@ class SamsungTVAsyncArt:
                 self._ws_url,
                 timeout=aiohttp.ClientTimeout(total=self._timeout),
                 ssl=ssl_context,
+                heartbeat=ART_WS_HEARTBEAT,
             )
 
             # Wait for connection events
@@ -524,12 +533,22 @@ class SamsungTVAsyncArt:
         finally:
             if not cancelled:
                 # Receive loop is exiting on its own (TV standby, network
-                # drop, transport closed) and nobody else will clean up.
-                # Drop stale references so the next _send_art_request
-                # triggers a fresh open().
+                # drop, transport closed, or a missed heartbeat PONG on a
+                # zombie socket) and nobody else will clean up. Drop stale
+                # references so the next _send_art_request triggers a fresh
+                # open().
                 self._connected = False
                 self._ws = None
                 self._recv_task = None
+                # Invalidate the cached art_mode: the channel that keeps it
+                # live is gone, so the last value (typically "on", since Art
+                # Mode is a Frame's last state before power-off) is now stale
+                # and must not keep being reported. Resetting to None makes
+                # _art_mode_is_on() fall through to the independent power
+                # sources (IP Control / SmartThings / REST PowerState) instead
+                # of pinning a false "on". A reconnect restores the real value
+                # from the first event received.
+                self.art_mode = None
                 # Fail in-flight pending requests immediately rather than
                 # letting their callers block on the per-request timeout;
                 # the response will never arrive on this dead channel.

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b7"
+  "version": "8.1.0b8"
 }


### PR DESCRIPTION
## Summary

Root-cause fix for the "TV powered off but Art Mode / Power switches stay on" bug. The power-only guards (PR #73) mitigate the *symptom*; this fixes the *cause*: the Art-channel WebSocket going "zombie".

### The zombie socket
When a Frame TV is powered off — especially via SmartThings/the cloud or the media_player card, which bypass the WebSocket — the Art channel often never receives the final transition event and the TV may drop the connection without a clean TCP close. The socket then looks open but delivers nothing, and:
- aiohttp had **no heartbeat**, so the dead connection was never detected;
- reconnection was **lazy** (only on the next user-triggered art request);
- the art coordinator reads `art_mode` from the media_player cache, so it never makes a real API call that would reconnect.

Result: the cached `art_mode` stayed frozen at `"on"` indefinitely.

### Fix
1. **Heartbeat (20s)** on `ws_connect`: aiohttp sends periodic PINGs and tears the socket down on a missed PONG, so a zombie connection is detected and recycled automatically. (Kept above the 15s art coordinator poll so a live-but-quiet channel isn't torn down needlessly.)
2. **Invalidate cached `art_mode` on unexpected disconnect**: the receive-loop `finally` now resets `art_mode` to `None`. `art_mode_status` then falls through to the independent power sources (IP Control / SmartThings / REST PowerState) while the channel is down, and the real value is restored from the first event after reconnect.

## Notes
- Version bumped to **8.1.0b8**.
- `RELEASE_NOTES_8.1.0.md` updated.
- `py_compile`, `black`, `flake8` clean; manifest validates.
- Related to #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_