### PR TITLE
Expose Art Mode brightness sensor (on/off) as a select (8.1.0b16)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -69,6 +69,18 @@
   `art='on'` after the TV was switched off. This never calls the firmware-risky
   `artModeControl` method, so it is safe regardless of the Art Mode option.
 
+## Art Mode — settings entities
+
+- **New "Brightness Sensor" select** (Frame models that report it): the Art Mode
+  ambient brightness sensor (on/off) is now exposed as a select alongside the
+  existing **Motion Sensitivity** and **Motion Timer** selects, all read/write
+  over the Art channel. Created only when the TV reports the setting. This rounds
+  out the Art Mode settings the TV exposes via `get_artmode_settings`
+  (`brightness`, `color_temperature`, `motion_sensitivity`, `motion_timer`,
+  `brightness_sensor_setting`). Note: the Frame's general *Sleep Timer*
+  (System → Time, disabled in Art Mode) is **not** exposed by any channel — the
+  motion-based auto-off in Art Mode is the **Motion Timer** select.
+
 ## Art Mode switch — slow refresh after toggle fix
 
 - **Switch no longer snaps back ~25s after toggling Art Mode**: the IP Control

--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -1503,6 +1503,22 @@ class SamsungTVAsyncArt:
             self._invalidate_artmode_settings_cache()
         return data is not None
 
+    async def set_brightness_sensor_setting(self, value: str) -> bool:
+        """Enable/disable the Art Mode ambient brightness sensor.
+
+        Accepts ``"on"`` / ``"off"`` (per the decompiled firmware, calls
+        ScreenManagerSetBrightnessSensorEnableValue). Only supported on Frame
+        models that report `get_artmode_settings("brightness_sensor_setting")`.
+        No dedicated get request exists; read the current value back via
+        get_artmode_settings.
+        """
+        data = await self._send_art_request(
+            {"request": "set_brightness_sensor_setting", "value": value}
+        )
+        if data is not None:
+            self._invalidate_artmode_settings_cache()
+        return data is not None
+
     async def get_auto_rotation_status(self) -> dict | None:
         """Get auto rotation settings."""
         return await self._send_art_request({"request": "get_auto_rotation_status"})

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b15"
+  "version": "8.1.0b16"
 }

--- a/custom_components/samsungtv_smart/select.py
+++ b/custom_components/samsungtv_smart/select.py
@@ -336,6 +336,9 @@ async def _load_motion_options(
                     "motion_sensitivity"
                 )
                 timer_item = await art_api.get_artmode_settings("motion_timer")
+                brightness_sensor_item = await art_api.get_artmode_settings(
+                    "brightness_sensor_setting"
+                )
 
             entities = []
 
@@ -364,6 +367,25 @@ async def _load_motion_options(
                         device_unique_id,
                         options,
                         timer_item.get("value"),
+                    )
+                )
+
+            # Brightness sensor is on/off; the TV reports a value but no
+            # valid_values, so the option list is fixed (the only accepted
+            # values per the firmware).
+            if (
+                isinstance(brightness_sensor_item, dict)
+                and brightness_sensor_item.get("value") is not None
+            ):
+                entities.append(
+                    SamsungTVArtBrightnessSensorSelect(
+                        hass,
+                        entry,
+                        art_api,
+                        device_name,
+                        device_unique_id,
+                        ["off", "on"],
+                        str(brightness_sensor_item.get("value")),
                     )
                 )
 
@@ -816,6 +838,25 @@ class SamsungTVArtMotionTimerSelect(SamsungTVArtMotionSelectBase):
 
     async def _async_set(self, option: str) -> None:
         await self._art_api.set_motion_timer(option)
+
+
+class SamsungTVArtBrightnessSensorSelect(SamsungTVArtMotionSelectBase):
+    """Select entity for the Art Mode ambient brightness sensor (on/off).
+
+    The TV reports this setting's current value but no valid_values, so the
+    options are fixed to off/on (per the firmware, the only accepted values).
+    """
+
+    _attr_icon = "mdi:brightness-auto"
+    _setting_name = "brightness_sensor_setting"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._attr_unique_id = f"{self._device_unique_id}_art_brightness_sensor"
+        self._attr_name = "Brightness Sensor"
+
+    async def _async_set(self, option: str) -> None:
+        await self._art_api.set_brightness_sensor_setting(option)
 
 
 # ══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Adds a **Brightness Sensor** select for Frame TVs, completing the Art Mode settings the TV exposes.

## Context

While investigating Preston's report on #72 (Frame turning off on its own in Art Mode), I confirmed from his actual `get_artmode_settings` payload that the TV reports **5** settings items:

```
brightness, color_temperature, motion_sensitivity, motion_timer, brightness_sensor_setting
```

We exposed all of them **except `brightness_sensor_setting`** (the ambient light sensor on/off, tied to Night-Mode-style auto-dimming/off behavior).

## Change

- New **Brightness Sensor** select (off/on), alongside the existing Motion Sensitivity / Motion Timer selects, created only when the TV reports the setting.
- Read via `get_artmode_settings("brightness_sensor_setting")`, written via a new `set_brightness_sensor_setting` art request (`{"value":"on"|"off"}`, confirmed by the decompiled firmware notes — `ScreenManagerSetBrightnessSensorEnableValue`).
- The TV reports the current value but **no** `valid_values`, so the option list is fixed to `off`/`on` (the only accepted values).

## Note on "Sleep Timer"

The Frame's general **Sleep Timer** (System → Time, ≤180 min) is **disabled in Art Mode** and is **not** exposed over the Art channel or SmartThings — so it can't be controlled here. The motion-based auto-off in Art Mode is the existing **Motion Timer** select; no separate sleep-timer entity is possible.

## Verification

`py_compile`, `black --check`, `isort --check`, `flake8` (project `.flake8`) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_