### PR TITLE
Stop logging ERROR when state sensors skip a powered-off TV (8.1.0b17)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -7,6 +7,16 @@
 
 ## IP Control
 
+- **No more `ERROR ... TV is powered off` log noise from the state sensors**:
+  the read-only IP Control state coordinator (`getTVStates`/`getVideoStates`)
+  already skipped polling while the TV is off, but it did so by raising
+  `UpdateFailed("TV is powered off")`. Home Assistant logs the first failure of
+  each streak at `ERROR`, so every off→on transition produced a fresh
+  `ERROR ... Error fetching IP Control state ... TV is powered off` line. A
+  powered-off TV is an expected, recurring condition — not a failure — so the
+  coordinator now returns a `powered_off` snapshot instead of raising. The state
+  sensors still go *unavailable* while the TV is off (via that flag), but no
+  ERROR is logged.
 - **REST / WebSocket port no longer fight on split-port TVs (~2020 Frames)**:
   some 2020 Frames serve the REST/HTTP API on **8001** while the secure token
   WebSocket + Art channel live on **8002**. All three channels persisted their

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b16"
+  "version": "8.1.0b17"
 }

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -1953,8 +1953,17 @@ class IPControlStateCoordinator(DataUpdateCoordinator):
         try:
             # Skip the snapshots while the TV is off: the getters would return
             # stale values, and this avoids needless traffic to a sleeping TV.
+            # A powered-off TV is an expected, recurring condition — NOT an
+            # update failure — so do not raise UpdateFailed here. Doing so makes
+            # HA log an ERROR on the first cycle of every off streak (i.e. once
+            # per off->on transition), spamming the log. Instead return a
+            # "powered_off" snapshot and let the sensors report unavailable via
+            # that flag, keeping last_update_success True (no ERROR).
             if await client.async_get_power_state() == "powerOff":
-                raise UpdateFailed("TV is powered off")
+                self._log.debug(
+                    "IP Control state: TV is powered off, skipping state poll"
+                )
+                return {"tv": {}, "video": {}, "powered_off": True}
 
             tv_states = await client.async_get_tv_states()
             video_states = await client.async_get_video_states()
@@ -1970,7 +1979,7 @@ class IPControlStateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"IP Control state read failed: {ex}") from ex
 
         clear_token_problem(self.hass, self._entry.entry_id, METHOD_IP_CONTROL)
-        return {"tv": tv_states, "video": video_states}
+        return {"tv": tv_states, "video": video_states, "powered_off": False}
 
 
 class IPControlStateSensor(CoordinatorEntity, SensorEntity):
@@ -2009,8 +2018,17 @@ class IPControlStateSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def available(self) -> bool:
-        """Available only while IP Control is active and the last poll worked."""
+        """Available only while IP Control is active and the TV is on.
+
+        A powered-off TV is reported through the coordinator data (not as an
+        update failure), so honor that flag here to mark the sensor
+        unavailable while the TV is off without logging an ERROR each cycle.
+        """
         entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        data = self.coordinator.data or {}
         return bool(
-            entry and _ip_control_active(entry) and self.coordinator.last_update_success
+            entry
+            and _ip_control_active(entry)
+            and self.coordinator.last_update_success
+            and not data.get("powered_off")
         )


### PR DESCRIPTION
## Problem

Preston's b16 logs (issue #72) show recurring lines like:

```
ERROR [...sensor] [192.168.1.161] Error fetching IP Control state ... data: TV is powered off
```

These are **not** real failures. The read-only IP Control state coordinator
(`getTVStates`/`getVideoStates`, feeding the 12 diagnostic sensors) already
*skips* polling while the TV is off — but it did so by raising
`UpdateFailed("TV is powered off")`. Home Assistant logs the **first** failure
of each streak at `ERROR`, so every off→on transition produced a fresh ERROR
line. A powered-off TV is an expected, recurring condition, so it shouldn't be
logged at ERROR at all.

## Fix

When the TV reports `powerOff`, the coordinator now returns a `powered_off`
snapshot (`{"tv": {}, "video": {}, "powered_off": True}`) instead of raising.
`last_update_success` stays `True`, so no ERROR is logged. The state sensors
still go **unavailable** while the TV is off — `IPControlStateSensor.available`
now honors the `powered_off` flag in addition to `last_update_success`.

Behaviour is unchanged from the user's perspective (sensors unavailable while
off, repopulate on power-on); only the log noise is gone.

## Verification

`py_compile` / `black` / `isort` / `flake8` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_