### PR TITLE
Dismiss stale auth-token notifications on entry setup/reload (8.1.0b10)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -52,6 +52,20 @@
   (SmartThings lags ~30-45s, so it is best-effort; IP Control remains the
   instant, authoritative path.)
 
+## Stale "connection not authorized" notification fix
+
+- **Notifications are now dismissed on setup/reload**: the "Samsung TV — local
+  connection not authorized" and IP Control token-problem persistent
+  notifications were previously cleared *only* by a clean WebSocket
+  reconnect (or a successful IP Control call). If the TV stayed offline or
+  unreachable after the guard tripped, neither re-pairing nor a Home
+  Assistant restart could ever produce that one clean event, so the
+  notification stayed stuck forever even after the underlying problem was
+  fixed. Both notifications are now also proactively dismissed every time
+  the config entry is set up (covers HA restart, integration reload, and
+  Reconfigure → Authentication/IP Control, which all reload the entry) —
+  they are safely re-created if the rejection genuinely still occurs.
+
 ## Legacy remote WebSocket — unauthorized reconnect loop fix
 
 - **`ms.channel.unauthorized` now trips the auth-blocked guard**: the legacy

--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -92,6 +92,7 @@ from .const import (
     __min_ha_version__,
 )
 from .logo import CUSTOM_IMAGE_BASE_URL, STATIC_IMAGE_BASE_URL
+from .token_notify import METHOD_IP_CONTROL, METHOD_LOCAL, clear_token_problem
 
 # workaroud for failing import native domain when custom integration is present
 try:
@@ -1011,6 +1012,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # migrate options to new format if required
     _migrate_options_format(hass, entry)
+
+    # Dismiss any stale "local connection not authorized" / "IP Control
+    # token problem" notifications left over from a previous session. Both
+    # are only re-raised on a fresh auth rejection, so clearing them here
+    # is safe even on a clean reload — they will be re-created if the
+    # problem genuinely still exists, instead of staying stuck forever when
+    # the TV was simply offline and never produced the one clean reconnect
+    # that would otherwise dismiss them.
+    clear_token_problem(hass, entry.entry_id, METHOD_LOCAL)
+    clear_token_problem(hass, entry.entry_id, METHOD_IP_CONTROL)
 
     # setup entry
     if DOMAIN not in hass.data:

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b9"
+  "version": "8.1.0b10"
 }


### PR DESCRIPTION
## Problem

Preston (issue #72) reported a "Samsung TV — local connection not authorized" persistent notification stuck on his UpstairsTV (.20) on 8.1.0b9, which did not clear after reauthentication or a Home Assistant restart.

Root cause: the `METHOD_LOCAL`/`METHOD_IP_CONTROL` token-problem notifications (`token_notify.py`) were only ever dismissed by a *clean* WebSocket reconnect (`ms.channel.connect` without a token change) or a successful IP Control call. If the TV stays offline/unreachable after the auth guard trips, that one clean event can never happen, so the notification is stuck forever — re-pairing and restarting HA only reset in-memory state, they never touch the already-created persistent_notification UI entry.

## Fix

`async_setup_entry` in `__init__.py` now proactively dismisses both notifications for the entry every time the entry is set up — this covers HA restart, integration reload, and Reconfigure → Authentication/IP Control (which both trigger a reload). If the rejection genuinely still exists, the notification is simply re-created on the next failure; this is a normal, fast path so there's no meaningful downside to clearing eagerly.

## Test plan

- [x] `py_compile` / `flake8` clean
- [ ] Ask Preston to confirm the notification no longer survives a restart once this ships

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_