### PR TITLE
Confirm set_artmode via broadcast race instead of full timeout (8.1.0b25)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,5 +1,17 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
+## Art Mode — faster switch/media_player updates when toggling Art Mode
+
+- **`art_set_artmode`/the Art Mode switch could take up to 5s to confirm a
+  change**: some Frames (e.g. 2020/2021) never echo a matching response to
+  `set_artmode_status` — only an `art_mode_changed` broadcast confirms the
+  change, and that broadcast carries no request id, so it couldn't be matched
+  to the pending request and the call always waited out the full 5s timeout
+  before falling back to checking the broadcast-updated state. The wait now
+  races the direct response against that broadcast and returns as soon as
+  either confirms the requested state, instead of always paying the full
+  timeout.
+
 ## Remote entity — fix regression where Home/Source/Power/Menu stopped working
 
 - **Remote entity silently stopped being (re)created after a restart**: 8.1.0b15

--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -131,6 +131,11 @@ class SamsungTVAsyncArt:
 
         # Async handling
         self._pending_requests: dict[str, asyncio.Future] = {}
+        # set_artmode() waiters: some Frames never echo the matching
+        # request_id, only the art_mode_changed broadcast. Resolved as soon
+        # as that broadcast arrives, instead of always paying the full
+        # request timeout.
+        self._art_mode_broadcast_waiters: list[asyncio.Future] = []
         self._recv_task: asyncio.Task | None = None
         self._connected = False
 
@@ -615,6 +620,10 @@ class SamsungTVAsyncArt:
         elif sub_event == "art_mode_changed":
             self.art_mode = data.get("status") == "on"
             self._fire_art_event()
+            for future in self._art_mode_broadcast_waiters:
+                if not future.done():
+                    future.set_result(None)
+            self._art_mode_broadcast_waiters.clear()
         elif sub_event == "go_to_standby":
             # Ambiguous, not a definitive "art mode off": the panel also
             # fires this when it dims for its own power-save sleep timer
@@ -1262,23 +1271,53 @@ class SamsungTVAsyncArt:
         """Set art mode on or off."""
         if isinstance(mode, bool):
             mode = "on" if mode else "off"
-        data = await self._send_art_request(
-            {
-                "request": "set_artmode_status",
-                "value": mode,
-            }
-        )
-        if data is not None:
-            return True
-        # Fallback for older Frames (e.g. 2020/2021): these confirm the change
-        # by broadcasting an `art_mode_changed` event that carries no
-        # request_id, so it never matches the pending request and the send
-        # above times out even though the TV did switch. The event handler
-        # already updates self.art_mode from that broadcast, so trust it here
-        # rather than reporting a false failure. If the TV genuinely did not
-        # change, self.art_mode won't match the requested state and we still
-        # return False — so the success path is unchanged.
         desired = mode == "on"
+
+        # Some Frames (e.g. 2020/2021) never echo the matching request_id for
+        # set_artmode_status, only the art_mode_changed broadcast — and that
+        # broadcast carries no request_id either, so it can't be awaited via
+        # _send_art_request's normal matching. Race both: whichever confirms
+        # first (the direct response, or the broadcast updating self.art_mode)
+        # wins, instead of always paying the full request timeout.
+        broadcast_future = asyncio.get_event_loop().create_future()
+        self._art_mode_broadcast_waiters.append(broadcast_future)
+        request_task = asyncio.ensure_future(
+            self._send_art_request(
+                {
+                    "request": "set_artmode_status",
+                    "value": mode,
+                }
+            )
+        )
+        try:
+            done, _ = await asyncio.wait(
+                {request_task, broadcast_future},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if request_task in done and request_task.result() is not None:
+                return True
+            if self.art_mode == desired:
+                if broadcast_future in done:
+                    self._log.debug(
+                        "Art API: set_artmode(%s) confirmed early by an "
+                        "art_mode_changed broadcast",
+                        mode,
+                    )
+                return True
+            if request_task not in done:
+                await request_task
+                if request_task.result() is not None:
+                    return True
+        finally:
+            if broadcast_future in self._art_mode_broadcast_waiters:
+                self._art_mode_broadcast_waiters.remove(broadcast_future)
+            if not request_task.done():
+                request_task.cancel()
+
+        # Final fallback: the request timed out and no broadcast arrived in
+        # time either. If the TV's state already matches what we asked for
+        # (e.g. a late broadcast resolved it after our wait above), treat it
+        # as success; otherwise report a genuine failure.
         if self.art_mode == desired:
             self._log.debug(
                 "Art API: set_artmode(%s) timed out, but an art_mode_changed "

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b24"
+  "version": "8.1.0b25"
 }


### PR DESCRIPTION
## Summary
- Some Frames (2020/2021) never echo a matching response to `set_artmode_status` — only an `art_mode_changed` broadcast (no request id) confirms the change. Previously, `set_artmode()` always waited out the full 5s request timeout before falling back to checking that broadcast-updated state, making the Art Mode switch / media_player card feel slow to update.
- Now races the direct response against the broadcast and returns as soon as either confirms the requested state.

## Test plan
- [ ] Confirmed against logs showing `set_artmode(on) timed out, but an art_mode_changed broadcast confirms state=True` previously taking ~5s; verify confirmation now arrives as soon as the broadcast fires
- [ ] No regression on TVs that do echo the matching response (should still confirm immediately via that path)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_