### PR TITLE
Treat IP Control transport failures as powered-off, not ERROR (8.1.0b27)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,5 +1,20 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
+## IP Control — no more ERROR spam when the TV is simply off
+
+- **Transport-layer failures on the IP Control port are no longer logged as
+  ERROR**: on Frames that drop off the network entirely when powered off
+  (notably the 2020/2021 sets), a state read fails with `Host is unreachable`
+  / `timed out` / `Connection refused` — which is indistinguishable from "the
+  TV is simply off". The state coordinator already returns a quiet
+  `powered_off` snapshot once it knows the TV is off, but when the very probe
+  used to learn that can't reach the TV, the transport failure used to
+  surface as a recurring `ERROR ... IP Control state read failed`. These
+  network-layer failures are now treated like a powered-off snapshot (the
+  state sensors go *unavailable*, logged at DEBUG) instead of an update
+  failure. Genuine application errors (bad picture mode, malformed responses,
+  token rejection) are unaffected and still surface as before.
+
 ## Diagnostics — easier troubleshooting of automations/scripts referencing a config entry
 
 - **New `config_entry_id` attribute on the media_player entity**: automations

--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -84,6 +84,16 @@ class SamsungIPControlModeLockedError(SamsungIPControlError):
     """
 
 
+class SamsungIPControlTransportError(SamsungIPControlError):
+    """Network-layer failure reaching the TV (timeout, host unreachable, etc).
+
+    Distinct from an application-level error: on many Frames (notably the
+    2020/2021 sets) the TV drops off the network entirely when powered off,
+    so a transport failure on the IP Control port is indistinguishable from
+    "the TV is simply off" and should not be treated as a hard error.
+    """
+
+
 class SamsungIPControl:
     """Minimal async client for the Samsung IP Control JSON-RPC interface."""
 
@@ -518,7 +528,7 @@ class SamsungIPControl:
                     f"TLS error talking to {self._host}:{self._port}: {ex}"
                 ) from ex
             except (TimeoutError, OSError) as ex:
-                raise SamsungIPControlError(
+                raise SamsungIPControlTransportError(
                     f"transport failure talking to {self._host}:{self._port}: {ex}"
                 ) from ex
             finally:

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b26"
+  "version": "8.1.0b27"
 }

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -43,6 +43,7 @@ from .api.ipcontrol import (
     SamsungIPControl,
     SamsungIPControlAuthError,
     SamsungIPControlError,
+    SamsungIPControlTransportError,
 )
 from .const import (
     CONF_API_KEY,
@@ -2144,6 +2145,20 @@ class IPControlStateCoordinator(DataUpdateCoordinator):
                 self._device_title(),
             )
             raise UpdateFailed(f"IP Control token rejected: {ex}") from ex
+        except SamsungIPControlTransportError as ex:
+            # A network-layer failure (timeout, host unreachable, connection
+            # refused) is indistinguishable from "the TV is simply off" on the
+            # Frames that drop off the network when powered down — and the
+            # power-state probe above raises this very error when it can't
+            # reach the TV to learn it's off in the first place. Treat it like
+            # a powered-off snapshot (sensors go unavailable, no ERROR) instead
+            # of UpdateFailed, which would log an ERROR on every off streak for
+            # a perfectly normal condition. Genuine application errors still
+            # fall through to the UpdateFailed branch below.
+            self._log.debug(
+                "IP Control state: transport failure (TV likely off): %s", ex
+            )
+            return {"tv": {}, "video": {}, "powered_off": True}
         except SamsungIPControlError as ex:
             raise UpdateFailed(f"IP Control state read failed: {ex}") from ex
 


### PR DESCRIPTION
## Summary
Addresses Preston's report (#72) that the IP Control state sensors log recurring `ERROR ... Host is unreachable` / `timed out` **mainly when the TV is off**.

On Frames that drop off the network entirely when powered down (notably 2020/2021 sets), a state read fails at the transport layer — which is indistinguishable from "the TV is simply off". The coordinator already returns a quiet `powered_off` snapshot once it *knows* the TV is off, but the very power-state probe used to learn that raises the transport error when it can't reach the TV, so the failure surfaced as a recurring ERROR.

- New `SamsungIPControlTransportError` subclass for network-layer failures (timeout / host unreachable / connection refused).
- The state coordinator now treats it like a `powered_off` snapshot (sensors go *unavailable*, logged at DEBUG) instead of `UpdateFailed`/ERROR.
- Genuine application errors (bad picture mode `-32002`, malformed responses, token rejection) are unaffected and still surface as before.

## Test plan
- [ ] Power off a 2020/2021 Frame and confirm no `ERROR ... IP Control state read failed` lines appear, only DEBUG
- [ ] Confirm the IP Control state sensors still go *unavailable* while off
- [ ] Confirm a genuine error (e.g. `-32002` picture mode) still logs as before


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_