### PR TITLE
Fix slow (~25s) Art Mode switch refresh after toggle (8.1.0b11)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -37,6 +37,20 @@
   `art='on'` after the TV was switched off. This never calls the firmware-risky
   `artModeControl` method, so it is safe regardless of the Art Mode option.
 
+## Art Mode switch — slow refresh after toggle fix
+
+- **Switch no longer snaps back ~25s after toggling Art Mode**: the IP Control
+  `artModeControl` command itself is fast (~100ms), but right after an explicit
+  toggle the switch called its own `async_update()`, which read the
+  media_player's `art_mode_status` *before* it had caught up (5s poll + Art
+  WebSocket propagation, observed up to ~40s on a 2024 Frame). That stale
+  pre-toggle value overwrote the fresh optimistic state, so the switch flipped
+  back and only recovered on the next media_player cycle. The post-toggle
+  self-refresh is removed and an **optimistic-hold guard** now keeps the value
+  you just set for up to 45s, ignoring only *contradicting* stale readings — a
+  matching reading clears the hold immediately. Applies to both the switch's own
+  poll and the media_player state-change listener.
+
 ## Art Mode status — accuracy fixes
 
 - **Switches now use the authoritative Art Mode logic**: the `art_mode_status`

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b10"
+  "version": "8.1.0b11"
 }

--- a/custom_components/samsungtv_smart/switch.py
+++ b/custom_components/samsungtv_smart/switch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from datetime import timedelta
 import logging
+import time
 from typing import Any
 
 from pysmartthings import Capability, Command
@@ -209,6 +210,13 @@ class FrameArtModeSwitch(SwitchEntity):
         self._attr_is_on = None
         self._available = True
         self._updating = False
+        # Optimistic-hold guard: after an explicit user toggle the
+        # media_player's art_mode_status lags (~5s poll + Art WebSocket
+        # propagation), so for a short window we keep the value we just set and
+        # ignore any *contradicting* stale reading (which previously snapped the
+        # switch back and made it look like a ~25s refresh).
+        self._optimistic_value: bool | None = None
+        self._optimistic_until: float = 0.0
         self._media_player_entity_id: str | None = None
         self._ip_control: SamsungIPControl | None = None
         self._ip_control_token: str | None = None
@@ -450,19 +458,21 @@ class FrameArtModeSwitch(SwitchEntity):
                     )
                     result = await self._set_artmode(True)
                     if result:
-                        # Set state immediately for responsive UI
-                        self._attr_is_on = True
+                        # Set state immediately for responsive UI and hold it
+                        # against the lagging media_player reading.
+                        self._set_optimistic(True)
                         self._available = True
                         self.async_write_ha_state()
                         self._log.info("Art Mode turned ON for %s", self._device_name)
 
-                        # Wait for TV to confirm, then refresh state.
-                        # async_update() only mutates attributes — publish
-                        # the refreshed state so the UI is corrected if the
-                        # TV ended up differing from the optimistic write.
-                        await asyncio.sleep(2)
-                        await self.async_update()
-                        self.async_write_ha_state()
+                        # Keep the optimistic state and let the media_player
+                        # state-change listener correct it authoritatively once
+                        # art_mode_status actually flips. A self-triggered
+                        # async_update() here read the media_player's
+                        # art_mode_status before it had caught up (~5s poll +
+                        # WebSocket propagation), so it overwrote the fresh
+                        # optimistic True with a stale False — making the switch
+                        # snap back off and only recover ~25s later.
                         return  # Success, exit
                     else:
                         # set_artmode returned None/False — this can happen when
@@ -543,19 +553,20 @@ class FrameArtModeSwitch(SwitchEntity):
                     )
                     result = await self._set_artmode(False)
                     if result:
-                        # Set state immediately for responsive UI
-                        self._attr_is_on = False
+                        # Set state immediately for responsive UI and hold it
+                        # against the lagging media_player reading.
+                        self._set_optimistic(False)
                         self._available = True
                         self.async_write_ha_state()
                         self._log.info("Art Mode turned OFF for %s", self._device_name)
 
-                        # Wait for TV to confirm, then refresh state.
-                        # async_update() only mutates attributes — publish
-                        # the refreshed state so the UI is corrected if the
-                        # TV ended up differing from the optimistic write.
-                        await asyncio.sleep(2)
-                        await self.async_update()
-                        self.async_write_ha_state()
+                        # Keep the optimistic state and let the media_player
+                        # state-change listener correct it authoritatively once
+                        # art_mode_status actually flips. A self-triggered
+                        # async_update() here read the media_player's
+                        # art_mode_status before it had caught up, overwriting
+                        # the fresh optimistic value with a stale one (the
+                        # mirror of the turn-on slow-refresh bug).
                         return  # Success, exit
                     else:
                         self._log.debug(
@@ -588,6 +599,34 @@ class FrameArtModeSwitch(SwitchEntity):
         )
         self.async_write_ha_state()
 
+    # How long to trust an explicit user toggle over a contradicting
+    # media_player reading (its art_mode_status lags ~5s poll + WS propagation,
+    # observed up to ~40s on a 2024 Frame).
+    _OPTIMISTIC_HOLD_SECONDS = 45
+
+    def _set_optimistic(self, value: bool) -> None:
+        """Record an explicit toggle so stale readings don't override it."""
+        self._attr_is_on = value
+        self._optimistic_value = value
+        self._optimistic_until = time.monotonic() + self._OPTIMISTIC_HOLD_SECONDS
+
+    def _optimistic_blocks(self, incoming: bool) -> bool:
+        """Return True if ``incoming`` contradicts a still-valid optimistic value.
+
+        A reading that *matches* the optimistic value clears the hold (the
+        authoritative source caught up); a contradicting one within the window
+        is ignored (it is the lagging pre-toggle value).
+        """
+        if self._optimistic_value is None:
+            return False
+        if time.monotonic() >= self._optimistic_until:
+            self._optimistic_value = None
+            return False
+        if incoming == self._optimistic_value:
+            self._optimistic_value = None
+            return False
+        return True
+
     async def async_update(self) -> None:
         """Update the Art Mode state."""
         if self._updating:
@@ -616,9 +655,17 @@ class FrameArtModeSwitch(SwitchEntity):
             entity_id = self._get_media_player_entity_id()
             mp_state = self._hass.states.get(entity_id) if entity_id else None
             if mp_state is not None and "art_mode_status" in mp_state.attributes:
-                self._attr_is_on = mp_state.attributes.get("art_mode_status") == "on"
+                incoming = mp_state.attributes.get("art_mode_status") == "on"
                 self._available = True
-                self._log.debug("Art Mode state updated: %s", self._attr_is_on)
+                if self._optimistic_blocks(incoming):
+                    self._log.debug(
+                        "Ignoring stale art_mode_status=%s (holding optimistic %s)",
+                        incoming,
+                        self._optimistic_value,
+                    )
+                else:
+                    self._attr_is_on = incoming
+                    self._log.debug("Art Mode state updated: %s", self._attr_is_on)
             else:
                 async with asyncio.timeout(8):
                     art_mode = await self._art_api.get_artmode()
@@ -668,14 +715,23 @@ class FrameArtModeSwitch(SwitchEntity):
         if new_state is None:
             return
         art_status = new_state.attributes.get("art_mode_status")
-        if art_status == "on":
-            self._attr_is_on = True
-        elif art_status == "off":
+        if art_status in ("on", "off"):
             # Mirror the media_player's authoritative art_mode_status directly,
             # including when the TV is ON but no longer in Art Mode (e.g. an app
             # was just launched). Without this the switch kept its previous
-            # "on" value and lingered until its own poll.
-            self._attr_is_on = False
+            # value and lingered until its own poll. But honour a recent
+            # explicit toggle: this attribute lags after a switch action, and
+            # the stale pre-toggle value used to snap the switch back.
+            incoming = art_status == "on"
+            if self._optimistic_blocks(incoming):
+                self._log.debug(
+                    "Ignoring stale media_player art_mode_status=%s"
+                    " (holding optimistic %s)",
+                    art_status,
+                    self._optimistic_value,
+                )
+                return
+            self._attr_is_on = incoming
         elif new_state.state == STATE_OFF:
             self._attr_is_on = False
         elif new_state.state in ("unknown", "unavailable"):


### PR DESCRIPTION
## Problem

From a user log (TV `.161`, on, **not** in standby): toggling the Art Mode switch took ~25s to settle, even though the actual command is fast.

Timeline from the log:
- `19:37:31.666` — toggle → `Turning Art Mode ON`
- `19:37:31.780` — `Art Mode turned ON` ✅ (command succeeded in **114ms**, switch → True optimistic)
- `19:37:33.78` — `Art Mode state updated: **False**` ❌ — reverted to OFF
- stays False until `19:38:11` (~25-30s) before finally showing True

## Root cause

The command isn't slow — the **refresh** is. After a successful `_set_artmode()`, `async_turn_on`/`async_turn_off` did:

```python
await asyncio.sleep(2)
await self.async_update()   # reads media_player art_mode_status — still stale
self.async_write_ha_state()
```

`async_update()` mirrors the media_player's `art_mode_status`, which lags (5s poll + Art WebSocket propagation, up to ~40s on a 2024 Frame). So 2s post-toggle it read the *old* `off` value and overwrote the fresh optimistic `True`. The media_player state-change listener had the same flaw.

## Fix

- Remove the counterproductive post-toggle `sleep(2)+async_update()`.
- Add an **optimistic-hold guard**: an explicit toggle records its value for up to 45s; during that window a *contradicting* media_player reading is ignored (it's the stale pre-toggle value), while a *matching* reading clears the hold immediately. Applied in both `async_update()` and the media_player state-change listener.

Compile + `black` + `flake8` clean. Release notes updated, version → 8.1.0b11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_