### PR TITLE
OAuth: stop refresh storm on invalid_grant, trigger reauth (8.1.0b42)

### DIFF
--- a/RELEASE_NOTES_8.1.0.md
+++ b/RELEASE_NOTES_8.1.0.md
@@ -1,5 +1,17 @@
 # Release notes — 8.1.0 (since 8.0.0)
 
+## OAuth — stop the refresh-storm when the SmartThings refresh token is dead
+
+- **A rejected refresh token no longer hammers the auth endpoint thousands of
+  times**: when SmartThings replies `invalid_grant` ("Invalid refresh token"),
+  the token can't be refreshed and only re-authentication fixes it — but the
+  integration kept retrying the refresh on every cycle (observed 7000+ failed
+  attempts/hour, spamming ERROR logs and risking an auth rate-limit). It now
+  recognises `invalid_grant` as terminal: it **stops retrying**, starts Home
+  Assistant's **reauth flow once** (you get a "reconfigure" prompt), and
+  resumes automatically once a valid token is stored again after you
+  re-authenticate.
+
 ## Art thumbnails — stop re-probing the unsupported list path on 2024+ Frames
 
 - **No more `SYSTEM_FAIL (-1)` log spam per thumbnail on 2024-2025 Frames**:

--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -179,6 +179,45 @@ _LOGGER = logging.getLogger(__name__)
 # This is shared across all entities (media_player, switch, sensor)
 _OAUTH_REFRESH_LOCKS: dict[str, asyncio.Lock] = {}
 _OAUTH_REFRESH_IN_PROGRESS: dict[str, bool] = {}
+# Set once the SmartThings refresh token is rejected with invalid_grant: the
+# refresh token is dead and retrying only hammers the auth endpoint (observed
+# thousands of times/hour). We stop attempting refresh and trigger a reauth
+# flow; the flag is cleared automatically once a valid token is stored again.
+_OAUTH_TOKEN_INVALID: dict[str, bool] = {}
+
+
+def is_oauth_token_invalid(entry_id: str) -> bool:
+    """True when the entry's refresh token was rejected and reauth is needed."""
+    return _OAUTH_TOKEN_INVALID.get(entry_id, False)
+
+
+def set_oauth_token_invalid(entry_id: str, invalid: bool) -> None:
+    """Mark/clear the entry's refresh token as invalid (reauth required)."""
+    _OAUTH_TOKEN_INVALID[entry_id] = invalid
+
+
+def is_invalid_grant_error(ex: Exception) -> bool:
+    """True when an OAuth refresh failure is the terminal invalid_grant case."""
+    text = str(ex).lower()
+    return "invalid_grant" in text or "invalid refresh token" in text
+
+
+def start_oauth_reauth(hass: HomeAssistant, entry_id: str) -> None:
+    """Latch the invalid-token flag and kick off HA's reauth flow once."""
+    if _OAUTH_TOKEN_INVALID.get(entry_id):
+        return  # already handled — don't spawn duplicate reauth flows
+    _OAUTH_TOKEN_INVALID[entry_id] = True
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if entry is not None:
+        _LOGGER.warning(
+            "[%s] SmartThings refresh token rejected (invalid_grant) — reauth "
+            "required; stopping refresh attempts until re-authenticated",
+            entry.title,
+        )
+        try:
+            entry.async_start_reauth(hass)
+        except Exception as exc:  # pylint: disable=broad-except
+            _LOGGER.debug("Could not start reauth flow: %s", exc)
 
 
 def get_oauth_refresh_lock(entry_id: str) -> asyncio.Lock:
@@ -499,6 +538,17 @@ async def async_get_samsungtv_api_key(  # noqa: C901
                         )
                         return access_token  # Try with expired token anyway
 
+                    # If the refresh token was already rejected (invalid_grant),
+                    # a reauth flow is pending — don't keep hammering the auth
+                    # endpoint on every cycle. Use the (expired) token and wait
+                    # for the user to re-authenticate.
+                    if is_oauth_token_invalid(entry.entry_id):
+                        _LOGGER.debug(
+                            "[%s] Skipping OAuth refresh — reauth pending",
+                            entry.title,
+                        )
+                        return access_token
+
                     # Acquire lock to prevent concurrent refresh. If another
                     # task is already refreshing, WAIT for it instead of
                     # returning the current (expired) token: platform setups
@@ -590,6 +640,7 @@ async def async_get_samsungtv_api_key(  # noqa: C901
                                     },
                                 )
                                 _LOGGER.info("OAuth token refreshed successfully")
+                                set_oauth_token_invalid(entry.entry_id, False)
                                 return new_token["access_token"]
                             else:
                                 _LOGGER.error(
@@ -598,7 +649,12 @@ async def async_get_samsungtv_api_key(  # noqa: C901
                                     "and add credentials for Samsung TV Smart."
                                 )
                         except Exception as ex:
-                            _LOGGER.error("Failed to refresh OAuth token: %s", ex)
+                            if is_invalid_grant_error(ex):
+                                # Terminal: refresh token is dead → reauth, stop
+                                # retrying (start_oauth_reauth logs + latches).
+                                start_oauth_reauth(hass, entry.entry_id)
+                            else:
+                                _LOGGER.error("Failed to refresh OAuth token: %s", ex)
                             # Try to use existing token anyway
                         finally:
                             set_oauth_refresh_in_progress(entry.entry_id, False)

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0b41"
+  "version": "8.1.0b42"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -67,7 +67,11 @@ from homeassistant.util.async_ import run_callback_threadsafe
 from . import (
     get_oauth_refresh_lock,
     get_smartthings_api_key,
+    is_invalid_grant_error,
+    is_oauth_token_invalid,
     set_oauth_refresh_in_progress,
+    set_oauth_token_invalid,
+    start_oauth_reauth,
 )
 from .api.art import SamsungTVAsyncArt
 from .api.ipcontrol import (
@@ -927,8 +931,16 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
         # Check if token needs refresh (within buffer period before expiration)
         if expires_at and current_time < (expires_at - OAUTH_TOKEN_REFRESH_BUFFER):
-            # Token still valid, no refresh needed
+            # Token still valid, no refresh needed. A valid token means any
+            # previous invalid_grant condition has been resolved (reauth done).
+            set_oauth_token_invalid(self._entry_id, False)
             return True
+
+        # If the refresh token was already rejected (invalid_grant), a reauth
+        # flow is pending — don't keep hammering the auth endpoint every cycle.
+        if is_oauth_token_invalid(self._entry_id):
+            self._log.debug("Skipping OAuth refresh — reauth pending")
+            return False
 
         # Token is expiring or expired
         time_until_expiry = expires_at - current_time if expires_at else 0
@@ -1003,14 +1015,21 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 new_token.get("expires_at", 0) - time.time(),
             )
             self._clear_oauth_issue()
+            set_oauth_token_invalid(self._entry_id, False)
             return True
 
         except Exception as ex:
-            self._log.error(
-                "Failed to refresh OAuth token: %s. "
-                "You may need to reconfigure the integration with OAuth.",
-                ex,
-            )
+            if is_invalid_grant_error(ex):
+                # Terminal: the refresh token is dead. Trigger reauth and stop
+                # retrying (start_oauth_reauth logs + latches the flag) so we
+                # don't hammer the SmartThings auth endpoint every cycle.
+                start_oauth_reauth(self.hass, self._entry_id)
+            else:
+                self._log.error(
+                    "Failed to refresh OAuth token: %s. "
+                    "You may need to reconfigure the integration with OAuth.",
+                    ex,
+                )
             self._raise_oauth_issue()
             return False
 


### PR DESCRIPTION
## Summary
From a user log (b41): the SmartThings **refresh token became invalid** (`invalid_grant` / "Invalid refresh token", HTTP 400). That's only fixable by re-authenticating — but the integration kept retrying the refresh on **every cycle**: the log shows **7016 failed refresh attempts** with matching ERROR spam. That hammers the SmartThings auth endpoint and risks an auth rate-limit/block.

Fix: treat `invalid_grant` as **terminal**:
- Latch a per-entry "token invalid" flag and **short-circuit** further refresh attempts (both in the module-level `async_get_samsungtv_api_key` and the media_player `_refresh_oauth_token`).
- Start Home Assistant's **reauth flow once** (`entry.async_start_reauth`) so the user gets a reconfigure prompt (plus the existing Repairs issue).
- The flag **auto-clears** as soon as a valid token is stored again (successful refresh, or a still-valid token after re-auth), so normal operation resumes on its own.

Non-terminal refresh errors (network blips, etc.) are unchanged — still logged and retried.

## Test plan
- [ ] With a revoked/expired refresh token, confirm at most one reauth flow starts and refresh attempts stop (no thousands of `invalid_grant` ERROR lines)
- [ ] Re-authenticate via the reauth prompt → refreshing resumes, flag clears, no reconfigure needed again
- [ ] A transient (non-invalid_grant) refresh failure still logs + retries as before


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_