### PR TITLE
Debounce transient content_id glitches during matte/select (8.1.0b23)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -221,6 +221,16 @@
   event alone meant the retry never fired; the integration now arms a short
   retry cooldown after an uncached Art Store miss and picks the thumbnail up
   within ~30s of the TV caching it, without re-fetching on every poll.
+- **No more flashing the wrong artwork during matte/select operations**: the
+  Frame occasionally returns a spurious one-off `content_id` from
+  `get_current_artwork` during matte changes (observed: a single poll reporting
+  an unrelated id such as `SAM-F0222` while another artwork is actually on
+  screen, corrected on the very next poll). The integration used to expose that
+  reading immediately — briefly showing the wrong artwork in HA and triggering a
+  wasted thumbnail fetch. A changed `content_id` is now **debounced**: it must be
+  seen on two consecutive polls before it is exposed, so a single bad reading is
+  ignored. Legitimate changes still appear promptly (polls are sub-second to a
+  few seconds apart during art activity).
 
 ## Art channel WebSocket — zombie-socket recovery
 

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b22"
+  "version": "8.1.0b23"
 }

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -511,6 +511,14 @@ class FrameArtCoordinator(DataUpdateCoordinator):
         # every single poll.
         self._store_retry_content_id: str | None = None
         self._store_retry_at: float | None = None
+        # Debounce for transient content_id glitches: the TV occasionally
+        # reports a spurious one-off content_id from get_current_artwork during
+        # matte/select operations (a single poll returning an unrelated id,
+        # corrected on the next poll). _confirmed_content_id is the trusted
+        # value currently exposed in HA; _pending_content_id is a changed id
+        # seen only once, held until a second consecutive poll confirms it.
+        self._confirmed_content_id: str | None = None
+        self._pending_content_id: str | None = None
         # Enabled by default - thumbnails are fetched for current artwork
         self._thumbnail_fetch_enabled = True
         self._thumbnail_failures = 0
@@ -607,12 +615,26 @@ class FrameArtCoordinator(DataUpdateCoordinator):
                 async with asyncio.timeout(8):
                     current = await self._art_api.get_current()
                     if current:
-                        content_id = current.get("content_id")
-                        data["current_artwork"] = {
-                            "content_id": content_id,
-                            "category_id": current.get("category_id"),
-                            "matte_id": current.get("matte_id"),
-                        }
+                        raw_content_id = current.get("content_id")
+                        content_id = self._confirm_content_id(raw_content_id)
+                        if content_id is not None and content_id == raw_content_id:
+                            # Trusted reading: expose it.
+                            data["current_artwork"] = {
+                                "content_id": content_id,
+                                "category_id": current.get("category_id"),
+                                "matte_id": current.get("matte_id"),
+                            }
+                        else:
+                            # Unconfirmed/transient reading: keep the previously
+                            # exposed artwork (already copied into data above) and
+                            # don't let this id drive thumbnail logic this cycle.
+                            if raw_content_id is not None:
+                                self._log.debug(
+                                    "Frame Art: ignoring unconfirmed content_id "
+                                    "%s this cycle",
+                                    raw_content_id,
+                                )
+                            content_id = None
             except asyncio.TimeoutError:
                 self._log.debug("Timeout getting current artwork")
             except Exception as ex:
@@ -914,6 +936,48 @@ class FrameArtCoordinator(DataUpdateCoordinator):
             self._current_thumbnail_content_id == content_id
             and self._has_current_thumbnail()
         )
+
+    def _confirm_content_id(self, raw_content_id: str | None) -> str | None:
+        """Debounce transient content_id glitches from the TV.
+
+        The Frame occasionally reports a spurious one-off content_id from
+        get_current_artwork during matte/select operations (observed: a single
+        poll returning an unrelated id such as SAM-F0222 while a different
+        artwork is actually displayed, corrected on the very next poll). Require
+        a *changed* id to be seen on two consecutive polls before trusting it,
+        so one bad reading never flashes in HA or triggers a wasted thumbnail
+        fetch.
+
+        Returns the trusted content_id. It equals ``raw_content_id`` only when
+        the reading is accepted; otherwise it returns the previously trusted id
+        (or None) so callers can tell an accepted reading from a held one.
+        """
+        if raw_content_id is None:
+            # Failed/empty poll: don't disturb the trusted value or pending state.
+            return None
+        if raw_content_id == self._confirmed_content_id:
+            # Steady state: clear any half-seen pending change.
+            self._pending_content_id = None
+            return raw_content_id
+        if self._confirmed_content_id is None:
+            # First reading after startup: nothing to protect, trust immediately.
+            self._confirmed_content_id = raw_content_id
+            self._pending_content_id = None
+            return raw_content_id
+        if raw_content_id == self._pending_content_id:
+            # Same new id seen twice in a row: it's real now.
+            self._confirmed_content_id = raw_content_id
+            self._pending_content_id = None
+            return raw_content_id
+        # First sighting of a new id: hold it tentatively, keep the trusted one.
+        self._log.debug(
+            "Frame Art: content_id %s seen once (current trusted: %s); waiting "
+            "for confirmation before exposing it",
+            raw_content_id,
+            self._confirmed_content_id,
+        )
+        self._pending_content_id = raw_content_id
+        return self._confirmed_content_id
 
     def _create_error_placeholder(self) -> bytes:
         """Create a generic download error placeholder image.


### PR DESCRIPTION
## Problem

From a user log: while **SAM-S1110599** was actually on screen and the user was changing the matte (TV `192.168.1.161`), a single `get_current_artwork` poll returned an unrelated **SAM-F0222**:

```
16:28:48  matte_changed → SAM-S1110599      (the matte change, OK)
16:28:50  get_current_artwork → SAM-F0222   ← spurious one-off TV response
16:28:50  Triggering thumbnail fetch for SAM-F0222 (changed: True)
16:28:51  select_image/image_selected → SAM-S1110599  (TV self-corrects)
16:28:52  get_thumbnail_list SAM-F0222 → error
16:29:07  get_current_artwork → SAM-S1110599 (back to normal)
```

`SAM-F0222` was never selected (no `select_image` for it) — it's a transient glitch the Frame emits during matte/select operations. The integration exposed that single reading immediately, so HA **briefly flashed the wrong artwork** and fired a **wasted thumbnail fetch** that errored.

## Fix

A *changed* `content_id` is now **debounced**: it must be observed on two consecutive polls before it is trusted and exposed (`_confirm_content_id`). A single bad reading is held tentatively and discarded when the next poll disagrees — it never reaches HA or the thumbnail logic.

- First reading after startup is trusted immediately (nothing to protect).
- Steady-state and genuine changes are unaffected; during art activity polls are sub-second to a few seconds apart, so legitimate changes still appear promptly.
- Failed/empty polls don't disturb the trusted value.

Lint suite (`py_compile` / `black` / `isort` / `flake8`) green. Version bumped to **8.1.0b23**; release notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_