### PR TITLE
Folder Gallery: reliable long-press + new double_tap_action (8.1.0b33)

### DIFF
--- a/Frame_Art_Gallery.md
+++ b/Frame_Art_Gallery.md
@@ -242,7 +242,8 @@ action:
 | `border_radius` | string | `8px` | Image border radius |
 | `show_filename` | boolean | `true` | Show filename on hover |
 | `filter` | string | `*` | File filter pattern |
-| `tap_action` | string/object | - | Action on tap |
+| `tap_action` | string/object | - | Action on single tap (e.g. `lightbox`, or a service/perform-action object) |
+| `double_tap_action` | object | - | Action on double tap (e.g. select the artwork directly). When set, a single tap is delayed slightly to detect the double tap. |
 | `hold_action` | object | - | Action on long press |
 | `action` | object | - | Default action (used by lightbox Select button) |
 
@@ -253,6 +254,32 @@ action:
 | `lightbox` | Open image in fullscreen lightbox with smart action buttons |
 | `action` | Execute the configured action directly |
 | `more-info` | Show entity more-info dialog |
+
+### Example: tap = preview, double-tap = select, hold = select
+
+```yaml
+type: custom:folder-gallery-card
+title: Gallery Personal
+folder_sensor: sensor.samsung_hacs_personal
+columns: 4
+aspect_ratio: "1"
+tap_action: lightbox          # single tap → open the preview
+double_tap_action:            # double tap → display the artwork on the TV
+  perform_action: samsungtv_smart.art_select_image
+  target:
+    entity_id: media_player.samsung_hacs
+  data:
+    content_id: "{{content_id}}"
+hold_action:                  # long press → display the artwork on the TV
+  perform_action: samsungtv_smart.art_select_image
+  target:
+    entity_id: media_player.samsung_hacs
+  data:
+    content_id: "{{content_id}}"
+```
+
+> When `double_tap_action` is set, a single tap is held back briefly (~250 ms)
+> to tell the two apart, so `tap_action` fires a touch later than usual.
 
 ### Template Variables
 

--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,5 +1,15 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
+## Folder Gallery card — `hold_action` now works on touch
+
+- **Long-press (`hold_action`) is detected reliably and no longer opens the
+  lightbox on release**: the card used to bind the hold to the `contextmenu`
+  event, which doesn't fire consistently on touch / the Companion app, and the
+  trailing `click` then triggered `tap_action` (e.g. the lightbox) anyway. Hold
+  detection now uses a pointer timer (with a small movement tolerance so a
+  scroll isn't mistaken for a press) and swallows the click that follows a
+  fired long-press, so `hold_action` runs on its own.
+
 ## Folder Gallery card — explicit `folder:` as a `/config/www/...` path no longer breaks thumbnails
 
 - **An explicitly-set `folder:` given as a filesystem path** (e.g.

--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,5 +1,13 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
+## Folder Gallery card — new `double_tap_action`
+
+- **The gallery card now supports `double_tap_action`** (HA's standard action
+  option), so you can wire e.g. single tap → lightbox preview, double tap →
+  display the artwork on the TV, and long press → display too. When a
+  `double_tap_action` is configured, a single tap is delayed briefly (~250 ms)
+  to tell the two apart; without it, single taps stay instant.
+
 ## Folder Gallery card — `hold_action` now works on touch
 
 - **Long-press (`hold_action`) is detected reliably and no longer opens the

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b31"
+  "version": "8.1.0b32"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b32"
+  "version": "8.1.0b33"
 }

--- a/custom_components/samsungtv_smart/www/folder-gallery-card.js
+++ b/custom_components/samsungtv_smart/www/folder-gallery-card.js
@@ -558,10 +558,64 @@ class FolderGalleryCard extends HTMLElement {
       </div>
     `;
 
-    // Add click handlers
+    // Add click + long-press handlers.
+    // Long-press is detected with a pointer timer rather than the `contextmenu`
+    // event: contextmenu doesn't fire reliably on touch / the HA Companion app,
+    // and a `click` always follows the release — which used to open the lightbox
+    // (tap_action) on top of, or instead of, the hold_action. Here a fired
+    // long-press swallows that trailing click.
+    const LONG_PRESS_MS = 500;
+    const MOVE_TOLERANCE = 10;
     container.querySelectorAll('.gallery-item').forEach(item => {
-      item.addEventListener('click', (e) => this.handleClick(e, item));
-      item.addEventListener('contextmenu', (e) => this.handleHold(e, item));
+      let pressTimer = null;
+      let holdFired = false;
+      let startX = 0;
+      let startY = 0;
+
+      const clearTimer = () => {
+        if (pressTimer) {
+          clearTimeout(pressTimer);
+          pressTimer = null;
+        }
+      };
+
+      item.addEventListener('pointerdown', (e) => {
+        holdFired = false;
+        startX = e.clientX;
+        startY = e.clientY;
+        clearTimer();
+        pressTimer = setTimeout(() => {
+          holdFired = true;
+          this.handleHold(e, item);
+        }, LONG_PRESS_MS);
+      });
+
+      item.addEventListener('pointermove', (e) => {
+        // Treat a finger/cursor drag as a scroll, not a press.
+        if (Math.abs(e.clientX - startX) > MOVE_TOLERANCE ||
+            Math.abs(e.clientY - startY) > MOVE_TOLERANCE) {
+          clearTimer();
+        }
+      });
+
+      ['pointerup', 'pointerleave', 'pointercancel'].forEach((evt) =>
+        item.addEventListener(evt, clearTimer));
+
+      item.addEventListener('click', (e) => {
+        if (holdFired) {
+          // A long-press already handled this interaction; swallow the click so
+          // tap_action (e.g. lightbox) doesn't also fire on release.
+          e.preventDefault();
+          e.stopPropagation();
+          holdFired = false;
+          return;
+        }
+        this.handleClick(e, item);
+      });
+
+      // Suppress the native context menu on long-press / right-click so it
+      // doesn't interrupt the hold.
+      item.addEventListener('contextmenu', (e) => e.preventDefault());
     });
   }
 

--- a/custom_components/samsungtv_smart/www/folder-gallery-card.js
+++ b/custom_components/samsungtv_smart/www/folder-gallery-card.js
@@ -59,6 +59,7 @@ class FolderGalleryCard extends HTMLElement {
       action: config.action || null,
       tap_action: config.tap_action || null,
       hold_action: config.hold_action || null,
+      double_tap_action: config.double_tap_action || null,
       sensor: config.sensor || null, // Sensor that provides image list
       image_list: config.image_list || null, // Static list of images
       ...config
@@ -566,11 +567,14 @@ class FolderGalleryCard extends HTMLElement {
     // long-press swallows that trailing click.
     const LONG_PRESS_MS = 500;
     const MOVE_TOLERANCE = 10;
+    const DOUBLE_TAP_MS = 250;
+    const hasDoubleTap = !!this._config.double_tap_action;
     container.querySelectorAll('.gallery-item').forEach(item => {
       let pressTimer = null;
       let holdFired = false;
       let startX = 0;
       let startY = 0;
+      let clickTimer = null;
 
       const clearTimer = () => {
         if (pressTimer) {
@@ -610,7 +614,26 @@ class FolderGalleryCard extends HTMLElement {
           holdFired = false;
           return;
         }
-        this.handleClick(e, item);
+
+        // Without a double_tap_action, fire the single tap immediately (no
+        // added latency). With one configured, debounce: a second click within
+        // the window is a double tap; otherwise the single tap fires on timeout.
+        if (!hasDoubleTap) {
+          this.handleClick(e, item);
+          return;
+        }
+
+        if (clickTimer) {
+          clearTimeout(clickTimer);
+          clickTimer = null;
+          this.executeAction(this._images[parseInt(item.dataset.index)],
+                             this._config.double_tap_action);
+        } else {
+          clickTimer = setTimeout(() => {
+            clickTimer = null;
+            this.handleClick(e, item);
+          }, DOUBLE_TAP_MS);
+        }
       });
 
       // Suppress the native context menu on long-press / right-click so it


### PR DESCRIPTION
## Summary
Two gallery interaction improvements (found while testing the modern `perform_action:` syntax).

**1. `hold_action` now works on touch (b32)**
The card bound the hold to the `contextmenu` event, which doesn't fire reliably on touch / the HA Companion app — and the trailing `click` then triggered `tap_action` (the lightbox) on release. Long-press is now detected with a pointer timer (500ms, 10px movement tolerance so a scroll isn't taken for a press), and the click that follows a fired hold is swallowed, so `hold_action` runs on its own.

**2. New `double_tap_action` (b33)**
Adds HA's standard `double_tap_action` to the card, so you can map single tap → lightbox, double tap → select, long press → select. When configured, single taps are debounced ~250ms to disambiguate; without it, single taps stay instant.

Both work with the legacy `{ service: ... }` and modern `{action: perform-action, perform_action: ...}` / `{perform_action: ...}` forms (b29).

## Test plan
- [ ] Long-press a thumbnail on the Companion app → hold action runs, lightbox does **not** open
- [ ] Short tap → `tap_action: lightbox` opens (slightly delayed only if `double_tap_action` is set)
- [ ] Double tap with `double_tap_action` set → artwork selected, lightbox not opened
- [ ] Scroll over the gallery while touching → no hold fired
- [ ] No `double_tap_action` configured → single tap stays instant
