### PR TITLE
Art API: quieter connection-failure logs (8.1.0b36)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,5 +1,15 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
+## Art API — quieter connection-failure logs
+
+- **Art channel connection failures no longer spam `WARNING`**: a TV that's
+  simply off/unreachable trips this on every poll, and the early attempts
+  usually recover on their own. The intermediate attempts (e.g. 1/3, 2/3) are
+  now logged at DEBUG, and a single `INFO` line is emitted only on the last
+  attempt — when the integration actually gives up and backs off — instead of
+  `WARNING`, since an unreachable TV is an expected condition rather than a
+  fault. The backoff detail line is now DEBUG.
+
 ## Art upload — new image's thumbnail no longer stays missing for minutes
 
 - **After uploading an image, its thumbnail is now fetched once the TV has

--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -389,13 +389,20 @@ class SamsungTVAsyncArt:
             # (not once per port), so a temporarily unreachable TV does not
             # reach the backoff threshold twice as fast.
             self._connection_failures += 1
-            self._log.warning(
+            # A TV that's simply off/unreachable trips this on every poll, and
+            # the early attempts usually recover on their own, so keep them at
+            # DEBUG. Surface a single INFO line only on the last attempt — i.e.
+            # when we actually give up and back off — rather than WARNING, since
+            # an unreachable TV is an expected condition, not a fault.
+            reached_max = self._connection_failures >= self._max_connection_failures
+            self._log.log(
+                logging.INFO if reached_max else logging.DEBUG,
                 "Art API: Connection failure %d/%d",
                 self._connection_failures,
                 self._max_connection_failures,
             )
 
-            if self._connection_failures >= self._max_connection_failures:
+            if reached_max:
                 # Exponential backoff: 2, 5, 10, 20, 30 minutes (capped)
                 backoff_minutes = min(
                     2
@@ -403,7 +410,7 @@ class SamsungTVAsyncArt:
                     30,
                 )
                 self._backoff_until = time.time() + (backoff_minutes * 60)
-                self._log.warning(
+                self._log.debug(
                     "Art API: Too many connection failures (%d), entering %d minute backoff period",
                     self._connection_failures,
                     backoff_minutes,

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b35"
+  "version": "8.1.0b36"
 }


### PR DESCRIPTION
## Summary
The Art channel connection-failure lines were logged at `WARNING` on every poll for a TV that's simply off/unreachable (Preston's residual log noise after the IP Control fix). The early attempts usually recover on their own.

- Intermediate attempts (1/3, 2/3) → **DEBUG**
- Last attempt (give-up / backoff) → single **INFO** line (was WARNING) — an unreachable TV is an expected condition, not a fault
- Backoff detail line → **DEBUG**

## Test plan
- [ ] With a TV off, confirm no `WARNING ... Art API: Connection failure` lines; at most one `INFO` line when it backs off
- [ ] Confirm the Art channel still recovers/reconnects when the TV comes back


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_