### PR TITLE
Folder Gallery: make double-tap survive gallery re-renders (8.1.0b34)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -5,8 +5,13 @@
 - **The gallery card now supports `double_tap_action`** (HA's standard action
   option), so you can wire e.g. single tap → lightbox preview, double tap →
   display the artwork on the TV, and long press → display too. When a
-  `double_tap_action` is configured, a single tap is delayed briefly (~250 ms)
+  `double_tap_action` is configured, a single tap is delayed briefly (~300 ms)
   to tell the two apart; without it, single taps stay instant.
+- **Double-tap detection now survives gallery re-renders**: the timing state is
+  tracked on the card (keyed by image index) instead of per-element, so a
+  sensor update that re-renders the gallery between the two clicks no longer
+  makes the second click look like a fresh first tap (which opened the lightbox
+  instead of running `double_tap_action`).
 
 ## Folder Gallery card — `hold_action` now works on touch
 

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b33"
+  "version": "8.1.0b34"
 }

--- a/custom_components/samsungtv_smart/www/folder-gallery-card.js
+++ b/custom_components/samsungtv_smart/www/folder-gallery-card.js
@@ -32,6 +32,10 @@ class FolderGalleryCard extends HTMLElement {
     this.attachShadow({ mode: 'open' });
     this._images = [];
     this._config = {};
+    // Double-tap detection state (survives gallery re-renders).
+    this._dtIndex = -1;
+    this._dtTime = 0;
+    this._dtTimer = null;
   }
 
   static get properties() {
@@ -567,14 +571,13 @@ class FolderGalleryCard extends HTMLElement {
     // long-press swallows that trailing click.
     const LONG_PRESS_MS = 500;
     const MOVE_TOLERANCE = 10;
-    const DOUBLE_TAP_MS = 250;
+    const DOUBLE_TAP_MS = 300;
     const hasDoubleTap = !!this._config.double_tap_action;
     container.querySelectorAll('.gallery-item').forEach(item => {
       let pressTimer = null;
       let holdFired = false;
       let startX = 0;
       let startY = 0;
-      let clickTimer = null;
 
       const clearTimer = () => {
         if (pressTimer) {
@@ -623,14 +626,28 @@ class FolderGalleryCard extends HTMLElement {
           return;
         }
 
-        if (clickTimer) {
-          clearTimeout(clickTimer);
-          clickTimer = null;
-          this.executeAction(this._images[parseInt(item.dataset.index)],
-                             this._config.double_tap_action);
+        // Double-tap state lives on the instance (keyed by image index), not in
+        // this closure: a sensor update can re-render the gallery between the
+        // two clicks, recreating the element and losing any per-element timer —
+        // which made the second click look like a fresh first click and opened
+        // the lightbox instead of firing double_tap_action.
+        const index = parseInt(item.dataset.index);
+        const now = Date.now();
+        if (this._dtIndex === index && (now - this._dtTime) < DOUBLE_TAP_MS) {
+          if (this._dtTimer) {
+            clearTimeout(this._dtTimer);
+            this._dtTimer = null;
+          }
+          this._dtIndex = -1;
+          this._dtTime = 0;
+          this.executeAction(this._images[index], this._config.double_tap_action);
         } else {
-          clickTimer = setTimeout(() => {
-            clickTimer = null;
+          this._dtIndex = index;
+          this._dtTime = now;
+          if (this._dtTimer) clearTimeout(this._dtTimer);
+          this._dtTimer = setTimeout(() => {
+            this._dtTimer = null;
+            this._dtIndex = -1;
             this.handleClick(e, item);
           }, DOUBLE_TAP_MS);
         }


### PR DESCRIPTION
## Summary
`hold_action` works, but `double_tap_action` didn't fire (the lightbox opened instead).

Root cause: double-tap timing was stored in each gallery item's event-listener closure. A folder sensor update re-renders the gallery (`renderGallery` rebuilds the items) — if that happens between the two clicks, the second click lands on a freshly-created element whose closure counter is reset, so it looks like a new first tap and `tap_action` (lightbox) fires.

- Double-tap state is now tracked on the card instance (keyed by image index), so it survives re-renders.
- Window widened from 250 → 300 ms.

## Test plan
- [ ] Double-tap a thumbnail → `double_tap_action` runs (artwork selected), lightbox does **not** open
- [ ] Single tap → `tap_action: lightbox` still opens (after the ~300ms disambiguation delay)
- [ ] Long press → `hold_action` still runs
- [ ] Repeat while the folder sensor is actively updating → double-tap still works


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_