### PR TITLE
Expose config_entry_id attribute and clean up stale oauth issues (8.1.0b26)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,5 +1,23 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
+## Diagnostics — easier troubleshooting of automations/scripts referencing a config entry
+
+- **New `config_entry_id` attribute on the media_player entity**: automations
+  or scripts that call `homeassistant.reload_config_entry` (or any other
+  entry_id-keyed service) directly can silently target a stale entry_id after
+  a TV is re-paired, with no obvious link back to the entity from the
+  resulting error. The current entry_id is now exposed as a state attribute,
+  so it can be checked directly from the entity instead of pulling a full
+  diagnostics dump.
+- **Stale `oauth_auth_failed_<entry_id>` Repairs issues no longer outlive their
+  config entry**: this issue is normally cleared automatically once a
+  SmartThings OAuth refresh succeeds again, but that only happens through the
+  entity that raised it. If the entry is removed (e.g. re-paired as a new
+  entry after the old one stopped refreshing), nothing ever clears the old
+  issue again — it just sits in the issue registry indefinitely, surviving
+  even after the user dismisses it in the UI. It's now deleted when its
+  config entry is removed.
+
 ## Art Mode — faster switch/media_player updates when toggling Art Mode
 
 - **`art_set_artmode`/the Art Mode switch could take up to 5s to confirm a

--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -38,10 +38,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.helpers.typing import ConfigType
 

--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -41,6 +41,7 @@ from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.helpers.typing import ConfigType
 
@@ -1098,6 +1099,13 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
         hass.data[DOMAIN].pop(entry.entry_id, None)
         if not hass.data[DOMAIN]:
             hass.data.pop(DOMAIN)
+    # The entry is gone for good (unlike unload/reload), so any Repairs issue
+    # keyed to its entry_id (e.g. oauth_auth_failed_<entry_id>) can never be
+    # cleared by a future successful refresh on this entry — nothing will ever
+    # call _clear_oauth_issue() for it again. Without this, dismissing the
+    # issue in the UI only hides it; the registry entry itself outlives the
+    # entry it refers to and clutters diagnostics indefinitely.
+    ir.async_delete_issue(hass, DOMAIN, f"oauth_auth_failed_{entry.entry_id}")
 
 
 # Options whose change adds/removes platforms or clients and therefore needs a

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b25"
+  "version": "8.1.0b26"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -183,6 +183,7 @@ ART_MODE_MEDIA_TITLE = "Art Mode"
 ATTR_IP_ADDRESS = "ip_address"
 ATTR_PICTURE_MODE = "picture_mode"
 ATTR_PICTURE_MODE_LIST = "picture_mode_list"
+ATTR_CONFIG_ENTRY_ID = "config_entry_id"
 
 CMD_OPEN_BROWSER = "open_browser"
 CMD_RUN_APP = "run_app"
@@ -2278,7 +2279,11 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
     @property
     def extra_state_attributes(self):
         """Return the optional state attributes."""
-        data = {ATTR_IP_ADDRESS: self._host}
+        # Surfaced mainly for troubleshooting: automations/scripts that
+        # reference a config entry directly (e.g. homeassistant.reload_config_entry)
+        # silently break after a re-pairing changes the entry_id, with no
+        # obvious link back to this entity from the error alone.
+        data = {ATTR_IP_ADDRESS: self._host, ATTR_CONFIG_ENTRY_ID: self._entry_id}
 
         # Art Mode status: delegate to _art_mode_is_on(), the single source of
         # truth (it layers IP Control cache → REST PowerState='standby' →


### PR DESCRIPTION
## Summary
- media_player now exposes `config_entry_id` as a state attribute — useful for troubleshooting automations/scripts that hardcode an entry_id (e.g. `homeassistant.reload_config_entry`) and silently break after a re-pairing changes it.
- `async_remove_entry` now deletes any `oauth_auth_failed_<entry_id>` Repairs issue for the removed entry. Previously this issue was only ever cleared by a *successful OAuth refresh on that same entity* — if the entry was removed/re-paired instead, the issue stayed in the registry indefinitely (even after being dismissed in the UI), cluttering diagnostics.

## Test plan
- [ ] Confirm `config_entry_id` shows up in the media_player's state attributes
- [ ] Remove a config entry that has an active `oauth_auth_failed_<entry_id>` issue and confirm it's deleted from Settings → Repairs / the issue registry


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_