### PR TITLE
Clearer log when a TV has no working secure 8002 channel (8.1.0b20)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -134,6 +134,15 @@
   (SSL + token), and persists the working port to the config entry. On a
   genuine 2024 model whose 8002 is firmware-filtered, the 8002 attempt simply
   fails and the existing guard trips one flip later — no port ping-pong.
+- **Clearer log when a TV has no working secure 8002 channel**: when the remote
+  channel has already flipped 8001 → 8002 and the secure channel *also* keeps
+  rejecting, the integration now says so explicitly instead of logging a
+  generic "re-pair required". Per the decompiled TV server
+  (`notes/QN55LS03FAFXZA/PORTS.md`), some firmwares fail to bring up the 8002
+  TLS vhost at all (`can't create vhost for '8002' port`, observed on some 2020
+  Frames), so neither 8001 nor 8002 can complete the token handshake — and a
+  re-pair can't fix what is a TV-side limitation. The new message names that
+  case directly to save debugging time.
 
 ## Stale "connection not authorized" notification fix
 

--- a/custom_components/samsungtv_smart/api/samsungws.py
+++ b/custom_components/samsungtv_smart/api/samsungws.py
@@ -516,12 +516,31 @@ class SamsungTVWS:
             if self._try_alternate_port():
                 return
             self._auth_blocked = True
-            self._log.warning(
-                "TV %s repeatedly rejected the connection (%s) — pausing "
-                "remote reconnection; re-pair required",
-                self.host,
-                reason,
-            )
+            if self.port == 8002 and self._tried_alt_port:
+                # We already flipped 8001 -> 8002 and the secure channel is
+                # ALSO rejecting. Per the decompiled msf-server
+                # (notes/QN55LS03FAFXZA/PORTS.md), some firmwares fail to bring
+                # up the 8002 TLS vhost at all ("can't create vhost for '8002'
+                # port") — observed on ~2020 Frames — so neither the plain 8001
+                # nor the secure 8002 channel can complete the token handshake.
+                # Surface that explicitly instead of a generic "re-pair", which
+                # won't help when the TV simply has no working secure channel.
+                self._log.warning(
+                    "TV %s rejected both the 8001 and the secure 8002 remote "
+                    "channels (%s) — this TV may not expose a working TLS "
+                    "(8002) channel (firmware failed to create the vhost, seen "
+                    "on some 2020 Frames); remote control over this channel "
+                    "cannot authorize. Pausing remote reconnection.",
+                    self.host,
+                    reason,
+                )
+            else:
+                self._log.warning(
+                    "TV %s repeatedly rejected the connection (%s) — pausing "
+                    "remote reconnection; re-pair required",
+                    self.host,
+                    reason,
+                )
             if self._auth_error_callback is not None:
                 self._auth_error_callback()
 

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b19"
+  "version": "8.1.0b21"
 }


### PR DESCRIPTION
## Context

From the decompiled TV server notes (`notes/QN55LS03FAFXZA/PORTS.md`): on the Frame, **8001 and 8002 are the same `msf-server` process** (8001 plaintext, 8002 TLS), and `msf-server`'s strings contain the literal error `can't create vhost for '8002' port`. On some firmwares (observed on ~2020 Frames) the 8002 TLS vhost fails to come up at all — so the secure channel where the token/pairing handshake lives simply doesn't exist, and **no re-pair can fix it** (it's a TV-side limitation).

## Change

Purely a logging/observability improvement — **no behavior change**.

When the remote channel has already flipped 8001 → 8002 (the existing auto-heal from #78) and the secure channel *also* keeps rejecting, the integration previously logged a generic `repeatedly rejected the connection — re-pair required`, which is misleading for this case. It now detects "we're on 8002, we got here by flipping, and it's still failing" and logs an explicit message naming the likely cause (no working TLS 8002 vhost), to save debugging time on these TVs.

## Note on ordering

This branches off `v8.1-dev` (b17) in parallel with #84 (b18/b19), so it's versioned **8.1.0b20** to avoid a version regression. Best merged after #84; if they conflict on the manifest version line / release notes, I can rebase.

## Verification

`flake8` / `py_compile` / `black` / `isort` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_