### PR TITLE
Art upload: retry new image's thumbnail until the TV has built it (8.1.0b35)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,5 +1,15 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
+## Art upload — new image's thumbnail no longer stays missing for minutes
+
+- **After uploading an image, its thumbnail is now fetched once the TV has
+  generated it**: the TV can take a while (sometimes minutes) to build the
+  thumbnail for a just-uploaded image, so the immediate batch download failed
+  for it ("No data" / "Connection reset") and the gallery showed a missing
+  thumbnail until an unrelated later refresh happened to pick it up. The upload
+  now retries that specific image's thumbnail in the background with a back-off
+  (up to ~6.5 min) and refreshes the gallery as soon as it lands.
+
 ## Folder Gallery card — new `double_tap_action`
 
 - **The gallery card now supports `double_tap_action`** (HA's standard action

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b34"
+  "version": "8.1.0b35"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -3450,9 +3450,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 # gallery shows a missing thumbnail until a later refresh happens
                 # to pick it up. Retry this specific content_id with backoff in
                 # the background until its thumbnail is available.
-                self.hass.async_create_task(
-                    self._retry_new_thumbnail(content_id)
-                )
+                self.hass.async_create_task(self._retry_new_thumbnail(content_id))
 
                 return {"success": True, "content_id": content_id}
 

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -3444,6 +3444,16 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 # Force immediate update 🚀
                 await self._force_art_coordinator_refresh()
 
+                # The TV often needs a while (sometimes minutes) to generate the
+                # thumbnail for a just-uploaded image, so the immediate batch
+                # fetch fails for it ("No data"/"Connection reset") and the
+                # gallery shows a missing thumbnail until a later refresh happens
+                # to pick it up. Retry this specific content_id with backoff in
+                # the background until its thumbnail is available.
+                self.hass.async_create_task(
+                    self._retry_new_thumbnail(content_id)
+                )
+
                 return {"success": True, "content_id": content_id}
 
             self._log.error("Frame Art: Upload failed - no content_id returned")
@@ -3454,6 +3464,41 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
             self._log.debug("Frame Art: Upload traceback: %s", traceback.format_exc())
             return {"error": str(ex)}
+
+    async def _retry_new_thumbnail(self, content_id: str) -> None:
+        """Fetch a just-uploaded image's thumbnail once the TV has built it.
+
+        Right after an upload the TV hasn't finished generating the thumbnail,
+        so the immediate batch download fails for it. Retry this one content_id
+        with a back-off (well past the TV's typical generation delay), stopping
+        as soon as it's available so the gallery fills in without waiting for an
+        unrelated later refresh.
+        """
+        # ~6.5 min total: covers the multi-minute generation delay seen in logs.
+        retry_delays = [15, 30, 60, 120, 180]
+        for delay in retry_delays:
+            await asyncio.sleep(delay)
+            try:
+                result = await self.async_art_get_thumbnail(content_id)
+            except Exception as ex:  # noqa: BLE001 - best-effort background retry
+                self._log.debug(
+                    "Frame Art: delayed thumbnail retry for %s errored: %s",
+                    content_id,
+                    ex,
+                )
+                continue
+            if result and not result.get("error"):
+                self._log.info(
+                    "Frame Art: thumbnail for %s is now available (delayed retry)",
+                    content_id,
+                )
+                # Nudge the gallery/sensor so it shows the new thumbnail now.
+                await self._force_art_coordinator_refresh()
+                return
+        self._log.debug(
+            "Frame Art: thumbnail for %s still unavailable after delayed retries",
+            content_id,
+        )
 
     async def async_art_delete(self, content_id: str) -> dict:
         """Delete an uploaded piece of artwork."""


### PR DESCRIPTION
## Summary
After uploading an image, its thumbnail was missing in the gallery for a while.

From the logs: upload of `MY_F0014` succeeds → `image_added` → the immediate batch processes the new image **first** (so order isn't the problem), but the TV hasn't generated its thumbnail yet, so all 3 quick attempts (~25s) return `No data` / `Connection reset` → `Could not download thumbnail ... Failed after 3 attempts`. ~3 minutes later an unrelated batch finally fetches it.

Fix: after a successful upload, retry that specific `content_id`'s thumbnail in the background with a back-off (15/30/60/120/180s ≈ 6.5 min), stopping as soon as it's available, and refresh the gallery/sensor so it shows up immediately.

## Test plan
- [ ] Upload an image and confirm its thumbnail appears in the gallery within a minute or two without any manual refresh
- [ ] Confirm an already-generated thumbnail (cached) doesn't trigger needless work
- [ ] Confirm the immediate batch behaviour for other (already-built) images is unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_