### PR TITLE
Fix Art Store thumbnails taking minutes to appear (8.1.0b22)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -210,6 +210,17 @@
   materializes new content locally — exactly when a previously-uncached Art
   Store thumbnail becomes fetchable — so the skipped thumbnail is retried as
   soon as it can actually succeed, instead of waiting for the next poll.
+- **Art Store thumbnail no longer takes minutes to appear**: two fixes that
+  together caused a freshly favorited/displayed Art Store image to keep showing
+  the *previous* artwork's thumbnail for several minutes (until the displayed
+  artwork happened to change). First, the "do we already have this thumbnail?"
+  check is now **content-aware** — a leftover `current.jpg` from an earlier
+  artwork no longer masquerades as the current content's thumbnail and
+  suppresses the fetch. Second, favoriting Art Store content does **not** emit
+  an `image_added` broadcast (only personal uploads do), so relying on that
+  event alone meant the retry never fired; the integration now arms a short
+  retry cooldown after an uncached Art Store miss and picks the thumbnail up
+  within ~30s of the TV caching it, without re-fetching on every poll.
 
 ## Art channel WebSocket — zombie-socket recovery
 

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b21"
+  "version": "8.1.0b22"
 }

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -75,6 +75,13 @@ def _ip_control_active(entry: ConfigEntry) -> bool:
 # settings change slowly, so a relaxed cadence keeps JSON-RPC traffic light.
 IP_CONTROL_STATE_SCAN_INTERVAL = timedelta(seconds=30)
 
+# How long to wait before re-fetching the thumbnail of an Art Store (SAM-*)
+# artwork the TV has not cached locally yet. The TV materializes the thumbnail
+# a little while after the content is displayed/favorited; this bounded retry
+# recovers within seconds of that happening without hammering the art channel
+# on every poll.
+STORE_THUMBNAIL_RETRY_INTERVAL = 30  # seconds
+
 
 @dataclass(frozen=True, kw_only=True)
 class SamsungIPControlSensorDescription(SensorEntityDescription):
@@ -492,6 +499,18 @@ class FrameArtCoordinator(DataUpdateCoordinator):
         self._entry = entry
         self._hass = hass
         self._last_content_id: str | None = None
+        # content_id that the saved current.jpg actually represents. Tracked
+        # separately from "does current.jpg exist on disk" so a stale file from
+        # a previous artwork cannot masquerade as the current content's
+        # thumbnail (which used to block re-fetching for minutes — see
+        # _has_thumbnail_for).
+        self._current_thumbnail_content_id: str | None = None
+        # Art Store (SAM-*) content the TV has not cached yet: remember which
+        # content_id is pending and the earliest time to retry, so we recover
+        # within seconds of the TV materializing it without re-fetching on
+        # every single poll.
+        self._store_retry_content_id: str | None = None
+        self._store_retry_at: float | None = None
         # Enabled by default - thumbnails are fetched for current artwork
         self._thumbnail_fetch_enabled = True
         self._thumbnail_failures = 0
@@ -627,19 +646,32 @@ class FrameArtCoordinator(DataUpdateCoordinator):
                         "Frame Art: Thumbnail auto-fetch disabled, skipping %s",
                         content_id,
                     )
-            elif (
+            # Re-fetch when the content changed OR we don't actually hold this
+            # content's thumbnail. The check is content-aware (not just "does
+            # current.jpg exist"): a stale file from a previous artwork must not
+            # block fetching the current one. For Art Store content the TV has
+            # not cached yet, a short cooldown throttles the retry so we recover
+            # within seconds of it becoming available without polling-hammering.
+            need_thumbnail = (
+                content_id != self._last_content_id
+                or not self._has_thumbnail_for(content_id)
+            )
+            store_retry_waiting = (
+                self._store_retry_content_id == content_id
+                and self._store_retry_at is not None
+                and time.time() < self._store_retry_at
+            )
+            if (
                 content_id
                 and not thumbnail_in_backoff
-                and (
-                    content_id != self._last_content_id
-                    or not self._has_current_thumbnail()
-                )
+                and need_thumbnail
+                and not store_retry_waiting
             ):
                 self._log.info(
                     "Frame Art: Triggering thumbnail fetch for %s (changed: %s, has_thumbnail: %s)",
                     content_id,
                     content_id != self._last_content_id,
-                    self._has_current_thumbnail(),
+                    self._has_thumbnail_for(content_id),
                 )
                 # Schedule thumbnail fetch as background task (non-blocking)
                 self._hass.async_create_background_task(
@@ -653,11 +685,18 @@ class FrameArtCoordinator(DataUpdateCoordinator):
                     self._thumbnail_backoff_until - time.time(),
                     content_id,
                 )
+            elif content_id and store_retry_waiting:
+                self._log.debug(
+                    "Frame Art: Art Store thumbnail %s not cached yet, next "
+                    "retry in %.0fs",
+                    content_id,
+                    self._store_retry_at - time.time(),
+                )
             elif content_id:
                 self._log.debug(
                     "Frame Art: Skipping thumbnail fetch - same content_id %s, has_thumbnail: %s",
                     content_id,
-                    self._has_current_thumbnail(),
+                    self._has_thumbnail_for(content_id),
                 )
 
             # If we have a saved thumbnail, use it
@@ -855,6 +894,26 @@ class FrameArtCoordinator(DataUpdateCoordinator):
             "www", "frame_art", self._entry.entry_id, "current.jpg"
         )
         return os.path.isfile(www_path)
+
+    def _clear_store_retry(self, content_id: str) -> None:
+        """Clear the Art Store retry cooldown once ``content_id`` is resolved."""
+        if self._store_retry_content_id == content_id:
+            self._store_retry_content_id = None
+            self._store_retry_at = None
+
+    def _has_thumbnail_for(self, content_id: str) -> bool:
+        """Whether current.jpg exists AND actually represents ``content_id``.
+
+        ``_has_current_thumbnail`` only checks the file on disk, so a leftover
+        current.jpg from a previously displayed artwork would otherwise look
+        like a valid thumbnail for the new content and suppress the fetch. Gate
+        on the tracked content_id so we keep (re)fetching until we genuinely
+        hold this artwork's thumbnail.
+        """
+        return (
+            self._current_thumbnail_content_id == content_id
+            and self._has_current_thumbnail()
+        )
 
     def _create_error_placeholder(self) -> bytes:
         """Create a generic download error placeholder image.
@@ -1152,6 +1211,8 @@ class FrameArtCoordinator(DataUpdateCoordinator):
 
             self._log.info("Frame Art: Successfully saved thumbnail for %s", content_id)
             self._thumbnail_failures = 0
+            self._current_thumbnail_content_id = content_id
+            self._clear_store_retry(content_id)
             self.async_set_updated_data(self.data)
             return
 
@@ -1167,17 +1228,24 @@ class FrameArtCoordinator(DataUpdateCoordinator):
 
         # Art Store content the TV hasn't materialized yet: the failure is
         # structural (no local thumbnail exists), not a transport problem.
-        # Log it calmly and leave it — do NOT write an error placeholder or
-        # trip the global backoff. The next image_added / image_selected
-        # broadcast for this content will retrigger the fetch once the TV has
-        # actually cached it.
+        # Log it calmly and leave the current image — do NOT write an error
+        # placeholder or trip the global backoff. The TV caches the thumbnail a
+        # little while after the content is displayed/favorited; favoriting Art
+        # Store content does NOT emit an image_added broadcast (only personal
+        # uploads do), so we cannot rely on an event to retrigger the fetch.
+        # Instead arm a short retry cooldown so the next poll after it elapses
+        # re-attempts and picks the thumbnail up within seconds of it becoming
+        # available, rather than stalling until the artwork happens to change.
         if is_store_content:
+            self._store_retry_content_id = content_id
+            self._store_retry_at = time.time() + STORE_THUMBNAIL_RETRY_INTERVAL
             self._log.debug(
                 "Frame Art: No thumbnail for Art Store content %s yet "
                 "(last error: %s) — the TV only caches it once it has been "
-                "displayed/favorited. Leaving current image unchanged.",
+                "displayed/favorited. Will retry in %ds.",
                 content_id,
                 last_error,
+                STORE_THUMBNAIL_RETRY_INTERVAL,
             )
             return
 
@@ -1267,6 +1335,8 @@ class FrameArtCoordinator(DataUpdateCoordinator):
                 subdir,
             )
             self._thumbnail_failures = 0
+            self._current_thumbnail_content_id = content_id
+            self._clear_store_retry(content_id)
             self.async_set_updated_data(self.data)
 
         return promoted


### PR DESCRIPTION
## Context

From a user log: a freshly favorited Art Store image (`SAM-S1110737`) took **~11 minutes** to show its thumbnail in HA — first fetch failed at `17:13:28` (TV hadn't cached it yet), and the correct thumbnail only appeared at `17:24:22`, when the displayed artwork happened to change back to it. The whole window in between logged `Skipping thumbnail fetch - same content_id SAM-S1110737, has_thumbnail: True` every poll. Favoriting was correct on the TV side; only HA lagged.

## Root cause (two bugs)

1. **Content-blind "has thumbnail" check.** `_has_current_thumbnail()` only tests whether `current.jpg` exists on disk, not which artwork it represents. After the failed fetch left the *previous* artwork's `current.jpg` in place, that stale file satisfied `has_thumbnail: True` for `SAM-S1110737`. With `content_id == _last_content_id`, the fetch was skipped indefinitely.

2. **Retry relied on an event that never fires for Art Store content.** The b19 fix expected `image_added` / `image_of_list_added` to retrigger the fetch once the TV cached the thumbnail. The log confirms favoriting Art Store content emits only `favorite_changed` — `image_added` fired exactly once, for a *personal* upload (`MY_F0013`). So the retry never happened.

## Fix

- Track the content_id the saved `current.jpg` actually represents (`_current_thumbnail_content_id`) and gate the fetch on a new content-aware `_has_thumbnail_for(content_id)`, so a stale file can't suppress fetching the current artwork.
- After an uncached Art Store miss, arm a short retry cooldown (`STORE_THUMBNAIL_RETRY_INTERVAL = 30s`) so the next poll past it re-attempts and resolves within ~30s of the TV caching the thumbnail — without re-fetching on every poll (preserving b19's anti-hammer intent). Personal photos keep their existing multi-attempt/backoff behavior.

No change to personal-photo handling or the global backoff.

## Verification

`flake8` / `py_compile` / `black` / `isort` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_