### PR TITLE
Fix KeyError 'options' on reload + name TV in auth-token logs (8.1.0b40)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,5 +1,17 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
+## Fixes — reload crash + clearer logs
+
+- **`KeyError: 'options'` crash during reload/reconfigure**: the IP art-mode
+  refresh timer (and other `_get_option` callers) accessed `DATA_OPTIONS`
+  unconditionally, which raised `KeyError: 'options'` while `hass.data` was
+  being repopulated mid-reload — surfacing as repeated
+  `Error doing job: Task exception was never retrieved`. `_get_option` now
+  falls back to the default when options aren't present yet.
+- **Auth-token log lines now name the TV**: the `Using OAuth access token` /
+  SmartThings token debug (and the "no valid token" warning) now include the
+  config entry title, so multi-TV setups can tell which TV the line is about.
+
 ## New — Power & Energy consumption sensors (SmartThings)
 
 - **Power (W) and Energy (kWh) sensors** are now created for TVs that report the

--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -603,10 +603,12 @@ async def async_get_samsungtv_api_key(  # noqa: C901
                         finally:
                             set_oauth_refresh_in_progress(entry.entry_id, False)
 
-                _LOGGER.debug("Using OAuth access token")
+                _LOGGER.debug("[%s] Using OAuth access token", entry.title)
                 return access_token
 
-        _LOGGER.warning("OAuth method configured but no valid token found")
+        _LOGGER.warning(
+            "[%s] OAuth method configured but no valid token found", entry.title
+        )
         return entry.data.get(CONF_API_KEY)
 
     # Method 2: SmartThings Integration token
@@ -615,7 +617,7 @@ async def async_get_samsungtv_api_key(  # noqa: C901
         if st_unique_id:
             api_key = get_smartthings_api_key(hass, st_unique_id)
             if api_key:
-                _LOGGER.debug("Using SmartThings integration token")
+                _LOGGER.debug("[%s] Using SmartThings integration token", entry.title)
                 return api_key
             _LOGGER.warning(
                 "Failed to retrieve SmartThings integration access token, using last available"

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b39"
+  "version": "8.1.0b40"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -1410,7 +1410,15 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         """Get option from entity configuration."""
         if not self._entry_data:
             return default
-        option = self._entry_data[DATA_OPTIONS].get(param)
+        # DATA_OPTIONS can be transiently absent from _entry_data during a
+        # reload/reconfigure (hass.data is repopulated step by step). Accessing
+        # it unconditionally raised `KeyError: 'options'` and crashed callers
+        # like the IP art-mode refresh timer ("Task exception was never
+        # retrieved"). Fall back to the default instead.
+        options = self._entry_data.get(DATA_OPTIONS)
+        if not options:
+            return default
+        option = options.get(param)
         return default if option is None else option
 
     def _get_device_spec(self, key: str) -> Any | None:


### PR DESCRIPTION
## Summary
Two items found while reviewing logs after a reconfigure + re-enable of the integration.

**1. `KeyError: 'options'` crash on reload (real bug)**
During the reconfigure window the logs showed repeated `Error doing job: Task exception was never retrieved`, traced to:
```
_refresh_ip_art_mode → _get_ip_control_client → _get_option
    option = self._entry_data[DATA_OPTIONS].get(param)
KeyError: 'options'
```
`_get_option` accessed `DATA_OPTIONS` unconditionally, but `hass.data`/`_entry_data` can be transiently missing that key while being repopulated mid-reload, crashing the IP art-mode refresh callback. It now falls back to the default when options aren't present.

**2. Auth-token log lines didn't say which TV**
`Using OAuth access token` / `Using SmartThings integration token` (and the "no valid token" warning) are emitted from the module-level helper with no device context, so on multi-TV setups you can't tell which TV they refer to. They now include the config entry title.

## Test plan
- [ ] Reload / reconfigure a TV and confirm no `KeyError: 'options'` / `Task exception was never retrieved` from `_refresh_ip_art_mode`
- [ ] Confirm `[<TV name>] Using OAuth access token` now identifies the TV in logs


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_