### PR TITLE
Log at INFO when a model has no motion/brightness sensor (8.1.0b21)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -90,6 +90,13 @@
   `brightness_sensor_setting`). Note: the Frame's general *Sleep Timer*
   (System → Time, disabled in Art Mode) is **not** exposed by any channel — the
   motion-based auto-off in Art Mode is the **Motion Timer** select.
+- **Clearer log when a model has no motion/brightness sensor**: when the TV
+  reports none of `motion_sensitivity` / `motion_timer` /
+  `brightness_sensor_setting`, the integration now logs this at `INFO` (instead
+  of `debug`), stating explicitly that those three controls are intentionally
+  not created because the model has no such sensor. Expected on Frames without
+  the motion/ambient-light sensor (e.g. some 2020/2021 models) — it is not an
+  error.
 
 ## Art Mode switch — slow refresh after toggle fix
 

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b20"
+  "version": "8.1.0b21"
 }

--- a/custom_components/samsungtv_smart/select.py
+++ b/custom_components/samsungtv_smart/select.py
@@ -397,8 +397,14 @@ async def _load_motion_options(
                     [e._setting_name for e in entities],
                 )
             else:
-                _LOGGER.debug(
-                    "TV %s does not report Art Mode motion settings, skipping",
+                _LOGGER.info(
+                    "TV %s did not report any Art Mode motion/brightness sensor "
+                    "settings (motion_sensitivity, motion_timer, "
+                    "brightness_sensor_setting) — this model has no such sensor, "
+                    "so the Motion Sensitivity, Motion Timer and Brightness "
+                    "Sensor controls are intentionally not created. This is "
+                    "expected on Frames without the motion/ambient-light sensor "
+                    "(e.g. some 2020/2021 models); it is not an error.",
                     device_name,
                 )
             return


### PR DESCRIPTION
## Context

Comparing two Frames side by side (a 2024 vs a 2021), three controls present on the 2024 are absent on the 2021: **Brightness Sensor**, **Motion Sensitivity** and **Motion Timer**. This is **not a bug** — those three selects are created by `_load_motion_options` only if the TV reports the matching `get_artmode_settings` items (`motion_sensitivity`, `motion_timer`, `brightness_sensor_setting`). The 2021 Frame doesn't report them (no motion/ambient-light sensor), so they are correctly skipped. (Color Tone, Power, Reboot, Backlight, Art Mode brightness/color all work on both — IP Control and the Art channel are fine.)

## Change

Purely a logging/observability improvement — **no behavior change**.

When the TV reports none of the three sensor settings, the skip was logged only at `debug`. It's now logged at `INFO` with an explicit, reassuring message naming the three controls and stating this is expected on Frames without the motion/ambient-light sensor (e.g. some 2020/2021 models), not an error — so the absence is self-explanatory in the logs without enabling debug.

## Verification

`flake8` / `py_compile` / `black` / `isort` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_