### PR TITLE
Folder Gallery: lazy load/unload thumbnails for big original folders (8.2.0b1)

### DIFF
--- a/RELEASE_NOTES_8.2.0.md
+++ b/RELEASE_NOTES_8.2.0.md
@@ -1,0 +1,19 @@
+# Release notes — 8.2.0 (since 8.1.0)
+
+> **Status: pre-release (beta).** 8.2.0 builds on 8.1.0.
+
+## Folder Gallery card — handle big folders of full-size originals
+
+- **Thumbnails are now loaded/unloaded on demand (IntersectionObserver)**:
+  pointing the gallery at a folder of original photos (several MB each, many of
+  them) used to give every `<img>` its `src` up front, so the browser
+  downloaded and decoded the entire set at once and could choke. The card now
+  only sets `src` on images near the viewport and **drops it again** once they
+  scroll far offscreen, so the number of decoded bitmaps held in memory stays
+  bounded regardless of how large the folder is. Images also decode
+  asynchronously (`decoding="async"`), and tiles keep their size while
+  unloaded so scrolling stays stable.
+
+  > Note: this bounds the browser's memory/CPU; the full-size file is still
+  > downloaded when a tile actually scrolls into view. A future step may add
+  > server-side resized thumbnails for local folders to also cut bandwidth.

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b41"
+  "version": "8.2.0b1"
 }

--- a/custom_components/samsungtv_smart/www/folder-gallery-card.js
+++ b/custom_components/samsungtv_smart/www/folder-gallery-card.js
@@ -36,6 +36,8 @@ class FolderGalleryCard extends HTMLElement {
     this._dtIndex = -1;
     this._dtTime = 0;
     this._dtTimer = null;
+    // Lazy-load observer for the gallery thumbnails.
+    this._imgObserver = null;
   }
 
   static get properties() {
@@ -550,8 +552,8 @@ class FolderGalleryCard extends HTMLElement {
       <div class="gallery-grid">
         ${this._images.map((img, index) => `
           <div class="gallery-item" data-index="${index}" data-path="${img.path}" data-content-id="${img.content_id || ''}">
-            <img src="${img.path}" alt="${img.name}" loading="lazy" class="loading"
-                 onerror="this.classList.add('error')" 
+            <img data-src="${img.path}" alt="${img.name}" decoding="async" class="loading"
+                 onerror="this.classList.add('error')"
                  onload="this.classList.remove('loading')">
             ${this._config.show_filename ? `
               <div class="image-overlay">
@@ -562,6 +564,14 @@ class FolderGalleryCard extends HTMLElement {
         `).join('')}
       </div>
     `;
+
+    // Lazy load/unload via IntersectionObserver. A folder of full-size
+    // originals (several MB each, many of them) overwhelmed the browser when
+    // every <img> was given its src up front — it downloaded and decoded the
+    // whole set at once. Instead we only set src on images near the viewport,
+    // and DROP src again once they scroll far away, so the number of decoded
+    // bitmaps held in memory stays bounded regardless of folder size.
+    this._setupImageObserver(container);
 
     // Add click + long-press handlers.
     // Long-press is detected with a pointer timer rather than the `contextmenu`
@@ -657,6 +667,59 @@ class FolderGalleryCard extends HTMLElement {
       // doesn't interrupt the hold.
       item.addEventListener('contextmenu', (e) => e.preventDefault());
     });
+  }
+
+  _setupImageObserver(container) {
+    // Disconnect any observer from a previous render before rebuilding.
+    if (this._imgObserver) {
+      this._imgObserver.disconnect();
+    }
+
+    const imgs = container.querySelectorAll('.gallery-item img[data-src]');
+    if (!imgs.length) {
+      return;
+    }
+
+    // No IntersectionObserver (very old webview): fall back to loading all.
+    if (typeof IntersectionObserver === 'undefined') {
+      imgs.forEach((img) => {
+        if (img.dataset.src) {
+          img.src = img.dataset.src;
+        }
+      });
+      return;
+    }
+
+    this._imgObserver = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const img = entry.target;
+          if (entry.isIntersecting) {
+            // Approaching the viewport → load it.
+            if (!img.getAttribute('src') && img.dataset.src) {
+              img.classList.add('loading');
+              img.src = img.dataset.src;
+            }
+          } else if (img.getAttribute('src')) {
+            // Far offscreen again → drop the bitmap to free memory. The
+            // placeholder ('loading') keeps the tile sized so layout is stable.
+            img.removeAttribute('src');
+            img.classList.add('loading');
+          }
+        }
+      },
+      // Preload a bit before the tile is actually visible for smooth scrolling.
+      { root: null, rootMargin: "300px 0px", threshold: 0.01 }
+    );
+
+    imgs.forEach((img) => this._imgObserver.observe(img));
+  }
+
+  disconnectedCallback() {
+    if (this._imgObserver) {
+      this._imgObserver.disconnect();
+      this._imgObserver = null;
+    }
   }
 
   setupLightbox() {


### PR DESCRIPTION
## Summary
First feature on the new **8.2** line (targets `8.2-dev`).

Pointing the `folder-gallery-card` at a folder of **full-size originals** (several MB each, many of them) gave every `<img>` its `src` up front, so the browser downloaded + decoded the whole set at once and could choke.

- The card now uses an **IntersectionObserver**: it sets `src` only on images near the viewport and **drops `src` again** once they scroll far offscreen, so the number of decoded bitmaps held in memory stays bounded regardless of folder size.
- Images decode asynchronously (`decoding="async"`); tiles keep their size while unloaded so scrolling stays stable.
- Falls back to eager loading if `IntersectionObserver` is unavailable (very old webview).

> Scope: this bounds **browser memory/CPU**. The full-size file is still downloaded when a tile actually scrolls into view — a later step can add **server-side resized thumbnails** for local folders to also cut bandwidth (Pillow), if wanted.

## Test plan
- [ ] Point the gallery at a large folder of multi-MB originals → scrolling is smooth, browser memory stays bounded (only ~visible images loaded)
- [ ] Scroll down then back up → images reload correctly; no broken tiles
- [ ] Art Store / sensor-based galleries (small thumbnails) still work as before
- [ ] tap / double-tap / hold still work


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_