### PR TITLE
Folder Gallery card: support modern perform_action syntax (8.1.0b29)

### DIFF
--- a/Frame_Art_Gallery.md
+++ b/Frame_Art_Gallery.md
@@ -192,7 +192,6 @@ When you click an image and open the lightbox, the card automatically shows cont
 type: custom:folder-gallery-card
 title: Frame TV Favorites
 folder_sensor: sensor.store
-folder: /local/frame_art/store
 columns: 4
 image_height: 160px
 aspect_ratio: "1"
@@ -205,13 +204,23 @@ action:
     content_id: "{{content_id}}"
 ```
 
+> **Note:** with a `folder_sensor` (a `platform: folder` sensor whose `path` is
+> under `/config/www/`), the card derives the `/local/...` URL automatically, so
+> a separate `folder:` line is **not** needed. Only set `folder:` explicitly if
+> your files live somewhere the card can't derive (a path outside
+> `/config/www/`).
+>
+> The action also accepts the modern syntax — `perform_action:` instead of
+> `service:`, or an object-form `tap_action:` — in addition to the legacy
+> `action: { service: ... }` shown above.
+
 ### All Configuration Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `title` | string | - | Card title |
 | `folder_sensor` | string | - | Folder sensor entity ID |
-| `folder` | string | - | Base folder path (e.g., `/local/frame_art/store`) |
+| `folder` | string | *(auto)* | Base folder path (e.g., `/local/frame_art/store`). Optional — auto-derived from `folder_sensor`'s `path` when it's under `/config/www/`. Only needed for paths the card can't derive. |
 | `columns` | number | `4` | Number of columns |
 | `image_height` | string | `150px` | Image height (ignored if `aspect_ratio` set) |
 | `aspect_ratio` | string | - | Aspect ratio (e.g., `1`, `16/9`, `3/4`) |

--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,5 +1,17 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
+## Folder Gallery card — support the modern `perform_action:` syntax
+
+- **The gallery card's tap action now accepts the modern action syntax**: it
+  used to only understand the legacy `action: { service: ... }` shape and
+  silently did nothing with the newer `perform_action:` key or an object-form
+  `tap_action:` (e.g. `{action: perform-action, perform_action: ...}`). Both
+  forms now work, alongside the legacy one which keeps working unchanged.
+- **Docs: `folder:` is optional** — when a `folder_sensor` (a `platform: folder`
+  sensor) reports a `path` under `/config/www/`, the card derives the
+  `/local/...` URL automatically, so the separate `folder:` line is redundant.
+  Clarified in the gallery docs and removed from the basic example.
+
 ## Services — proper entity target (`target:`) instead of an `entity_id` data field
 
 - **All services now declare a `target:` selector** instead of listing

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b28"
+  "version": "8.1.0b29"
 }

--- a/custom_components/samsungtv_smart/www/folder-gallery-card.js
+++ b/custom_components/samsungtv_smart/www/folder-gallery-card.js
@@ -678,12 +678,33 @@ class FolderGalleryCard extends HTMLElement {
   handleClick(e, item) {
     const index = parseInt(item.dataset.index);
     const imageData = this._images[index];
-    
+
+    // Modern object-form tap_action, e.g.
+    //   tap_action:
+    //     action: perform-action      # (or the legacy call-service)
+    //     perform_action: samsungtv_smart.art_select_image
+    //     target: {...}
+    //     data: {...}
+    // HA's own cards accept this shape; handle it here so the new syntax works
+    // instead of silently doing nothing (the dispatcher used to only read the
+    // legacy `action: { service: ... }` block).
+    const tapAction = this._config.tap_action;
+    if (tapAction && typeof tapAction === 'object') {
+      if (tapAction.action === 'more-info' && this._config.entity) {
+        this.fireEvent('hass-more-info', { entityId: this._config.entity });
+      } else if (tapAction.action === 'none') {
+        // explicitly do nothing
+      } else {
+        this.executeAction(imageData, tapAction);
+      }
+      return;
+    }
+
     // If tap_action is 'lightbox' or not defined with action, show lightbox
-    if (this._config.tap_action === 'lightbox' || 
+    if (this._config.tap_action === 'lightbox' ||
         (!this._config.tap_action && this._config.action)) {
       this.openLightbox(imageData);
-    } 
+    }
     // Direct action on tap
     else if (this._config.tap_action === 'action' || this._config.action) {
       this.executeAction(imageData);
@@ -709,7 +730,9 @@ class FolderGalleryCard extends HTMLElement {
   executeAction(imageData, actionConfig = null) {
     const action = actionConfig || this._config.action;
     if (!action || !this._hass) return;
-    if (!action.service) return;
+    // Accept both the legacy `service:` key and the modern `perform_action:`
+    // key (HA renamed call-service -> perform-action).
+    if (!action.service && !action.perform_action) return;
 
     // Multi-frame upload routing.
     // When the action is an upload, the gallery points at a local photo
@@ -729,9 +752,9 @@ class FolderGalleryCard extends HTMLElement {
   }
 
   _dispatchAction(imageData, action, entityOverride = null) {
-    if (!action || !this._hass || !action.service) return Promise.resolve();
+    const service = action ? (action.service || action.perform_action) : null;
+    if (!action || !this._hass || !service) return Promise.resolve();
 
-    const service = action.service;
     const [domain, serviceName] = service.split('.');
 
     // Build service data with template substitution
@@ -788,7 +811,7 @@ class FolderGalleryCard extends HTMLElement {
   }
 
   _isUploadAction(action) {
-    const svc = (action.service || '').toLowerCase();
+    const svc = (action.service || action.perform_action || '').toLowerCase();
     if (svc.endsWith('art_upload')) return true;
     // Generic heuristic: an upload-style action carries a file_path payload.
     return !!(action.data && Object.prototype.hasOwnProperty.call(action.data, 'file_path'));


### PR DESCRIPTION
## Summary
Follow-up to #94 (Preston). The `folder-gallery-card` tap action did nothing with the modern `perform_action:` syntax — its dispatcher only read the legacy `action: { service: ... }` shape and bailed out when `service:` was missing. That's why `tap_action: { action: perform-action, perform_action: ... }` silently failed on his cards while the legacy form worked.

- `_dispatchAction` / `executeAction` / `_isUploadAction` now accept `perform_action` as an alias for `service`.
- `handleClick` now handles an **object-form** `tap_action:` (e.g. `{action: perform-action, perform_action: ..., target:, data:}`), routing `more-info`/`none` appropriately.
- Legacy `action: { service: ... }` keeps working unchanged.
- Docs: clarified that `folder:` is **optional** — auto-derived from `folder_sensor`'s `path` when under `/config/www/` (Preston's second observation) — and dropped the redundant line from the basic example.

Note: the divergent stale copy under `www/community/folder-gallery-card/` (not the one the integration serves) was left untouched.

## Test plan
- [ ] In a `custom:folder-gallery-card`, use `tap_action: { action: perform-action, perform_action: samsungtv_smart.art_select_image, target:, data: }` and confirm the artwork is selected (previously did nothing)
- [ ] Confirm the legacy `tap_action: action` + `action: { service: ... }` still works
- [ ] Confirm a config with only `folder_sensor` (no `folder:`) still renders the gallery


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_