### PR TITLE
Stop polling the art channel while the TV is off (8.1.0b37)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,6 +1,16 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
-## Art API — quieter connection-failure logs
+## Art Mode selects — stop polling the art channel while the TV is off
+
+- **The Motion Sensitivity / Motion Timer / Brightness Sensor selects no longer
+  query the TV while it is powered off**: they polled `get_artmode_settings`
+  over the Art WebSocket every cycle regardless of power, so an off TV kept
+  getting poked on the art channel continuously (≈2 requests/min overnight).
+  Beyond being wasteful, this constant poking of a sleeping art-app could leave
+  Art Mode wedged by morning. The selects now skip the poll when the
+  media_player reports the TV off (and not in Art Mode), keeping their last
+  known value — matching what the Frame Art coordinator already does. When the
+  TV is genuinely off, the integration no longer touches the art channel at all.
 
 - **Art channel connection failures no longer spam `WARNING`**: a TV that's
   simply off/unreachable trips this on every poll, and the early attempts

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b36"
+  "version": "8.1.0b37"
 }

--- a/custom_components/samsungtv_smart/select.py
+++ b/custom_components/samsungtv_smart/select.py
@@ -9,9 +9,17 @@ import time
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_ID, CONF_NAME, CONF_PORT, CONF_TOKEN
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_ID,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_TOKEN,
+    STATE_OFF,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -791,6 +799,31 @@ class SamsungTVArtMotionSelectBase(SelectEntity):
             name=self._device_name,
         )
 
+    def _tv_powered_off(self) -> bool:
+        """True when the TV is off (and not in Art Mode) — skip art polling.
+
+        Polling ``get_artmode_settings`` over the art WebSocket while the TV is
+        powered off keeps poking the (sleeping) art-app for nothing and can wedge
+        it overnight. Mirror the switch: rely on the media_player's already
+        published state + ``art_mode_status`` attribute instead of issuing our
+        own TV request, so this never adds traffic to a TV that's off.
+        """
+        ent_reg = er.async_get(self.hass)
+        mp_id = None
+        for entity in er.async_entries_for_config_entry(ent_reg, self._entry.entry_id):
+            if entity.domain == "media_player":
+                mp_id = entity.entity_id
+                break
+        if not mp_id:
+            return False  # unknown → don't suppress
+        state = self.hass.states.get(mp_id)
+        if state is None:
+            return False
+        if state.state not in (STATE_OFF, "unavailable"):
+            return False  # TV is on
+        # media_player off/unavailable → TV off UNLESS Art Mode is active
+        return state.attributes.get("art_mode_status") != "on"
+
     async def _async_set(self, option: str) -> None:
         """To be implemented by subclass: call the matching art_api setter."""
         raise NotImplementedError
@@ -806,6 +839,11 @@ class SamsungTVArtMotionSelectBase(SelectEntity):
             ) from ex
 
     async def async_update(self) -> None:
+        # Don't touch the art channel while the TV is off: it's pointless (the
+        # art-app is asleep) and the constant overnight polling can wedge the
+        # art-app by morning. Keep the last known value instead.
+        if self._tv_powered_off():
+            return
         try:
             item = await self._art_api.get_artmode_settings(self._setting_name)
             if item and isinstance(item, dict):


### PR DESCRIPTION
## Summary
Diagnosed from an overnight log: while the TV (.161) was in **standby**, the integration kept hitting the **art WebSocket** — ~**118 `get_artmode_settings`/hour** plus a few `get_current_artwork`/`get_content_list`/`get_slideshow_status`. The Frame Art coordinator already skips when off, but the **Motion Sensitivity / Motion Timer / Brightness Sensor selects** (`SamsungTVArtMotionSelectBase`, `should_poll=True`) called `get_artmode_settings` every cycle **with no power gating**, poking the sleeping art-app continuously.

The user confirmed causation: **disabling the integration over a night avoided the morning Art-Mode wedge** — so the constant overnight poking is implicated.

Fix: the art selects now skip their poll when the media_player reports the TV **off and not in Art Mode** (reading the already-published `art_mode_status` attribute, no extra TV request), keeping their last known value — the same gating the coordinator applies. When the TV is genuinely off, the integration no longer touches the art channel at all.

ColorTone (IP Control) and Picture Mode (SmartThings cloud) selects don't touch the art channel and are unchanged.

## Test plan
- [ ] TV off overnight → confirm no `get_artmode_settings` (or other art-channel) requests to that TV in the logs while standby
- [ ] TV on / in Art Mode → selects still refresh their values normally
- [ ] Confirm the morning Art-Mode wedge no longer occurs with the integration enabled


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_