### PR TITLE
Fix regression: remote entity stops being recreated after restart (8.1.0b24)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,5 +1,23 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
+## Remote entity — fix regression where Home/Source/Power/Menu stopped working
+
+- **Remote entity silently stopped being (re)created after a restart**: 8.1.0b15
+  added a guard against a duplicate `remote.<tv>` entity (caused by a rapid
+  reload firing a stale 5s-delayed setup callback on top of the new one) by
+  checking the **entity registry** for an existing `remote` entry before
+  creating one. That check was wrong: the entity registry persists across full
+  Home Assistant restarts, so on the very first normal restart after updating,
+  it always found the previous session's registry entry and bailed out —
+  meaning the remote entity was never actually added again, for any TV, until
+  the integration happened to reload in a way that cleared it. This is what
+  broke the Home/Source/Power/Menu/d-pad commands (which go through the
+  `remote.<tv>` entity) starting at 8.1.0b15. Fixed by properly cancelling the
+  pending 5s callback on unload (`entry.async_on_unload`) instead of probing
+  the persistent registry — the original duplicate-add race is still
+  prevented, but normal restarts now recreate the remote entity correctly
+  every time.
+
 > **Status: pre-release (beta).** 8.1.0 builds on the stable 8.0.0 three-channel
 > rework with IP Control reliability and observability improvements.
 

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b23"
+  "version": "8.1.0b24"
 }

--- a/custom_components/samsungtv_smart/remote.py
+++ b/custom_components/samsungtv_smart/remote.py
@@ -13,9 +13,7 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
 from homeassistant.components.media_player.const import SERVICE_PLAY_MEDIA
-from homeassistant.components.remote import ATTR_NUM_REPEATS
-from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
-from homeassistant.components.remote import RemoteEntity
+from homeassistant.components.remote import ATTR_NUM_REPEATS, RemoteEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_SERVICE,
@@ -53,13 +51,7 @@ async def async_setup_entry(
         for tv_entity in tv_entries:
             if tv_entity.domain == MP_DOMAIN:
                 mp_entity_id = tv_entity.entity_id
-            elif tv_entity.domain == REMOTE_DOMAIN:
-                # A remote entity already exists for this entry. This callback is
-                # scheduled via async_call_later and is not cancelled on unload,
-                # so a rapid reload can fire a stale pending callback on top of
-                # the new setup's — adding a second remote with the same unique
-                # id ("does not generate unique IDs ... ignoring"). Skip it.
-                return
+                break
 
         if mp_entity_id is None:
             return
@@ -67,8 +59,15 @@ async def async_setup_entry(
         config = hass.data[DOMAIN][entry.entry_id][DATA_CFG]
         async_add_entities([SamsungTVRemote(config, entry.entry_id, mp_entity_id)])
 
-    # we wait for TV media player entity to be created
-    async_call_later(hass, 5, _add_remote_entity)
+    # We wait for the TV media player entity to be created. Cancel this pending
+    # callback on unload — otherwise a rapid reload fires the stale callback
+    # from the previous setup on top of the new one, registering a duplicate
+    # unique id ("does not generate unique IDs ... ignoring"). The entity
+    # registry is NOT a substitute check for this: it persists across full HA
+    # restarts, so probing it here used to make the remote entity silently
+    # never get (re)created after the very first restart.
+    cancel_add_remote_entity = async_call_later(hass, 5, _add_remote_entity)
+    entry.async_on_unload(cancel_add_remote_entity)
 
 
 class SamsungTVRemote(SamsungTVEntity, RemoteEntity):


### PR DESCRIPTION
## Problem

Preston reported (issue #72) that Home/Source/Power/Menu and the d-pad stopped working on all three of his TVs, and bisected it to **8.1.0b15** (commit `e3d27ea`, "Decouple REST port from WS/Art port; fix duplicate remote entity").

That commit added a guard against a duplicate `remote.<tv>` entity: a rapid reload could fire a stale 5s-delayed `_add_remote_entity` callback from the *previous* setup on top of the *new* one, registering the same unique id twice ("does not generate unique IDs ... ignoring"). The fix probed the **entity registry** — if a `remote` domain entry already existed for the config entry, skip creating a new one.

That check is wrong: the entity registry **persists across full HA restarts**, not just within a single running process. So on the very first normal restart after updating to b15, the guard always found the previous session's registry entry and returned early — `async_add_entities` was never called, and the remote entity silently stopped being (re)created. This is a permanent regression, not transient: every restart since b15 has had no working `remote.<tv>` entity, hence no Home/Source/Power/Menu (which route through it).

## Fix

Cancel the pending `async_call_later` callback on unload via `entry.async_on_unload(...)`, which is what actually prevents the original duplicate-add race (a stale callback from a prior setup firing after a rapid reload) — instead of probing the persistent entity registry. Normal restarts now recreate the remote entity correctly every time, since there's no stale pending callback for `async_on_unload` to need to suppress in that case.

Lint suite (`py_compile`/`black`/`isort`/`flake8`) green. Version bumped to **8.1.0b24**; release notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_