### PR TITLE
Folder Gallery: expose thumbnails + tap/double-tap/hold in visual editor (8.2.0b2)

### DIFF
--- a/Frame_Art_Gallery.md
+++ b/Frame_Art_Gallery.md
@@ -228,6 +228,41 @@ action:
 > `service:`, or an object-form `tap_action:` — in addition to the legacy
 > `action: { service: ... }` shown above.
 
+### Editing in the UI (visual editor)
+
+You don't have to write YAML: add the card from the dashboard and use the
+visual editor. Besides the basic fields (title, sensor, folder, columns, image
+height) it exposes:
+
+- **Thumbnails** — a *Server-side thumbnails* checkbox and a *Thumbnail width*
+  field.
+- **Actions** — dropdowns for **single tap / double tap / long press**
+  (*Open preview / Display on TV / Nothing*) plus a *Frame TV entity* field.
+  Picking "Display on TV" builds the `samsungtv_smart.art_select_image` action
+  for you. Anything more advanced can still be done in the code editor.
+
+### Large folders of original photos
+
+Pointing the card at a folder of full-size originals (several MB each, many of
+them) would make the browser download and decode every original just to draw
+the grid. By default the card requests small **server-side resized thumbnails**
+instead (`server_thumbnails: true`), so only kilobytes per tile are sent; the
+full-resolution image is still used for the lightbox and tap/hold actions.
+
+```yaml
+type: custom:folder-gallery-card
+title: Photos
+folder_sensor: sensor.my_photos
+columns: 4
+thumbnail_width: 500        # sharper tiles; lower for less bandwidth
+# server_thumbnails: false  # load full originals instead
+```
+
+Thumbnails are cached on disk under `/config/www/frame_art/.thumb_cache/` and
+regenerated only when the source file changes (keyed by path + width + mtime).
+Requires Pillow (bundled with Home Assistant); if it's unavailable the endpoint
+transparently falls back to the original image.
+
 ### All Configuration Options
 
 | Option | Type | Default | Description |
@@ -242,6 +277,8 @@ action:
 | `border_radius` | string | `8px` | Image border radius |
 | `show_filename` | boolean | `true` | Show filename on hover |
 | `filter` | string | `*` | File filter pattern |
+| `server_thumbnails` | boolean | `true` | Serve small server-resized thumbnails for the grid instead of the full originals (recommended for folders of large photos). The full-resolution image is still used for the lightbox and actions. Set `false` to load originals. |
+| `thumbnail_width` | number | `400` | Width (px) of the server-generated thumbnails. Raise for sharper tiles, lower for even less bandwidth. |
 | `tap_action` | string/object | - | Action on single tap (e.g. `lightbox`, or a service/perform-action object) |
 | `double_tap_action` | object | - | Action on double tap (e.g. select the artwork directly). When set, a single tap is delayed slightly to detect the double tap. |
 | `hold_action` | object | - | Action on long press |

--- a/RELEASE_NOTES_8.2.0.md
+++ b/RELEASE_NOTES_8.2.0.md
@@ -2,6 +2,15 @@
 
 > **Status: pre-release (beta).** 8.2.0 builds on 8.1.0.
 
+## Folder Gallery card — more options in the visual editor
+
+- The card's visual editor now exposes, in addition to the basic fields:
+  - **Server-side thumbnails** (checkbox) and **Thumbnail width** (px).
+  - **Actions** for single tap / double tap / long press, each a simple
+    dropdown (*Open preview / Display on TV / Nothing*), plus a **Frame TV
+    entity** field used to build the "Display on TV" action. No need to hand-
+    write the YAML action objects anymore for the common setup.
+
 ## Folder Gallery card — server-side resized thumbnails for big folders
 
 - **The gallery now loads small resized thumbnails instead of the originals.**

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.2.0b1"
+  "version": "8.2.0b3"
 }

--- a/custom_components/samsungtv_smart/www/folder-gallery-card.js
+++ b/custom_components/samsungtv_smart/www/folder-gallery-card.js
@@ -1072,7 +1072,52 @@ class FolderGalleryCardEditor extends HTMLElement {
     this.render();
   }
 
+  // --- helpers to map between config actions and the simple dropdowns ------
+
+  _actionKind(action) {
+    // 'select' (display artwork on TV) | 'none'
+    if (!action || typeof action !== 'object') return 'none';
+    const svc = (action.service || action.perform_action || '').toLowerCase();
+    return svc.includes('art_select_image') ? 'select' : 'none';
+  }
+
+  _tapKind() {
+    const t = this._config.tap_action;
+    if (t === 'lightbox') return 'lightbox';
+    if (t === 'action') return this._actionKind(this._config.action);
+    if (typeof t === 'object') return this._actionKind(t);
+    return 'none';
+  }
+
+  _tvEntity() {
+    const from = (a) =>
+      a && typeof a === 'object' && a.target && a.target.entity_id
+        ? a.target.entity_id
+        : null;
+    return (
+      from(this._config.action) ||
+      from(this._config.double_tap_action) ||
+      from(this._config.hold_action) ||
+      ''
+    );
+  }
+
+  _buildSelectAction(tvEntity) {
+    if (!tvEntity) return null;
+    return {
+      perform_action: 'samsungtv_smart.art_select_image',
+      target: { entity_id: tvEntity },
+      data: { content_id: '{{content_id}}' },
+    };
+  }
+
   render() {
+    const tapKind = this._tapKind();
+    const dtapKind = this._actionKind(this._config.double_tap_action);
+    const holdKind = this._actionKind(this._config.hold_action);
+    const tvEntity = this._tvEntity();
+    const sel = (v, cur) => (v === cur ? 'selected' : '');
+
     this.shadowRoot.innerHTML = `
       <style>
         .form-row {
@@ -1091,6 +1136,7 @@ class FolderGalleryCardEditor extends HTMLElement {
           background: var(--card-background-color);
           color: var(--primary-text-color);
         }
+        .form-row input[type="checkbox"] { width: auto; margin-right: 8px; }
         .form-row .hint {
           display: block;
           margin-top: 4px;
@@ -1098,6 +1144,7 @@ class FolderGalleryCardEditor extends HTMLElement {
           font-weight: normal;
           color: var(--secondary-text-color);
         }
+        .section { margin: 16px 0 4px; font-weight: 700; opacity: 0.8; }
       </style>
 
       <div class="form-row">
@@ -1125,26 +1172,112 @@ class FolderGalleryCardEditor extends HTMLElement {
         <label>Columns</label>
         <input type="number" id="columns" value="${this._config.columns || 4}" min="1" max="10">
       </div>
-      
+
       <div class="form-row">
         <label>Image Height</label>
         <input type="text" id="image_height" value="${this._config.image_height || '150px'}">
       </div>
+
+      <div class="section">Thumbnails</div>
+      <div class="form-row">
+        <label><input type="checkbox" id="server_thumbnails" ${this._config.server_thumbnails !== false ? 'checked' : ''}>Server-side resized thumbnails</label>
+        <span class="hint">Recommended for folders of full-size originals — sends small thumbnails to the browser instead of the multi-MB files. The full image is still used on click.</span>
+      </div>
+      <div class="form-row">
+        <label>Thumbnail width (px)</label>
+        <input type="number" id="thumbnail_width" value="${this._config.thumbnail_width || 400}" min="64" max="1024">
+      </div>
+
+      <div class="section">Actions</div>
+      <div class="form-row">
+        <label>Frame TV entity (for "Display on TV")</label>
+        <input type="text" id="_tv_entity" value="${tvEntity}" placeholder="media_player.samsung_frame">
+      </div>
+      <div class="form-row">
+        <label>Single tap</label>
+        <select id="_tap_kind">
+          <option value="lightbox" ${sel('lightbox', tapKind)}>Open preview (lightbox)</option>
+          <option value="select" ${sel('select', tapKind)}>Display on TV</option>
+          <option value="none" ${sel('none', tapKind)}>Nothing</option>
+        </select>
+      </div>
+      <div class="form-row">
+        <label>Double tap</label>
+        <select id="_dtap_kind">
+          <option value="none" ${sel('none', dtapKind)}>Nothing</option>
+          <option value="select" ${sel('select', dtapKind)}>Display on TV</option>
+        </select>
+      </div>
+      <div class="form-row">
+        <label>Long press</label>
+        <select id="_hold_kind">
+          <option value="none" ${sel('none', holdKind)}>Nothing</option>
+          <option value="select" ${sel('select', holdKind)}>Display on TV</option>
+        </select>
+        <span class="hint">"Display on TV" needs the Frame TV entity above.</span>
+      </div>
     `;
 
-    // Add event listeners
-    ['title', 'folder', 'folder_sensor', 'columns', 'image_height'].forEach(field => {
-      const input = this.shadowRoot.getElementById(field);
-      if (input) {
-        input.addEventListener('change', (e) => {
-          let value = e.target.value;
-          if (field === 'columns') value = parseInt(value);
-          this.fireEvent('config-changed', { 
-            config: { ...this._config, [field]: value } 
-          });
-        });
+    const ids = [
+      'title',
+      'folder',
+      'folder_sensor',
+      'columns',
+      'image_height',
+      'server_thumbnails',
+      'thumbnail_width',
+      '_tv_entity',
+      '_tap_kind',
+      '_dtap_kind',
+      '_hold_kind',
+    ];
+    ids.forEach((id) => {
+      const el = this.shadowRoot.getElementById(id);
+      if (el) {
+        el.addEventListener('change', () => this._emit());
       }
     });
+  }
+
+  _emit() {
+    const g = (id) => this.shadowRoot.getElementById(id);
+    const cfg = { ...this._config };
+
+    cfg.title = g('title').value || '';
+    const sensor = g('folder_sensor').value.trim();
+    cfg.folder_sensor = sensor || undefined;
+    const folder = g('folder').value.trim();
+    cfg.folder = folder || undefined;
+    cfg.columns = parseInt(g('columns').value, 10) || 4;
+    cfg.image_height = g('image_height').value || '150px';
+    cfg.server_thumbnails = g('server_thumbnails').checked;
+    cfg.thumbnail_width = parseInt(g('thumbnail_width').value, 10) || 400;
+
+    const tv = g('_tv_entity').value.trim();
+    const selectAction = this._buildSelectAction(tv);
+
+    // Single tap
+    const tapKind = g('_tap_kind').value;
+    if (tapKind === 'lightbox') {
+      cfg.tap_action = 'lightbox';
+      cfg.action = undefined;
+    } else if (tapKind === 'select' && selectAction) {
+      cfg.tap_action = 'action';
+      cfg.action = selectAction;
+    } else {
+      cfg.tap_action = undefined;
+      cfg.action = undefined;
+    }
+
+    // Double tap / long press
+    cfg.double_tap_action =
+      g('_dtap_kind').value === 'select' ? selectAction || undefined : undefined;
+    cfg.hold_action =
+      g('_hold_kind').value === 'select' ? selectAction || undefined : undefined;
+
+    Object.keys(cfg).forEach((k) => cfg[k] === undefined && delete cfg[k]);
+    this._config = cfg;
+    this.fireEvent('config-changed', { config: cfg });
   }
 
   fireEvent(type, detail) {


### PR DESCRIPTION
## Summary
The `folder-gallery-card` visual editor was limited to title / sensor / folder / columns / image height. It now also exposes:

- **Thumbnails**: a *Server-side thumbnails* checkbox and a *Thumbnail width* (px) field (the 8.2.0b1 options).
- **Actions**: simple per-gesture dropdowns for **single tap / double tap / long press** — *Open preview (lightbox)* / *Display on TV* / *Nothing* — plus a **Frame TV entity** field. Choosing "Display on TV" builds the `samsungtv_smart.art_select_image` action (with `content_id: "{{content_id}}"`) targeting that entity, so the common setup no longer needs hand-written YAML action objects.

Reads the existing config back into the controls (detects `lightbox`, an `art_select_image` action, and the target entity), so opening the editor on a YAML-configured card shows the right selections. Full YAML editing still works for anything more advanced.

## Test plan
- [ ] Add the card via the UI → the new Thumbnails + Actions fields appear
- [ ] Set double-tap/long-press to "Display on TV" + a Frame TV entity → the YAML gets the correct `art_select_image` action; gestures work on the TV
- [ ] Open the editor on an existing YAML card → selections reflect the current config
- [ ] Toggle server thumbnails / change width → reflected in YAML and rendering


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_