### PR TITLE
Folder Gallery: server-side resized thumbnails for big folders (8.2.0b1)

### DIFF
--- a/RELEASE_NOTES_8.2.0.md
+++ b/RELEASE_NOTES_8.2.0.md
@@ -1,0 +1,23 @@
+# Release notes — 8.2.0 (since 8.1.0)
+
+> **Status: pre-release (beta).** 8.2.0 builds on 8.1.0.
+
+## Folder Gallery card — server-side resized thumbnails for big folders
+
+- **The gallery now loads small resized thumbnails instead of the originals.**
+  Pointing the card at a folder of full-size photos (several MB each, many of
+  them) used to make the browser download and decode every original at full
+  resolution just to render the grid — slow, memory-heavy, and visually poor.
+  The integration now exposes an on-demand thumbnail endpoint
+  (`/api/samsungtv_smart/thumbnail`) that returns a small cached JPEG (resized
+  with Pillow, cached on disk keyed by file + size + mtime). The card points
+  its grid images there, so only kilobytes per tile reach the browser; the
+  full-resolution original is still used for the lightbox and tap/hold actions.
+
+  - Enabled by default. Disable per card with `server_thumbnails: false`.
+  - Tune the size with `thumbnail_width:` (default `400`).
+  - Only local files (`/local/...`) are routed through the resizer; remote URLs
+    are used as-is. If Pillow isn't available, the endpoint transparently falls
+    back to the original image.
+  - The endpoint only ever reads files under `<config>/www` (already public at
+    `/local/`) and validates the path against traversal.

--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -1052,6 +1052,15 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     # Register folder-gallery-card as Lovelace resource
     await _register_gallery_card(hass)
 
+    # On-demand resized-thumbnail endpoint used by the gallery card so big
+    # folders of full-size originals don't get downloaded at full resolution.
+    try:
+        from .http_thumbnail import SamsungTVThumbnailView
+
+        hass.http.register_view(SamsungTVThumbnailView(hass))
+    except Exception as exc:  # pylint: disable=broad-except
+        _LOGGER.warning("Could not register thumbnail view: %s", exc)
+
     return True
 
 

--- a/custom_components/samsungtv_smart/http_thumbnail.py
+++ b/custom_components/samsungtv_smart/http_thumbnail.py
@@ -1,0 +1,140 @@
+"""On-demand resized-thumbnail HTTP view for the folder gallery card.
+
+A folder of full-size originals (several MB each, many of them) made the gallery
+download and decode the whole set at full resolution just to show a grid. The
+card now points its grid `<img>` tags at this endpoint, which returns a small
+cached JPEG instead, so only kilobytes per tile travel to the browser.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+
+from aiohttp import web
+
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+THUMBNAIL_URL = "/api/samsungtv_smart/thumbnail"
+_CACHE_SUBDIR = ("frame_art", ".thumb_cache")
+_MIN_W = 64
+_MAX_W = 1024
+_DEFAULT_W = 400
+
+
+class SamsungTVThumbnailView(HomeAssistantView):
+    """Serve a downscaled JPEG thumbnail of an image stored under ``<config>/www``.
+
+    Unauthenticated on purpose: plain ``<img>`` requests carry no HA auth, and
+    this only ever reads files under ``<config>/www`` — which Home Assistant
+    already serves publicly at ``/local/`` — so it exposes nothing new. The
+    requested path is strictly validated to stay within that directory
+    (realpath containment check) to prevent traversal.
+    """
+
+    url = THUMBNAIL_URL
+    name = "api:samsungtv_smart:thumbnail"
+    requires_auth = False
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the view."""
+        self._hass = hass
+        self._www = os.path.realpath(hass.config.path("www"))
+        self._cache_dir = os.path.join(hass.config.path("www"), *_CACHE_SUBDIR)
+
+    async def get(self, request: web.Request) -> web.StreamResponse:
+        """Return a resized JPEG for ``?path=<url>&w=<width>``."""
+        raw_path = request.query.get("path")
+        if not raw_path:
+            return web.Response(status=400, text="missing path")
+
+        try:
+            width = int(request.query.get("w", _DEFAULT_W))
+        except (TypeError, ValueError):
+            width = _DEFAULT_W
+        width = max(_MIN_W, min(_MAX_W, width))
+
+        src = self._resolve(raw_path)
+        if src is None:
+            return web.Response(status=404, text="not found")
+
+        try:
+            data = await self._hass.async_add_executor_job(
+                self._build_thumbnail, src, width
+            )
+        except FileNotFoundError:
+            return web.Response(status=404, text="not found")
+        except Exception as ex:  # noqa: BLE001 - never 500 the whole grid
+            _LOGGER.debug("Thumbnail build failed for %s: %s", src, ex)
+            # Fall back to the original so the tile still shows something.
+            raise web.HTTPFound(self._local_url(src)) from None
+
+        if data is None:
+            # Pillow unavailable → serve the original (un-resized) instead.
+            raise web.HTTPFound(self._local_url(src))
+
+        return web.Response(
+            body=data,
+            content_type="image/jpeg",
+            headers={"Cache-Control": "max-age=86400"},
+        )
+
+    def _resolve(self, raw_path: str) -> str | None:
+        """Map a ``/local/...`` URL (or www-relative path) to a file under www."""
+        path = raw_path.split("?", 1)[0]
+        if path.startswith("/local/"):
+            rel = path[len("/local/") :]
+        elif path.startswith("/config/www/"):
+            rel = path[len("/config/www/") :]
+        else:
+            rel = path.lstrip("/")
+
+        candidate = os.path.realpath(os.path.join(self._www, rel))
+        # Strict containment: candidate must be the www dir or below it.
+        if candidate != self._www and not candidate.startswith(self._www + os.sep):
+            return None
+        if not os.path.isfile(candidate):
+            return None
+        return candidate
+
+    def _local_url(self, abs_path: str) -> str:
+        """Build the public ``/local/...`` URL for an absolute www path."""
+        rel = os.path.relpath(abs_path, self._www).replace(os.sep, "/")
+        return f"/local/{rel}"
+
+    def _build_thumbnail(self, src: str, width: int) -> bytes | None:
+        """Return resized JPEG bytes (runs in executor). None if Pillow missing.
+
+        Results are cached on disk keyed by (path, width, mtime), so a file is
+        only re-encoded when it actually changes.
+        """
+        try:
+            from PIL import Image, ImageOps  # noqa: PLC0415 - optional, lazy
+        except ImportError:
+            return None
+
+        mtime = int(os.path.getmtime(src))
+        key = hashlib.sha1(f"{src}|{width}|{mtime}".encode()).hexdigest()
+        os.makedirs(self._cache_dir, exist_ok=True)
+        cache_file = os.path.join(self._cache_dir, f"{key}.jpg")
+
+        if os.path.isfile(cache_file):
+            with open(cache_file, "rb") as fh:
+                return fh.read()
+
+        with Image.open(src) as image:
+            # Honour EXIF orientation; cap to width (allow tall portraits).
+            image = ImageOps.exif_transpose(image)
+            image.thumbnail((width, width * 4))
+            if image.mode not in ("RGB", "L"):
+                image = image.convert("RGB")
+            tmp_file = f"{cache_file}.tmp"
+            image.save(tmp_file, format="JPEG", quality=78, optimize=True)
+        os.replace(tmp_file, cache_file)
+
+        with open(cache_file, "rb") as fh:
+            return fh.read()

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b42"
+  "version": "8.2.0b1"
 }

--- a/custom_components/samsungtv_smart/www/folder-gallery-card.js
+++ b/custom_components/samsungtv_smart/www/folder-gallery-card.js
@@ -66,6 +66,8 @@ class FolderGalleryCard extends HTMLElement {
       double_tap_action: config.double_tap_action || null,
       sensor: config.sensor || null, // Sensor that provides image list
       image_list: config.image_list || null, // Static list of images
+      server_thumbnails: config.server_thumbnails !== false, // resize via integration
+      thumbnail_width: config.thumbnail_width || 400,
       ...config
     };
     
@@ -523,6 +525,17 @@ class FolderGalleryCard extends HTMLElement {
     this.setupLightbox();
   }
 
+  _thumbUrl(path) {
+    // Route grid thumbnails through the integration's resize endpoint so a
+    // folder of full-size originals isn't downloaded at full resolution. Only
+    // applies to local files (/local/...); remote/absolute URLs are used as-is.
+    // The original path is still used for the lightbox and tap/hold actions.
+    if (this._config.server_thumbnails === false) return path;
+    if (!path || !path.startsWith('/local/')) return path;
+    const w = parseInt(this._config.thumbnail_width, 10) || 400;
+    return `/api/samsungtv_smart/thumbnail?path=${encodeURIComponent(path)}&w=${w}`;
+  }
+
   renderGallery() {
     const container = this.shadowRoot.querySelector('.gallery-container');
     const countEl = this.shadowRoot.querySelector('.image-count');
@@ -550,8 +563,8 @@ class FolderGalleryCard extends HTMLElement {
       <div class="gallery-grid">
         ${this._images.map((img, index) => `
           <div class="gallery-item" data-index="${index}" data-path="${img.path}" data-content-id="${img.content_id || ''}">
-            <img src="${img.path}" alt="${img.name}" loading="lazy" class="loading"
-                 onerror="this.classList.add('error')" 
+            <img src="${this._thumbUrl(img.path)}" alt="${img.name}" loading="lazy" decoding="async" class="loading"
+                 onerror="this.classList.add('error')"
                  onload="this.classList.remove('loading')">
             ${this._config.show_filename ? `
               <div class="image-overlay">


### PR DESCRIPTION
## Summary
Replaces the reverted client-side IntersectionObserver approach (#109, which left tiles blank). Targets `8.2-dev`.

The integration now serves **on-demand resized JPEG thumbnails** at `/api/samsungtv_smart/thumbnail` (resized with Pillow, cached on disk keyed by file+width+mtime). The gallery grid points its `<img>` at that endpoint instead of the full original, so a folder of multi-MB originals only sends **kilobytes per tile** to the browser. The full-resolution original is still used for the lightbox and tap/hold actions.

**Behaviour**
- Enabled by default; disable per card with `server_thumbnails: false`.
- Size via `thumbnail_width:` (default `400`).
- Only local files (`/local/...`) are routed through the resizer; remote URLs used as-is.
- If Pillow is unavailable, the endpoint transparently redirects to the original.

**Security**
- The view is unauthenticated by design — plain `<img>` requests carry no HA auth, and it only ever reads files under `<config>/www`, which HA already serves publicly at `/local/`. The requested path is strictly validated (realpath containment) against traversal.

## Test plan
- [ ] Point the gallery at a folder of multi-MB originals → tiles render as small thumbnails, fast, low memory
- [ ] Click a tile → full-resolution image opens in the lightbox
- [ ] tap / double-tap / hold actions still use the original `content_id`/path
- [ ] `server_thumbnails: false` → original behaviour (full images)
- [ ] Art Store / sensor galleries still render


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_