### PR TITLE
2020 Frames: IP Control TLS (DH key) fix + stop 404-app re-query spam (8.1.0b14)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -7,6 +7,20 @@
 
 ## IP Control
 
+- **Older Frames (~2020) TLS handshake fix (`dh key too small`)**: some 2020
+  Frames negotiate a Diffie-Hellman group smaller than 1024 bits on the IP
+  Control port (1516), which OpenSSL rejected even after the existing
+  `@SECLEVEL=1` retry — so *all* IP Control on those TVs (power, device info,
+  art-mode read) failed with `[SSL: DH_KEY_TOO_SMALL]`. The legacy-TLS retry now
+  drops to `@SECLEVEL=0`. These are local, self-signed panels already contacted
+  with `CERT_NONE`, so this is safe and strictly looser than the previous level.
+- **Stop re-querying not-installed apps**: an app present in the configured
+  app/source list but not installed on the TV returned `404 Not found` on every
+  scan — on TVs that never report an installed-app list (e.g. some 2020 Frames)
+  this meant the same missing app was polled forever (1900+ times in one logged
+  session). Such app ids are now remembered and skipped until the TV reports a
+  fresh installed-app list.
+
 - **Daily device-info refresh**: TV model and firmware version (learned via
   IP Control's `getDeviceInformation`) are now refreshed automatically every
   24h instead of only once at pairing time, so an OTA firmware upgrade is

--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -18,7 +18,7 @@ Protocol notes (confirmed on Frame 2024 / 2025):
     (Settings -> Connections -> Network -> Expert Settings).
   * Older Samsung TVs (Tizen <= 5.5, ~2020 Frames) negotiate a weak DH group
     that OpenSSL's default security level rejects ("dh key too small"). The
-    client detects this and transparently retries with @SECLEVEL=1.
+    client detects this and transparently retries with @SECLEVEL=0.
 
 The blocking HTTP work runs in the executor so the event loop is never blocked.
 The SSL context is also built lazily inside the executor — `create_default_context`
@@ -106,7 +106,7 @@ class SamsungIPControl:
         self._ctx: ssl.SSLContext | None = None
         # Older TVs (Tizen <= 5.5, ~2020 Frames) negotiate a weak DH group and
         # are rejected by OpenSSL's default security level. When that happens
-        # we retry once with @SECLEVEL=1 and remember it for subsequent calls.
+        # we retry once with @SECLEVEL=0 and remember it for subsequent calls.
         self._tls_legacy = False
         # Consecutive (artModeControl says on / pictureMode says not-art)
         # disagreements, for the desync guard in async_get_art_mode.
@@ -392,7 +392,12 @@ class SamsungIPControl:
         ctx.verify_mode = ssl.CERT_NONE
         if legacy:
             try:
-                ctx.set_ciphers("DEFAULT:@SECLEVEL=1")
+                # SECLEVEL=0 (not 1): some ~2020 Frames negotiate a DH group
+                # smaller than 1024 bits, which SECLEVEL=1 still rejects with
+                # "dh key too small". These are local, self-signed panels we
+                # already talk to with CERT_NONE, so dropping to SECLEVEL=0 (the
+                # most permissive) is safe and strictly looser than SECLEVEL=1.
+                ctx.set_ciphers("DEFAULT@SECLEVEL=0")
             except ssl.SSLError as ex:
                 _LOGGER.warning(
                     "Could not lower TLS security level for %s: %s", self._host, ex
@@ -408,7 +413,7 @@ class SamsungIPControl:
     ) -> dict[str, Any]:
         """Blocking JSON-RPC request — runs in the executor.
 
-        Retries once with @SECLEVEL=1 on a "dh key too small" SSL error so the
+        Retries once with @SECLEVEL=0 on a "dh key too small" SSL error so the
         client transparently handles older Samsung TVs.
         """
         body: dict[str, Any] = {

--- a/custom_components/samsungtv_smart/api/samsungws.py
+++ b/custom_components/samsungtv_smart/api/samsungws.py
@@ -335,6 +335,11 @@ class SamsungTVWS:
         self._power_on_artmode = False
 
         self._installed_app = {}
+        # App ids the TV answered "404 Not found" for: not installed, so we stop
+        # re-querying them every scan (otherwise a single missing app in the
+        # configured app_list is polled forever — observed 1900+ times in one
+        # session). Cleared whenever the TV reports a fresh installed-app list.
+        self._app_not_found: set[str] = set()
         self._running_apps: dict[str, datetime] = {}
         self._running_app: str | None = None
         self._running_app_changed: bool | None = None
@@ -801,6 +806,9 @@ class SamsungTVWS:
             app = App(app_id, app_info["name"], app_info["app_type"])
             installed_app[app_id] = app
         self._installed_app = installed_app
+        # Fresh authoritative list from the TV — re-evaluate previously
+        # not-found apps (one may have been installed since).
+        self._app_not_found.clear()
 
     def _client_control_thread(self):
         """Start the client control WS thread used to manage running apps."""
@@ -904,20 +912,24 @@ class SamsungTVWS:
             return
         error_code = response.get("error", {}).get("code", 0)
         if error_code == 404:  # Not found error
-            if self._installed_app:
-                if app_id not in self._installed_app:
-                    self._log.error("App ID %s not found", app_id)
-                return
-            # app_type = self._app_type.get(app_id)
-            # if app_type is None:
-            #     self._log.info(
-            #         "App ID %s with type DEEP_LINK not found, set as NATIVE_LAUNCH",
-            #         app_id,
-            #     )
-            #     self._app_type[app_id] = 4
+            # Remember this app is not installed so we stop polling it every
+            # scan. Without this a single missing app in the configured
+            # app_list is queried on every cycle forever (TVs that never report
+            # an installed-app list, e.g. some 2020 Frames, hit this hard).
+            if app_id not in self._app_not_found:
+                self._app_not_found.add(app_id)
+                self._log.debug(
+                    "App ID %s not found on TV — skipping it until next "
+                    "installed-app refresh",
+                    app_id,
+                )
 
     def _get_app_status(self, app_id, app_type):
         """Send a message to control WS channel to get the app status."""
+        if app_id in self._app_not_found:
+            # Already known not installed — don't re-query (and don't log).
+            return
+
         self._log.debug("Get app status: AppID: %s, AppType: %s", app_id, app_type)
 
         if not (self._ws_control and self._is_control_connected):

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b13"
+  "version": "8.1.0b14"
 }


### PR DESCRIPTION
## Context

While re-checking Preston's `log14.log` (2020 Frame, `.20`), two more issues surfaced — both already present, not regressions.

## 1. IP Control TLS handshake fails on ~2020 Frames (`DH_KEY_TOO_SMALL`)

```
IP Control getDeviceInformation for 192.168.4.20 failed (TLS error talking to
192.168.4.20:1516: [SSL: DH_KEY_TOO_SMALL] dh key too small)
IP Control art-mode read for 192.168.4.20 failed (... DH_KEY_TOO_SMALL ...)
```

The TV negotiates a Diffie-Hellman group smaller than 1024 bits on the IP Control port (1516). There was already a `@SECLEVEL=1` retry, but SECLEVEL=1 still rejects sub-1024-bit DH — so **all** IP Control on that TV (power, device info, art-mode read) failed.

**Fix:** the legacy-TLS retry now drops to `@SECLEVEL=0`. These are local, self-signed panels already contacted with `CERT_NONE`, so SECLEVEL=0 is safe and strictly looser than the previous level. Verified the cipher string is accepted on OpenSSL 3.0.

## 2. Not-installed apps re-queried forever (404 spam)

```
Get app status: AppID: 3202005021235, AppType: 2
{'error': {'code': 404, 'message': 'Not found error.', ...}, 'id': '3202005021235'}
```
— repeated **1969 times** in the session.

An app in the configured app/source list but not installed on the TV returns `404`. On TVs that never report an installed-app list (some 2020 Frames), `_get_running_app` rebuilds the full list every scan and re-queries the missing app forever. The mechanism meant to mark 404s was commented out.

**Fix:** 404 app ids are remembered (`_app_not_found`) and skipped on subsequent scans; the set is cleared whenever the TV reports a fresh installed-app list (so a newly installed app is picked up).

Compile + `black` + `isort` + `flake8` clean. Release notes updated, version → 8.1.0b14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_