### PR TITLE
Self-heal legacy remote WS port 8001 → 8002 for TokenAuth TVs (8.1.0b12)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -66,6 +66,21 @@
   (SmartThings lags ~30-45s, so it is best-effort; IP Control remains the
   instant, authoritative path.)
 
+## Legacy remote WebSocket — automatic 8001 → 8002 port self-heal
+
+- **TokenAuth TVs stuck on the unencrypted 8001 channel now recover on their
+  own**: a Frame configured (often historically) on port 8001 rejects every
+  remote-control connect with `ms.channel.unauthorized` **and never shows the
+  on-screen authorization prompt** — because the prompt + token flow only
+  exists on the secure `wss://…:8002` channel. The integration would just keep
+  retrying 8001 forever and pause with a "local connection not authorized"
+  notification that re-pairing/restarting couldn't fix (the SmartThings/OAuth
+  re-auth is unrelated to this local channel). Now, right before pausing
+  reconnection, the remote channel **flips 8001 → 8002 once** and retries there
+  (SSL + token), and persists the working port to the config entry. On a
+  genuine 2024 model whose 8002 is firmware-filtered, the 8002 attempt simply
+  fails and the existing guard trips one flip later — no port ping-pong.
+
 ## Stale "connection not authorized" notification fix
 
 - **Notifications are now dismissed on setup/reload**: the "Samsung TV — local

--- a/custom_components/samsungtv_smart/api/samsungws.py
+++ b/custom_components/samsungtv_smart/api/samsungws.py
@@ -377,6 +377,13 @@ class SamsungTVWS:
         self._auth_recovered_callback = None
         self._consecutive_new_tokens = 0
         self._auth_blocked = False
+        # Port self-heal for the remote channel. A TokenAuthSupport TV that ends
+        # up configured on the unencrypted 8001 channel rejects every connect
+        # with ms.channel.unauthorized and never shows an on-screen prompt — the
+        # prompt + token flow only exists on the secure 8002 channel. Before
+        # pausing reconnection for good we flip 8001 -> 8002 once and retry.
+        self._port_changed_callback = None
+        self._tried_alt_port = False
 
     @property
     def auth_blocked(self) -> bool:
@@ -447,6 +454,39 @@ class SamsungTVWS:
         """Register a callback fired when a connection authorizes cleanly again."""
         self._auth_recovered_callback = func
 
+    def register_port_changed_callback(self, func):
+        """Register a callback fired when the WS port self-heals (8001<->8002).
+
+        Receives the new port so the caller can persist it to the config entry,
+        so the next restart connects on the working port directly.
+        """
+        self._port_changed_callback = func
+
+    def _try_alternate_port(self) -> bool:
+        """Flip the remote channel from the 8001 to the 8002 port once.
+
+        Returns True if the port was switched (caller should retry instead of
+        tripping the auth guard). A TokenAuth TV stuck on the unencrypted 8001
+        channel rejects every connect with no on-screen prompt; the secure 8002
+        channel is where the prompt + token actually happen. We only flip from
+        8001 -> 8002 and only once per session: on a genuine 2024 model (whose
+        8002 is filtered) the 8002 attempt simply fails and the guard trips as
+        before, just one port-flip later — no ping-pong.
+        """
+        if self.port != 8001 or self._tried_alt_port:
+            return False
+        self._log.warning(
+            "TV %s rejected the unencrypted 8001 remote channel repeatedly "
+            "(no on-screen prompt) — switching to the secure 8002 channel",
+            self.host,
+        )
+        self.port = 8002
+        self._tried_alt_port = True
+        self._consecutive_new_tokens = 0
+        if self._port_changed_callback is not None:
+            self._port_changed_callback(8002)
+        return True
+
     def register_status_callback(self, func):
         """Register callback function used on status change."""
         self._status_callback = func
@@ -465,6 +505,11 @@ class SamsungTVWS:
             not self._auth_blocked
             and self._consecutive_new_tokens >= MAX_CONSECUTIVE_NEW_TOKENS
         ):
+            # Before giving up, a TV stuck on the unencrypted 8001 channel may
+            # just need the secure 8002 channel (where the prompt + token live).
+            # Flip once and let the reconnect retry there instead of pausing.
+            if self._try_alternate_port():
+                return
             self._auth_blocked = True
             self._log.warning(
                 "TV %s repeatedly rejected the connection (%s) — pausing "

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b11"
+  "version": "8.1.0b12"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -576,6 +576,12 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         self._ws.register_auth_error_callback(auth_error_callback)
         self._ws.register_auth_recovered_callback(auth_recovered_callback)
 
+        def ws_port_changed_callback(port):
+            """Persist the remote channel's self-healed port (8001<->8002)."""
+            run_callback_threadsafe(self.hass.loop, self._persist_art_port, port)
+
+        self._ws.register_port_changed_callback(ws_port_changed_callback)
+
         # rest api initialization
         self._rest_api = SamsungTVAsyncRest(
             host=self._host,


### PR DESCRIPTION
## Problem

From a user log (issue #72), the **UpstairsTV (`.20`, a 2020 TokenAuthSupport Frame)** could not be authorized no matter what — re-pairing, OAuth re-auth, restart, power-cycle all failed, and **no on-screen prompt ever appeared** while the integration reported "authorization succeeded".

Log evidence:

```
ws://192.168.4.20:8001/...samsung.remote.control   ← port 8001, unencrypted, NO token
{'event': 'ms.channel.unauthorized'}   ← every connect, ~1/s
WARNING TV 192.168.4.20 repeatedly rejected the connection ... pausing remote reconnection
```

By contrast the working `.19` Frame uses `https://…:8002`.

## Root cause

The `.20` entry was locked on **port 8001**. On a TokenAuthSupport TV the unencrypted 8001 channel accepts the socket but then rejects auth with `ms.channel.unauthorized` and **never shows the prompt** — the prompt + token flow only exists on the secure `wss://…:8002` channel. The SmartThings/OAuth re-auth the notification points users to is unrelated to this local channel, so it could never fix it. The REST channel already self-heals its port (8001↔8002); the remote WS channel did not.

## Fix

Before tripping the permanent auth-blocked guard, the remote channel now **flips 8001 → 8002 once** and retries there (SSL + token), persisting the working port to the config entry so the next restart connects directly. Safety:
- Only flips **8001 → 8002**, and only **once per session** (`_tried_alt_port`) — no ping-pong.
- On a genuine **2024 model** whose 8002 is firmware-filtered, the 8002 attempt simply fails and the existing guard trips one flip later — behaviour unchanged for those.

Workaround for affected users meanwhile: Reconfigure → Connection → set port **8002**.

Compile + `black` + `flake8` clean. Release notes updated, version → 8.1.0b12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_