### PR TITLE
Folder Gallery: fix /config/www thumbnails + clarify folder: vs sensor (8.1.0b31)

### DIFF
--- a/Frame_Art_Gallery.md
+++ b/Frame_Art_Gallery.md
@@ -137,8 +137,10 @@ so you can point the card straight at them with **no manual configuration**:
 ```yaml
 type: custom:folder-gallery-card
 folder_sensor: sensor.mastertv_store
-folder: /local/frame_art/YOUR_ENTRY_ID/store
 ```
+
+(No `folder:` line needed — see [the note below](#basic-configuration) on what
+`folder:` is actually for.)
 
 **Legacy / optional:** if you prefer the built-in Home Assistant `folder`
 platform (for example to watch a custom directory the integration doesn't
@@ -204,15 +206,23 @@ action:
     content_id: "{{content_id}}"
 ```
 
-> **Where do the images come from?** The *list* of images always comes from a
-> `folder_sensor` / `sensor` (a `platform: folder` sensor) or from `image_list`.
-> A browser can't enumerate a directory from a URL, so **`folder:` on its own
-> shows nothing** — it only supplies the base URL the thumbnails are loaded
-> from. With a folder sensor whose `path` is under `/config/www/`, the card
-> derives that `/local/...` URL automatically, so a separate `folder:` line
-> isn't needed. Set `folder:` only to override it; you can give it as a
-> `/local/...` URL or a `/config/www/...` path (both are accepted — the latter
-> is mapped to `/local/...` for you).
+> **What does `folder:` actually do? (usually: nothing you need to set)**
+>
+> The **image list** always comes from the `folder_sensor` / `sensor` (a
+> `platform: folder` sensor) or from `image_list`. A browser can't list a
+> directory from a URL, so `folder:` is *only* the base URL prepended to each
+> filename to build the thumbnail `<img>` src — it never produces the list
+> itself.
+>
+> - **Folder sensor under `/config/www/`** (the normal case): the card derives
+>   the `/local/...` URL automatically from the sensor's `path`, so you **don't
+>   need `folder:` at all**. That's why the examples omit it.
+> - **Set `folder:` only when the card can't derive the URL** — files served
+>   from outside `/config/www/`, or a custom/template sensor whose `file_list`
+>   has bare filenames and no `path`. Give a `/local/...` URL (a
+>   `/config/www/...` path is also accepted and mapped to `/local/...`).
+> - **`folder:` with no sensor and no `image_list` → empty gallery.** On its own
+>   it can't list any files.
 >
 > The action also accepts the modern syntax — `perform_action:` instead of
 > `service:`, or an object-form `tap_action:` — in addition to the legacy

--- a/Frame_Art_Gallery.md
+++ b/Frame_Art_Gallery.md
@@ -204,11 +204,15 @@ action:
     content_id: "{{content_id}}"
 ```
 
-> **Note:** with a `folder_sensor` (a `platform: folder` sensor whose `path` is
-> under `/config/www/`), the card derives the `/local/...` URL automatically, so
-> a separate `folder:` line is **not** needed. Only set `folder:` explicitly if
-> your files live somewhere the card can't derive (a path outside
-> `/config/www/`).
+> **Where do the images come from?** The *list* of images always comes from a
+> `folder_sensor` / `sensor` (a `platform: folder` sensor) or from `image_list`.
+> A browser can't enumerate a directory from a URL, so **`folder:` on its own
+> shows nothing** — it only supplies the base URL the thumbnails are loaded
+> from. With a folder sensor whose `path` is under `/config/www/`, the card
+> derives that `/local/...` URL automatically, so a separate `folder:` line
+> isn't needed. Set `folder:` only to override it; you can give it as a
+> `/local/...` URL or a `/config/www/...` path (both are accepted — the latter
+> is mapped to `/local/...` for you).
 >
 > The action also accepts the modern syntax — `perform_action:` instead of
 > `service:`, or an object-form `tap_action:` — in addition to the legacy
@@ -220,7 +224,7 @@ action:
 |--------|------|---------|-------------|
 | `title` | string | - | Card title |
 | `folder_sensor` | string | - | Folder sensor entity ID |
-| `folder` | string | *(auto)* | Base folder path (e.g., `/local/frame_art/store`). Optional — auto-derived from `folder_sensor`'s `path` when it's under `/config/www/`. Only needed for paths the card can't derive. |
+| `folder` | string | *(auto)* | Base **URL** for thumbnails (e.g., `/local/frame_art/store`). Optional — auto-derived from `folder_sensor`'s `path` when under `/config/www/`. Does **not** provide the image list (a sensor or `image_list` does). A `/config/www/...` value is accepted and mapped to `/local/...`. |
 | `columns` | number | `4` | Number of columns |
 | `image_height` | string | `150px` | Image height (ignored if `aspect_ratio` set) |
 | `aspect_ratio` | string | - | Aspect ratio (e.g., `1`, `16/9`, `3/4`) |

--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,5 +1,18 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
+## Folder Gallery card — explicit `folder:` as a `/config/www/...` path no longer breaks thumbnails
+
+- **An explicitly-set `folder:` given as a filesystem path** (e.g.
+  `/config/www/media/Photos`) now resolves correctly: the card maps
+  `/config/www/...` → `/local/...` (the URL Home Assistant actually serves),
+  so thumbnails load instead of all showing as broken images. Previously this
+  mapping was only applied to the path auto-derived from a folder sensor, not
+  to a `folder:` typed by the user.
+- **Docs clarified**: `folder:` only supplies the base URL for thumbnails — the
+  image *list* always comes from a `folder_sensor` / `sensor` or `image_list`.
+  `folder:` on its own shows nothing (a browser can't list a directory from a
+  URL).
+
 ## Folder Gallery card — support the modern `perform_action:` syntax
 
 - **The gallery card's tap action now accepts the modern action syntax**: it

--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -12,6 +12,11 @@
   image *list* always comes from a `folder_sensor` / `sensor` or `image_list`.
   `folder:` on its own shows nothing (a browser can't list a directory from a
   URL).
+- **Visual editor is clearer about `folder:`**: the Sensor field now comes first
+  and is labelled as the required source of the image list; the Folder Path
+  field is marked optional with an inline hint explaining it's auto-detected
+  from the sensor (and shows nothing on its own). Saves the common confusion of
+  setting only a folder path and getting an empty gallery.
 
 ## Folder Gallery card — support the modern `perform_action:` syntax
 

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b29"
+  "version": "8.1.0b30"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b30"
+  "version": "8.1.0b31"
 }

--- a/custom_components/samsungtv_smart/www/folder-gallery-card.js
+++ b/custom_components/samsungtv_smart/www/folder-gallery-card.js
@@ -113,6 +113,13 @@ class FolderGalleryCard extends HTMLElement {
     // If neither yields a usable URL, `folder` stays empty and per-image
     // fallbacks may apply below (image_list with absolute URLs, etc.).
     let folder = (this._config.folder || '').replace(/\/+$/, '');
+    // An explicitly-set folder may be given as a filesystem path
+    // (/config/www/...) rather than the browser URL (/local/...). HA serves
+    // /config/www/ at /local/, so map it — otherwise the <img> src points at a
+    // path the browser can't fetch and every thumbnail breaks.
+    if (folder.startsWith('/config/www/')) {
+      folder = folder.replace(/^\/config\/www\//, '/local/');
+    }
     if (!folder) {
       const sensorEntity = this._config.folder_sensor || this._config.sensor;
       if (sensorEntity) {

--- a/custom_components/samsungtv_smart/www/folder-gallery-card.js
+++ b/custom_components/samsungtv_smart/www/folder-gallery-card.js
@@ -984,23 +984,36 @@ class FolderGalleryCardEditor extends HTMLElement {
           background: var(--card-background-color);
           color: var(--primary-text-color);
         }
+        .form-row .hint {
+          display: block;
+          margin-top: 4px;
+          font-size: 0.8em;
+          font-weight: normal;
+          color: var(--secondary-text-color);
+        }
       </style>
-      
+
       <div class="form-row">
         <label>Title</label>
         <input type="text" id="title" value="${this._config.title || ''}">
       </div>
-      
+
       <div class="form-row">
-        <label>Folder Path</label>
-        <input type="text" id="folder" value="${this._config.folder || ''}" placeholder="/local/images">
-      </div>
-      
-      <div class="form-row">
-        <label>Sensor (provides image list)</label>
+        <label>Sensor (provides the image list)</label>
         <input type="text" id="folder_sensor" value="${this._config.folder_sensor || this._config.sensor || ''}" placeholder="sensor.your_folder_sensor">
+        <span class="hint">Required — a <code>platform: folder</code> sensor (e.g. <code>sensor.&lt;tv&gt;_store</code>). This is what lists the images.</span>
       </div>
-      
+
+      <div class="form-row">
+        <label>Folder Path (optional)</label>
+        <input type="text" id="folder" value="${this._config.folder || ''}" placeholder="auto-detected from the sensor">
+        <span class="hint">${
+          (this._config.folder_sensor || this._config.sensor)
+            ? 'Auto-detected from the sensor — leave empty unless your files are outside <code>/config/www/</code>.'
+            : 'Only the base URL for thumbnails — it does <b>not</b> list images. On its own it shows nothing; set a sensor above.'
+        }</span>
+      </div>
+
       <div class="form-row">
         <label>Columns</label>
         <input type="number" id="columns" value="${this._config.columns || 4}" min="1" max="10">


### PR DESCRIPTION
## Summary
Follow-up to #94. Two related improvements around the `folder-gallery-card`.

**1. Fix broken thumbnails when `folder:` is a `/config/www/...` path (b30)**
When `folder:` was set explicitly to a filesystem path (e.g. `/config/www/media/Photos`), the card used it verbatim as the thumbnail URL prefix, so every `<img>` pointed at `/config/www/...` — which the browser can't fetch — and all thumbnails broke (count correct, none rendered). The card now maps an explicit `folder:` under `/config/www/` → `/local/`, the same normalization already applied to a sensor-derived path.

**2. Clarify what `folder:` is for, in the editor and docs (b31)**
The confusion: `folder:` does *not* list images — the list always comes from a `folder_sensor` / `sensor` or `image_list`. `folder:` is only the base URL for thumbnails, and is auto-derived from the sensor under `/config/www/`, so it's usually not needed at all. `folder:` alone → empty gallery.
- Visual editor: Sensor field now comes first, labelled as the required image-list source; Folder Path marked optional with an inline hint (auto-detected from sensor; shows nothing on its own).
- Docs (`Frame_Art_Gallery.md`): restructured note + options table spelling this out; dropped the redundant `folder:` from examples.

Note: the divergent stale copy under `www/community/folder-gallery-card/` (not served by the integration) was left untouched.

## Test plan
- [ ] `sensor: sensor.photos` + `folder: /config/www/media/Photos` → thumbnails load (previously broken)
- [ ] `sensor: sensor.photos` + no `folder:` → still works (auto-derived)
- [ ] `folder: /local/media/Photos` → unchanged, still works
- [ ] Visual editor shows Sensor first with hints; folder-only config makes the "shows nothing" hint appear
