### PR TITLE
Decouple REST port from WS/Art port; fix duplicate remote entity (8.1.0b15)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -7,6 +7,24 @@
 
 ## IP Control
 
+- **REST / WebSocket port no longer fight on split-port TVs (~2020 Frames)**:
+  some 2020 Frames serve the REST/HTTP API on **8001** while the secure token
+  WebSocket + Art channel live on **8002**. All three channels persisted their
+  self-healed port to a single shared config value, so the REST self-heal (which
+  learned 8001) and the remote-channel self-heal (which needs 8002) kept
+  overwriting each other — on every reload the remote channel re-ran its
+  `8001 → 8002` flip and REST re-flipped it back, an endless ping-pong (visible
+  as repeated *"switching to the secure 8002 channel"* / *"succeeded on 8001 --
+  switching to it"* warnings). REST now learns and persists its **own** port
+  (`rest_port`), decoupled from the WS/Art port, so each channel keeps the port
+  that works for it. Also fixes a nonsensical *"Art API: Port changed from 8002
+  to 8002"* log line.
+- **Duplicate `remote.<tv>` entity on rapid reload**: the remote entity is added
+  via a 5s-delayed callback that wasn't cancelled on unload, so reloading the
+  integration within ~5s fired a stale pending callback on top of the new
+  setup's — registering a second remote with the same unique id (*"Platform
+  samsungtv_smart does not generate unique IDs ... ignoring remote.<tv>"*). The
+  setup now skips adding a remote when one already exists for the entry.
 - **Older Frames (~2020) TLS handshake fix (`dh key too small`)**: some 2020
   Frames negotiate a Diffie-Hellman group smaller than 1024 bits on the IP
   Control port (1516), which OpenSSL rejected even after the existing

--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -327,19 +327,24 @@ class SamsungTVAsyncArt:
             if await self._connect_once(self._port):
                 return True
 
+            previous_port = self._port
             alternate_port = 8001 if self._port == 8002 else 8002
             self._log.debug(
                 "Art API: Port %d failed, trying alternate port %d",
-                self._port,
+                previous_port,
                 alternate_port,
             )
+            # _connect_once already sets self._port to the port it succeeds on,
+            # so log previous_port (not self._port) to avoid a nonsensical
+            # "Port changed from N to N" line.
             if await self._connect_once(alternate_port):
-                self._log.warning(
-                    "Art API: Port changed from %d to %d "
-                    "(likely a firmware update filtered the previous port)",
-                    self._port,
-                    alternate_port,
-                )
+                if previous_port != alternate_port:
+                    self._log.warning(
+                        "Art API: Port changed from %d to %d "
+                        "(likely a firmware update filtered the previous port)",
+                        previous_port,
+                        alternate_port,
+                    )
                 self._port = alternate_port
                 self._learn_port(alternate_port)
                 return True

--- a/custom_components/samsungtv_smart/config_flow.py
+++ b/custom_components/samsungtv_smart/config_flow.py
@@ -74,6 +74,7 @@ from .const import (
     CONF_OAUTH_TOKEN,
     CONF_PING_PORT,
     CONF_POWER_ON_METHOD,
+    CONF_REST_PORT,
     CONF_SHOW_CHANNEL_NR,
     CONF_SOURCE_LIST,
     CONF_ST_ENTRY_UNIQUE_ID,
@@ -932,6 +933,10 @@ class SamsungTVSmartOAuth2FlowHandler(
         updates = {
             CONF_HOST: self._host,
             CONF_PORT: self._tv_info.ws_port,
+            # Drop any REST port learned for the previous connection so REST
+            # re-learns from the freshly chosen port instead of keeping a stale
+            # value (the TV behind this entry may have changed).
+            CONF_REST_PORT: None,
             # Re-detect Art API get-capabilities after a reconfigure (the TV
             # behind this entry may have changed); None forces a fresh probe.
             CONF_SUPPORTS_GET_BRIGHTNESS: None,

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -75,6 +75,12 @@ CONF_LOAD_ALL_APPS = "load_all_apps"
 CONF_LOGO_OPTION = "logo_option"
 CONF_PING_PORT = "ping_port"
 CONF_POWER_ON_METHOD = "power_on_method"
+# REST/HTTP port, learned independently of CONF_PORT (the WS/token + Art port).
+# Some older Frames (~2020) serve the REST API on 8001 while the secure token
+# WebSocket + Art channel live on 8002, so a single shared port made the two
+# self-heal mechanisms fight forever (8001 <-> 8002 ping-pong). Falls back to
+# CONF_PORT when unset (existing installs / TVs where one port serves both).
+CONF_REST_PORT = "rest_port"
 CONF_SHOW_CHANNEL_NR = "show_channel_number"
 CONF_SOURCE_LIST = "source_list"
 CONF_SYNC_TURN_OFF = "sync_turn_off"

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b14"
+  "version": "8.1.0b15"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -111,6 +111,7 @@ from .const import (
     CONF_OAUTH_TOKEN,
     CONF_PING_PORT,
     CONF_POWER_ON_METHOD,
+    CONF_REST_PORT,
     CONF_SHOW_CHANNEL_NR,
     CONF_SLIDESHOW_API,
     CONF_SOURCE_LIST,
@@ -587,9 +588,14 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             host=self._host,
             session=session,
             timeout=DEFAULT_TIMEOUT,
-            port=config.get(CONF_PORT, DEFAULT_PORT),
+            # REST keeps its own learned port, decoupled from CONF_PORT (the
+            # WS/token + Art port). On ~2020 Frames REST answers on 8001 while
+            # the secure WS/Art channel is on 8002 — sharing one port made the
+            # two self-heals overwrite each other forever. Falls back to
+            # CONF_PORT for existing installs / single-port TVs.
+            port=config.get(CONF_REST_PORT) or config.get(CONF_PORT, DEFAULT_PORT),
         )
-        self._rest_api.register_port_callback(self._persist_art_port)
+        self._rest_api.register_port_callback(self._persist_rest_port)
 
         # Frame Art API - use shared instance if available, otherwise create new one
         shared_art_api = entry_data.get(DATA_ART_API) if entry_data else None
@@ -876,6 +882,21 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             return
         self.hass.config_entries.async_update_entry(
             entry, data={**entry.data, CONF_PORT: port}
+        )
+
+    def _persist_rest_port(self, port: int) -> None:
+        """Persist the REST API's runtime port fallback to entry.data.
+
+        Stored under CONF_REST_PORT, separate from CONF_PORT, so the REST
+        self-heal (8001 <-> 8002) does not overwrite the WS/token + Art port.
+        On ~2020 Frames the two channels legitimately need different ports;
+        sharing one value made each self-heal undo the other's on every reload.
+        """
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None or entry.data.get(CONF_REST_PORT) == port:
+            return
+        self.hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_REST_PORT: port}
         )
 
     async def _do_oauth_refresh(self) -> bool:

--- a/custom_components/samsungtv_smart/remote.py
+++ b/custom_components/samsungtv_smart/remote.py
@@ -13,7 +13,9 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
 from homeassistant.components.media_player.const import SERVICE_PLAY_MEDIA
-from homeassistant.components.remote import ATTR_NUM_REPEATS, RemoteEntity
+from homeassistant.components.remote import ATTR_NUM_REPEATS
+from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
+from homeassistant.components.remote import RemoteEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_SERVICE,
@@ -51,7 +53,13 @@ async def async_setup_entry(
         for tv_entity in tv_entries:
             if tv_entity.domain == MP_DOMAIN:
                 mp_entity_id = tv_entity.entity_id
-                break
+            elif tv_entity.domain == REMOTE_DOMAIN:
+                # A remote entity already exists for this entry. This callback is
+                # scheduled via async_call_later and is not cancelled on unload,
+                # so a rapid reload can fire a stale pending callback on top of
+                # the new setup's — adding a second remote with the same unique
+                # id ("does not generate unique IDs ... ignoring"). Skip it.
+                return
 
         if mp_entity_id is None:
             return


### PR DESCRIPTION
Fixes the issues from Preston's latest report on #72 (2020 upstairs TV, .20).

## Port flapping (root cause)

On ~2020 Frames the **REST/HTTP API answers on 8001** while the **secure token WebSocket + Art channel live on 8002**. All three channels persisted their self-healed port to a single shared `CONF_PORT`, so:

- REST self-heal learned **8001** → wrote `CONF_PORT=8001`
- remote-channel self-heal needs **8002** → flipped and wrote `CONF_PORT=8002`

…each undoing the other on every reload — an endless `8001 ↔ 8002` ping-pong, visible in the log as repeated `switching to the secure 8002 channel` / `succeeded on 8001 -- switching to it` warnings.

**Fix:** REST now learns and persists its **own** port (`CONF_REST_PORT`), decoupled from the WS/Art port, falling back to `CONF_PORT` when unset (existing installs / single-port TVs). A connection reconfigure clears the learned REST port so it re-learns from the freshly chosen port.

## Secondary fixes

- **`Art API: Port changed from 8002 to 8002`** nonsensical log: `_connect_once` already sets `self._port` to the port it succeeds on, so the success log read the post-mutation value. Now logs the previous port and only when it actually changed.
- **Duplicate `remote.<tv>` entity** (`does not generate unique IDs ... ignoring remote.upstairstv`): the remote entity is added via a 5s-delayed `async_call_later` callback that isn't cancelled on unload, so a rapid reload fired a stale pending callback on top of the new setup's, registering a second remote with the same unique id. Setup now skips adding a remote when one already exists for the entry.

## Not included

The Frame motion-detector / sleep-timer exposure Preston suggested — those settings are already exposed, so no change needed there.

## Verification

`py_compile`, `black --check`, `isort --check`, `flake8` (project `.flake8`) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_