### PR TITLE
Power sensors: full parity with native SmartThings (8.1.0b39)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -6,7 +6,12 @@
   SmartThings `powerConsumptionReport` capability (same data shown in the
   SmartThings app). They're attached to the TV device, with the proper
   device classes/state classes so they integrate with the HA Energy dashboard.
-  Energy is converted from the Wh SmartThings reports to kWh.
+  Energy values are converted from the Wh SmartThings reports to kWh.
+- **Full parity with the native SmartThings sensors**: in addition to Power and
+  Energy, the *Energy difference* (`deltaEnergy`), *Power energy*
+  (`powerEnergy`) and *Energy saved* (`energySaved`) sensors are now exposed —
+  useful on TVs where the cumulative `energy` field stays 0 and the real
+  consumption is reported in `deltaEnergy`.
 
 ## Art Mode selects — stop polling the art channel while the TV is off
 

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b38"
+  "version": "8.1.0b39"
 }

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -347,7 +347,13 @@ async def async_setup_entry(
                 main_status = await st_client.get_device_status(device_id)
                 if "powerConsumptionReport" in main_status.get("main", {}):
                     _LOGGER.info("Adding power consumption sensors for %s", device_name)
-                    for measure in ("power", "energy"):
+                    for measure in (
+                        "power",
+                        "energy",
+                        "deltaEnergy",
+                        "powerEnergy",
+                        "energySaved",
+                    ):
                         entities.append(
                             SmartThingsPowerConsumptionSensor(
                                 hass=hass,
@@ -2119,6 +2125,30 @@ class SmartThingsPowerConsumptionSensor(SensorEntity):
             UnitOfEnergy.KILO_WATT_HOUR,
             1000,  # SmartThings reports Wh; HA wants kWh
         ),
+        "deltaEnergy": (
+            "energy_difference",
+            "Energy difference",
+            SensorDeviceClass.ENERGY,
+            SensorStateClass.TOTAL_INCREASING,
+            UnitOfEnergy.KILO_WATT_HOUR,
+            1000,
+        ),
+        "powerEnergy": (
+            "power_energy",
+            "Power energy",
+            SensorDeviceClass.ENERGY,
+            SensorStateClass.TOTAL_INCREASING,
+            UnitOfEnergy.KILO_WATT_HOUR,
+            1000,
+        ),
+        "energySaved": (
+            "energy_saved",
+            "Energy saved",
+            SensorDeviceClass.ENERGY,
+            SensorStateClass.TOTAL_INCREASING,
+            UnitOfEnergy.KILO_WATT_HOUR,
+            1000,
+        ),
     }
 
     def __init__(
@@ -2142,7 +2172,10 @@ class SmartThingsPowerConsumptionSensor(SensorEntity):
         suffix, friendly, dev_class, state_class, unit, divisor = self._MEASURES[
             measure
         ]
-        self._field = suffix
+        # The SmartThings powerConsumption dict is keyed by the measure name
+        # (power, energy, deltaEnergy, powerEnergy, energySaved); suffix is only
+        # used for the entity's unique_id / friendly name.
+        self._field = measure
         self._friendly = friendly
         self._divisor = divisor
         self._attr_device_class = dev_class


### PR DESCRIPTION
## Summary
Follow-up to #104. The native SmartThings integration shows 5 power-report sensors; we only exposed 2 (Power, Energy). This adds the missing 3 for parity:
- **Energy difference** (`deltaEnergy`)
- **Power energy** (`powerEnergy`)
- **Energy saved** (`energySaved`)

This matters on TVs (like the reporter's QE55Q80BATXXH) where the cumulative `energy` field stays `0` and the real per-window consumption is reported in `deltaEnergy` — so "Energy 0.00 kWh" alone was uninformative, exactly as the native app also shows.

All energy fields are kWh (Wh→kWh), `device_class: energy`, `state_class: total_increasing`; Power stays W / measurement. The `powerConsumption` dict is read by its original SmartThings keys; entity unique_ids use snake_case suffixes.

TV channel / TV channel name sensors from the native app are intentionally not duplicated (already covered by the media_player).

## Test plan
- [ ] On a TV with `powerConsumptionReport`, confirm 5 sensors: Power, Energy, Energy difference, Power energy, Energy saved
- [ ] `deltaEnergy` shows the real consumption when `energy` stays 0
- [ ] No duplicate unique_id / no errors on TVs without the capability


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_