### PR TITLE
Mute/volume via IP Control + unauthorized-reconnect-loop fix (8.1.0b9)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -52,6 +52,18 @@
   (SmartThings lags ~30-45s, so it is best-effort; IP Control remains the
   instant, authoritative path.)
 
+## Legacy remote WebSocket — unauthorized reconnect loop fix
+
+- **`ms.channel.unauthorized` now trips the auth-blocked guard**: the legacy
+  remote-control WebSocket already paused reconnection after 5 consecutive
+  rejected tokens (`ms.channel.connect` with a changed token, or `ms.error`
+  "No Authorized") to avoid hammering the TV and re-arming the on-screen
+  pairing prompt forever. The bare `ms.channel.unauthorized` event some
+  firmwares send instead was never handled, so on those TVs the reconnect
+  loop ran unthrottled (observed once a second, indefinitely) and every
+  remote command sent over that channel failed silently. It now feeds the
+  same guard as the other two rejection paths.
+
 ## Art channel WebSocket — zombie-socket recovery
 
 - **Heartbeat / dead-connection detection**: the Art-channel WebSocket now opens

--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -22,6 +22,13 @@
   values are not settable over IP Control on consumer Frames — and share a
   single coordinator (two JSON-RPC calls per poll for all 12). Gated behind IP
   Control being paired and enabled; paused while the TV is off.
+- **Mute and relative volume via IP Control**: `async_mute_volume`,
+  `async_volume_up` and `async_volume_down` now try IP Control's
+  `muteControl` / `volumeUpDnControl` first (when paired and enabled) and
+  fall back to the WebSocket `KEY_MUTE`/`KEY_VOLUP`/`KEY_VOLDOWN` remote keys
+  on any IP Control error. `volumeUpDnControl` is relative-only on Frame
+  2024/2025 (no absolute level over IP Control — `directVolumeControl` is not
+  implemented on consumer Frames), matching the WS keys it replaces.
 - **Power-off false-positive fix** (Art Mode / Power switches stuck "on"): when
   IP Control is paired and enabled, a **safe power-only guard** now reads
   `powerControl` on every refresh — even when the *Enable IP Control Art Mode*

--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -288,6 +288,43 @@ class SamsungIPControl:
             raise SamsungIPControlError(f"unexpected colorTone response: {result!r}")
         return response_value
 
+    async def async_get_mute(self) -> bool:
+        """Return whether the TV is currently muted."""
+        result = await self._async_request("muteControl")
+        value = result.get("mute")
+        if value not in ("muteOn", "muteOff"):
+            raise SamsungIPControlError(f"unexpected mute response: {result!r}")
+        return value == "muteOn"
+
+    async def async_set_mute(self, mute: bool) -> bool:
+        """Set and return whether the TV is muted.
+
+        ``muteControl`` is the only mute setter that works via IP Control on
+        a Frame 2024/2025 — the matching field in ``getTVStates`` is
+        read-only.
+        """
+        target = "muteOn" if mute else "muteOff"
+        result = await self._async_request("muteControl", {"mute": target})
+        value = result.get("mute", target)
+        if value not in ("muteOn", "muteOff"):
+            raise SamsungIPControlError(f"unexpected mute response: {result!r}")
+        return value == "muteOn"
+
+    async def async_volume_up(self) -> None:
+        """Step the volume up by one (relative — no absolute level over IP Control).
+
+        ``volumeUpDnControl`` is the only volume setter that works via IP
+        Control on a Frame 2024/2025 — ``directVolumeControl`` (absolute
+        volume) returns ``-32601 "Method not found"``. There is no getter:
+        the call is fire-and-forget, matching the WebSocket ``KEY_VOLUP``
+        semantics it replaces.
+        """
+        await self._async_request("volumeUpDnControl", {"control": "volumeUp"})
+
+    async def async_volume_down(self) -> None:
+        """Step the volume down by one. See :meth:`async_volume_up`."""
+        await self._async_request("volumeUpDnControl", {"control": "volumeDn"})
+
     async def async_get_device_information(self) -> dict[str, str]:
         """Return the TV's model, firmware version and serial number."""
         result = await self._async_request("getDeviceInformation")

--- a/custom_components/samsungtv_smart/api/samsungws.py
+++ b/custom_components/samsungtv_smart/api/samsungws.py
@@ -451,6 +451,30 @@ class SamsungTVWS:
         """Register callback function used on status change."""
         self._status_callback = func
 
+    def _bump_auth_failure(self, reason: str) -> None:
+        """Count one more rejected-connection event and trip the auth guard.
+
+        Shared by every code path that signals a rejected token (new-token
+        issuance on ``ms.channel.connect``, ``ms.error`` "No Authorized", and
+        the bare ``ms.channel.unauthorized`` event) so they all feed the same
+        ``MAX_CONSECUTIVE_NEW_TOKENS`` threshold instead of each needing its
+        own counter.
+        """
+        self._consecutive_new_tokens += 1
+        if (
+            not self._auth_blocked
+            and self._consecutive_new_tokens >= MAX_CONSECUTIVE_NEW_TOKENS
+        ):
+            self._auth_blocked = True
+            self._log.warning(
+                "TV %s repeatedly rejected the connection (%s) — pausing "
+                "remote reconnection; re-pair required",
+                self.host,
+                reason,
+            )
+            if self._auth_error_callback is not None:
+                self._auth_error_callback()
+
     def unregister_status_callback(self):
         """Unregister callback function used on status change."""
         self._status_callback = None
@@ -676,20 +700,7 @@ class SamsungTVWS:
             if token:
                 self._set_token(token)
             if token_changed:
-                self._consecutive_new_tokens += 1
-                if (
-                    not self._auth_blocked
-                    and self._consecutive_new_tokens >= MAX_CONSECUTIVE_NEW_TOKENS
-                ):
-                    self._auth_blocked = True
-                    self._log.warning(
-                        "TV %s issued %d new tokens in a row — pausing remote "
-                        "reconnection to stop re-prompting; re-pair required",
-                        self.host,
-                        self._consecutive_new_tokens,
-                    )
-                    if self._auth_error_callback is not None:
-                        self._auth_error_callback()
+                self._bump_auth_failure("new token issued")
             else:
                 # Connected with no token, or the same token we already had =>
                 # the stored token was accepted. Always signal recovery
@@ -709,19 +720,14 @@ class SamsungTVWS:
             self._log.debug("Message remote: error %s", data)
             if "authoriz" in str(data.get("message", "")).lower():
                 # "No Authorized": the TV refused this connection's token.
-                self._consecutive_new_tokens += 1
-                if (
-                    not self._auth_blocked
-                    and self._consecutive_new_tokens >= MAX_CONSECUTIVE_NEW_TOKENS
-                ):
-                    self._auth_blocked = True
-                    self._log.warning(
-                        "TV %s repeatedly returned 'No Authorized' — pausing "
-                        "remote reconnection; re-pair required",
-                        self.host,
-                    )
-                    if self._auth_error_callback is not None:
-                        self._auth_error_callback()
+                self._bump_auth_failure("'No Authorized' (ms.error)")
+        elif event == "ms.channel.unauthorized":
+            # Some firmwares reject the connection with this bare event
+            # instead of ms.channel.connect (new token) or ms.error
+            # ("No Authorized") — neither of which fires on this path, so
+            # without this branch the reconnect loop hammered the TV every
+            # ~1s forever instead of ever tripping the auth-blocked guard.
+            self._bump_auth_failure("ms.channel.unauthorized")
         elif event == "ed.installedApp.get":
             self._log.debug("Message remote: received installedApp")
             self._handle_installed_app(response)

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b8"
+  "version": "8.1.0b9"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -2555,7 +2555,8 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         """Volume up the media player."""
         if self._state != MediaPlayerState.ON:
             return
-        await self.async_send_command("KEY_VOLUP")
+        if not await self._async_ip_control_volume_step(up=True):
+            await self.async_send_command("KEY_VOLUP")
         if self.volume_level is not None:
             self._attr_volume_level = min(1.0, self.volume_level + 0.01)
 
@@ -2563,9 +2564,34 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         """Volume down media player."""
         if self._state != MediaPlayerState.ON:
             return
-        await self.async_send_command("KEY_VOLDOWN")
+        if not await self._async_ip_control_volume_step(up=False):
+            await self.async_send_command("KEY_VOLDOWN")
         if self.volume_level is not None:
             self._attr_volume_level = max(0.0, self.volume_level - 0.01)
+
+    async def _async_ip_control_volume_step(self, *, up: bool) -> bool:
+        """Step volume via IP Control's ``volumeUpDnControl``, if paired.
+
+        Returns ``True`` on success so the caller skips the WebSocket
+        ``KEY_VOLUP``/``KEY_VOLDOWN`` fallback. ``volumeUpDnControl`` is
+        relative-only (no absolute level over IP Control on Frame 2024/2025),
+        matching the WS keys it replaces.
+        """
+        client = self._get_ip_control_client()
+        if client is None:
+            return False
+        try:
+            if up:
+                await client.async_volume_up()
+            else:
+                await client.async_volume_down()
+            return True
+        except SamsungIPControlError as ex:
+            self._log.debug(
+                "IP Control volume step failed (%s); falling back to WebSocket",
+                ex,
+            )
+            return False
 
     async def async_mute_volume(self, mute):
         """Send mute command."""
@@ -2573,7 +2599,18 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             return
         if self.is_volume_muted is not None and mute == self.is_volume_muted:
             return
-        await self.async_send_command("KEY_MUTE")
+        client = self._get_ip_control_client()
+        sent_via_ip_control = False
+        if client is not None:
+            try:
+                await client.async_set_mute(mute)
+                sent_via_ip_control = True
+            except SamsungIPControlError as ex:
+                self._log.debug(
+                    "IP Control mute failed (%s); falling back to WebSocket", ex
+                )
+        if not sent_via_ip_control:
+            await self.async_send_command("KEY_MUTE")
         if self.is_volume_muted is not None:
             self._attr_is_volume_muted = mute
 


### PR DESCRIPTION
## Summary
- Add `async_get_mute`/`async_set_mute`/`async_volume_up`/`async_volume_down` to `SamsungIPControl` (`muteControl` / `volumeUpDnControl` JSON-RPC methods, confirmed on Frame 2024/2025 per `IP_Control_Protocol_Reference.md`).
- Wire them into `media_player.py`'s `async_mute_volume`, `async_volume_up`, `async_volume_down`: try IP Control first (when paired and enabled), fall back to the existing WebSocket `KEY_MUTE`/`KEY_VOLUP`/`KEY_VOLDOWN` remote keys on any `SamsungIPControlError` — same fallback pattern already used for power/art-mode.
- `volumeUpDnControl` is relative-only on Frame 2024/2025 (`directVolumeControl`, absolute volume, is not implemented on consumer Frames), matching the semantics of the WS keys it replaces.
- **Fix an unrelated bug found while triaging a b8 tester log (issue #72)**: the legacy remote-control WebSocket already paused reconnection after 5 consecutive rejected tokens (covering `ms.channel.connect` with a changed token, and `ms.error` "No Authorized"), to avoid hammering the TV and re-arming the on-screen pairing prompt forever. Some firmwares instead send a bare `{"event": "ms.channel.unauthorized"}`, which fell through unhandled — so on those TVs the reconnect loop ran roughly once a second, indefinitely, with every remote command failing silently. It now feeds the same guard (factored into a shared `_bump_auth_failure()` helper).
- Bump version to `8.1.0b9`, update `RELEASE_NOTES_8.1.0.md`.

## Test plan
- [x] `py_compile`, `black --check`, `flake8` clean on the touched files.
- [ ] Manual verification on a live TV: mute toggle and volume up/down both via IP Control (paired) and via the WS fallback (unpaired / IP Control disabled).
- [ ] Confirm with the issue #72 reporter that the `ms.channel.unauthorized` loop no longer recurs on their 2020/2021 (non-Frame-pairing-flow) sets.
