### PR TITLE
Stop re-probing get_thumbnail_list once the TV returns -1 (8.1.0b41)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,5 +1,17 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
+## Art thumbnails — stop re-probing the unsupported list path on 2024+ Frames
+
+- **No more `SYSTEM_FAIL (-1)` log spam per thumbnail on 2024-2025 Frames**:
+  these models don't support `get_thumbnail_list`, but the code probed it
+  before every single thumbnail fetch (logging one SYSTEM_FAIL each, plus a
+  wasted round-trip) before falling back to the working direct `get_thumbnail`.
+  Once the TV returns a definitive `error -1`, the integration now remembers it
+  and goes straight to `get_thumbnail`. The negative is only latched on that
+  explicit code — never on a transient "no response" — so a TV-not-ready blip
+  can't disable the fast path on TVs that do support it. (Cosmetic/perf only,
+  thumbnails worked before via the fallback.)
+
 ## Fixes — reload crash + clearer logs
 
 - **`KeyError: 'options'` crash during reload/reconfigure**: the IP art-mode

--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -1007,20 +1007,25 @@ class SamsungTVAsyncArt:
         # on most TV models. Only the direct socket fallback (get_thumbnail) fails for
         # SAM-* images. Never set the flag to False: a startup error (TV not ready)
         # must not permanently disable the fast path for the whole session.
-        self._log.debug(
-            "Art API: Trying get_thumbnail_list for %s (capability=%s)",
-            content_id,
-            self._supports_thumbnail_list,
-        )
-        result = await self._get_thumbnail_via_list(content_id)
-        if result:
-            if self._supports_thumbnail_list is None:
-                self._log.info(
-                    "Art API: TV supports get_thumbnail_list — "
-                    "fast path active for this session"
-                )
-                self._supports_thumbnail_list = True
-            return result
+        # Skip the list path entirely once we've learned this TV rejects it
+        # with a definitive error -1 (2024-2025 Tizen): otherwise every single
+        # thumbnail fetch logs a SYSTEM_FAIL and wastes a round-trip before the
+        # direct get_thumbnail fallback below.
+        if self._supports_thumbnail_list is not False:
+            self._log.debug(
+                "Art API: Trying get_thumbnail_list for %s (capability=%s)",
+                content_id,
+                self._supports_thumbnail_list,
+            )
+            result = await self._get_thumbnail_via_list(content_id)
+            if result:
+                if self._supports_thumbnail_list is None:
+                    self._log.info(
+                        "Art API: TV supports get_thumbnail_list — "
+                        "fast path active for this session"
+                    )
+                    self._supports_thumbnail_list = True
+                return result
 
         self._log.debug("Art API: Using get_thumbnail direct for %s", content_id)
 
@@ -1138,6 +1143,22 @@ class SamsungTVAsyncArt:
                 content_id,
                 _describe_art_error(data.get("error_code")),
             )
+            # A definitive error_code -1 means this model doesn't support the
+            # list path at all (2024-2025 Tizen) — remember it so we stop
+            # re-probing it on every single thumbnail and go straight to the
+            # direct get_thumbnail. We only latch on this explicit code, NOT on
+            # a missing/transient response (handled above as "no response"),
+            # so a TV-not-ready blip can't permanently disable the fast path.
+            try:
+                if int(data.get("error_code")) == -1:
+                    if self._supports_thumbnail_list is not False:
+                        self._log.info(
+                            "Art API: TV does not support get_thumbnail_list "
+                            "(error -1) — using direct get_thumbnail from now on"
+                        )
+                    self._supports_thumbnail_list = False
+            except (TypeError, ValueError):
+                pass
             return None
 
         try:

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b40"
+  "version": "8.1.0b41"
 }


### PR DESCRIPTION
## Summary
On 2024-2025 Frames, `get_thumbnail_list` isn't supported and the TV replies `error -1` (SYSTEM_FAIL). The code probed it before **every single** thumbnail fetch — logging one `SYSTEM_FAIL (-1)` and wasting a round-trip each time — before falling back to the working direct `get_thumbnail`. (In one log this produced 249 `SYSTEM_FAIL (-1)` lines.)

It's benign (thumbnails worked via the fallback), and confirmed **not** related to the Art-Mode wedge — it shows on a healthy/factory-reset TV too. This just removes the noise/waste:

- `_get_thumbnail_via_list` now latches `_supports_thumbnail_list = False` on a definitive `error_code -1`.
- `get_thumbnail` skips the list path entirely once that's known, going straight to the direct path.
- The negative is only set on the explicit `-1` code — never on a transient "no response" — so a TV-not-ready blip can't permanently disable the fast path on TVs that genuinely support the list.

## Test plan
- [ ] On a 2024 Frame, confirm at most one `SYSTEM_FAIL (-1)` then `using direct get_thumbnail from now on`, and no further list probes
- [ ] Thumbnails still download (via direct `get_thumbnail`)
- [ ] On a pre-2024 TV that supports the list, the fast path still activates


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_