### PR TITLE
Art Mode: decode error codes + stop hammering uncached Art Store thumbnails (8.1.0b19)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -174,6 +174,27 @@
   in-flow `async_reload` / `async_update_reload_and_abort` calls were replaced
   accordingly (`async_update_and_abort`, `reload_on_update=False`).
 
+## Art Mode — thumbnails for Art Store content
+
+- **Stop hammering uncached Art Store (SAM-S\*) thumbnails**: the Frame only
+  keeps a thumbnail in its local cache once the content has actually been
+  materialized (displayed, favorited, downloaded). For Art Store items that
+  aren't cached yet, `get_thumbnail` returns `SYSTEM_FAIL` / 0 bytes because
+  there is genuinely nothing to serve — a structural condition, not a transient
+  transport error. The integration previously treated it as transient: 3
+  retries, an error placeholder, and a 5-minute global backoff, repeated every
+  poll, spamming the log for content that could never resolve until the TV
+  cached it. Art Store content is now fetched on a single attempt and, on
+  failure, left quietly (no placeholder, no backoff) with a calm debug line.
+  Personal photos (MY_F\*) keep the multi-attempt retry, since their failures
+  really are transient.
+- **Refresh on new content**: the Art channel now also listens for the TV's
+  `image_added` / `image_of_list_added` broadcasts (it already handled
+  `image_selected`, `favorite_changed`, etc.). These fire when the TV
+  materializes new content locally — exactly when a previously-uncached Art
+  Store thumbnail becomes fetchable — so the skipped thumbnail is retried as
+  soon as it can actually succeed, instead of waiting for the next poll.
+
 ## Art channel WebSocket — zombie-socket recovery
 
 - **Heartbeat / dead-connection detection**: the Art-channel WebSocket now opens

--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -197,6 +197,14 @@
   (`[192.168.x.y] Update took X.Xs, longer than the Xs scan interval`)
   instead of relying solely on Home Assistant's core scheduler warning, which
   cannot identify which TV/entity is responsible in a multi-TV setup.
+- **Art-app error codes are now decoded in the logs**: the Art channel's
+  `{"event": "error", "error_code": N}` replies (e.g. on a failed thumbnail
+  download) used to log only the bare numeric code, which is meaningless
+  without cross-referencing the decompiled firmware notes. Debug logs now show
+  the decoded name alongside it (e.g. `SYSTEM_FAIL (-1)`, `NOT_SUPPORTED_API
+  (-9)`, `INSUFFICIENT_SPACE (-11)`), making it possible to tell a generic
+  TV-side failure apart from e.g. a full thumbnail cache or an unsupported
+  request on a given firmware.
 
 ---
 

--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -52,6 +52,37 @@ MS_CHANNEL_READY_EVENT = "ms.channel.ready"
 # genuinely live-but-quiet channel is not torn down unnecessarily.
 ART_WS_HEARTBEAT = 20
 
+# Art-app error codes returned in {"event": "error", "error_code": N} replies,
+# per the decompiled firmware (notes/QN55LS03FAFXZA/ART_MODE_DECOMPILED.md).
+# Logged alongside the raw code so e.g. a thumbnail failure reads as
+# "SYSTEM_FAIL (-1)" instead of a bare, otherwise meaningless "-1".
+ART_ERROR_CODES = {
+    -14: "INSUFFICIENT_SYSTEM_SPACE",
+    -13: "PREVIEW_NOT_STARTED",
+    -12: "CHECKOUT_IN_PROGRESS",
+    -11: "INSUFFICIENT_SPACE",
+    -10: "TEMPORARILY_UNAVAILABLE",
+    -9: "NOT_SUPPORTED_API",
+    -8: "SSO_REQUIRED",
+    -7: "INVALID_PARAMETER",
+    -6: "REQUEST_PARSE_FAIL",
+    -5: "DB_ERROR",
+    -4: "FILE_NOT_FOUND",
+    -3: "NO_MEMORY",
+    -2: "NO_PERMISSION",
+    -1: "SYSTEM_FAIL",
+    0: "NO_ERROR",
+}
+
+
+def _describe_art_error(error_code: Any) -> str:
+    """Format an art-app error_code with its known name, if any."""
+    try:
+        name = ART_ERROR_CODES.get(int(error_code))
+    except (TypeError, ValueError):
+        name = None
+    return f"{name} ({error_code})" if name else str(error_code)
+
 
 def _get_ssl_context() -> ssl.SSLContext:
     """Get SSL context for secure connections without blocking calls."""
@@ -611,7 +642,7 @@ class SamsungTVAsyncArt:
         # Check for error
         if sub_event == "error":
             error_code = data.get("error_code", "unknown")
-            self._log.debug("Art API: Error event: %s", error_code)
+            self._log.debug("Art API: Error event: %s", _describe_art_error(error_code))
 
         # Resolve pending requests
         request_id = data.get("request_id", data.get("id"))
@@ -818,7 +849,7 @@ class SamsungTVAsyncArt:
         if data.get("event") == "error":
             self._log.debug(
                 "Art API: get_thumbnail_list returned error: %s",
-                data.get("error_code"),
+                _describe_art_error(data.get("error_code")),
             )
             return {}
 
@@ -991,7 +1022,10 @@ class SamsungTVAsyncArt:
 
         # Check for error
         if data.get("event") == "error":
-            self._log.debug("Art API: get_thumbnail error: %s", data.get("error_code"))
+            self._log.debug(
+                "Art API: get_thumbnail error: %s",
+                _describe_art_error(data.get("error_code")),
+            )
             return None
 
         try:
@@ -1080,7 +1114,7 @@ class SamsungTVAsyncArt:
             self._log.debug(
                 "Art API: get_thumbnail_list error for %s: %s",
                 content_id,
-                data.get("error_code"),
+                _describe_art_error(data.get("error_code")),
             )
             return None
 

--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -634,9 +634,15 @@ class SamsungTVAsyncArt:
             "slideshow_changed",
             "favorite_changed",
             "rotation_changed",
+            "image_added",
+            "image_of_list_added",
         ):
             # Confirmed broadcasts (WEBSOCKET_DECOMPILED.md) for changes the
             # Frame Art sensor otherwise only learns about on its next poll.
+            # image_added / image_of_list_added fire when the TV materializes
+            # new content locally — that is when an Art Store (SAM-S*)
+            # thumbnail finally becomes fetchable, so refreshing here retries
+            # the thumbnail that was skipped while the content was uncached.
             self._fire_art_content_event()
 
         # Check for error

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b17"
+  "version": "8.1.0b18"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b18"
+  "version": "8.1.0b19"
 }

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -1025,17 +1025,35 @@ class FrameArtCoordinator(DataUpdateCoordinator):
     async def _fetch_and_save_thumbnail(self, content_id: str) -> None:
         """Fetch and save thumbnail in background (non-blocking).
 
-        Uses retry logic to handle transient failures: the Samsung Art API
-        sometimes returns 0 bytes when the TV is busy or the WebSocket is slow.
-        These are NOT DRM failures — thumbnails are never DRM-protected.
+        For personal photos (MY_F*) a 0-byte / failed response is usually a
+        transient transport issue (TV busy, slow WebSocket), so retries help.
+
+        For Art Store content (SAM-S*) it is different: the TV only keeps a
+        thumbnail in its local cache (``data/download_thumbnail_contents/``)
+        once the item has actually been downloaded — i.e. displayed, favorited
+        or otherwise materialized. Until then ``get_thumbnail`` returns
+        ``SYSTEM_FAIL`` / 0 bytes because there is genuinely nothing to serve.
+        That is structural, not transient, so hammering it with retries + an
+        error placeholder + a global backoff (the previous behavior) just
+        spammed the log for content that was never going to resolve until the
+        TV materialized it. Such content is fetched on a single attempt and, on
+        failure, left quietly for the next ``image_added`` / ``image_selected``
+        broadcast to retrigger.
         """
         import os
 
         self._log.info("Frame Art: Starting thumbnail fetch for %s", content_id)
 
-        # Retry logic: up to 3 attempts with progressive delays.
-        max_retries = 3
-        retry_delays = [1, 2, 5]  # seconds
+        # Art Store (SAM-S*) thumbnails only exist once the TV has materialized
+        # the content locally; retrying before that is pointless. Personal
+        # photos can fail transiently, so they keep the multi-attempt retry.
+        is_store_content = content_id.startswith("SAM-S")
+        if is_store_content:
+            max_retries = 1
+            retry_delays: list[int] = []
+        else:
+            max_retries = 3
+            retry_delays = [1, 2, 5]  # seconds
         thumbnail_data = None
         last_error = None
 
@@ -1147,13 +1165,30 @@ class FrameArtCoordinator(DataUpdateCoordinator):
         if await self._restore_current_from_cache(content_id):
             return
 
+        # Art Store content the TV hasn't materialized yet: the failure is
+        # structural (no local thumbnail exists), not a transport problem.
+        # Log it calmly and leave it — do NOT write an error placeholder or
+        # trip the global backoff. The next image_added / image_selected
+        # broadcast for this content will retrigger the fetch once the TV has
+        # actually cached it.
+        if is_store_content:
+            self._log.debug(
+                "Frame Art: No thumbnail for Art Store content %s yet "
+                "(last error: %s) — the TV only caches it once it has been "
+                "displayed/favorited. Leaving current image unchanged.",
+                content_id,
+                last_error,
+            )
+            return
+
         # No cached copy available — save generic error placeholder.
-        # NOT a DRM issue: thumbnails are never DRM-protected.
+        # Personal photos are never DRM-protected; a failure here is a
+        # transient transport issue (TV busy, WebSocket lag).
         self._thumbnail_failures += 1
         self._log.warning(
             "Frame Art: Could not download thumbnail for %s after %d attempts "
             "(last error: %s), and no cached copy was found. "
-            "Transient transport failure, not DRM.",
+            "Transient transport failure.",
             content_id,
             max_retries,
             last_error,


### PR DESCRIPTION
Follow-up to #83 (already merged). Two related Art-channel improvements, both driven by issue #72 logs.

## 1. Decode art-app error codes in the logs (b18)

The Art channel's `{"event": "error", "error_code": N}` replies (e.g. on a failed thumbnail download) used to log only the bare numeric code — meaningless without cross-referencing the decompiled firmware notes. The known error enum (from `notes/QN55LS03FAFXZA/ART_MODE_DECOMPILED.md`) is now decoded so debug logs read e.g. `SYSTEM_FAIL (-1)`, `NOT_SUPPORTED_API (-9)`, `INSUFFICIENT_SPACE (-11)`.

## 2. Stop hammering uncached Art Store (SAM-S*) thumbnails (b19)

The Frame only keeps a thumbnail in its local cache (`data/download_thumbnail_contents/`) once the content has been **materialized** (displayed, favorited, downloaded). For Art Store items not yet cached, `get_thumbnail` returns `SYSTEM_FAIL` / 0 bytes because there's genuinely nothing to serve — a structural condition, not a transient transport error.

The integration previously treated it as transient: 3 retries + error placeholder + 5-min global backoff, **every poll**, spamming the log for content that could never resolve until the TV cached it.

- Art Store content (`SAM-S*`) is now fetched on a **single attempt**; on failure it's left quietly (no placeholder, no backoff) with a calm debug line.
- Personal photos (`MY_F*`) keep the multi-attempt retry — their failures really are transient.
- The Art channel now also listens for the TV's `image_added` / `image_of_list_added` broadcasts (it already handled `image_selected`, `favorite_changed`, etc.). These fire when the TV materializes new content locally — exactly when a previously-uncached Art Store thumbnail becomes fetchable — so the skipped thumbnail is retried as soon as it can actually succeed.

## Verification

`py_compile` / `black` / `isort` / `flake8` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_