### PR TITLE
Folder Gallery: per-gallery action buttons via gallery_type (8.2.0b4)

### DIFF
--- a/Frame_Art_Gallery.md
+++ b/Frame_Art_Gallery.md
@@ -234,6 +234,9 @@ You don't have to write YAML: add the card from the dashboard and use the
 visual editor. Besides the basic fields (title, sensor, folder, columns, image
 height) it exposes:
 
+- **Gallery type** — forces the fullscreen-preview buttons for the whole
+  gallery: *Personal* (Select + Delete), *Favorites* (Select + Unfavourite),
+  *Upload* (Upload), or *Auto* (detect per image).
 - **Thumbnails** — a *Server-side thumbnails* checkbox and a *Thumbnail width*
   field.
 - **Actions** — dropdowns for **single tap / double tap / long press**
@@ -277,6 +280,7 @@ transparently falls back to the original image.
 | `border_radius` | string | `8px` | Image border radius |
 | `show_filename` | boolean | `true` | Show filename on hover |
 | `filter` | string | `*` | File filter pattern |
+| `gallery_type` | string | *(auto)* | Forces which action buttons the fullscreen preview shows for the whole gallery: `personal` (Select + Delete), `favorites` (Select + Unfavourite), `upload` (Upload). Omit / `auto` = detect per image from the content-id prefix. |
 | `server_thumbnails` | boolean | `true` | Serve small server-resized thumbnails for the grid instead of the full originals (recommended for folders of large photos). The full-resolution image is still used for the lightbox and actions. Set `false` to load originals. |
 | `thumbnail_width` | number | `400` | Width (px) of the server-generated thumbnails. Raise for sharper tiles, lower for even less bandwidth. |
 | `tap_action` | string/object | - | Action on single tap (e.g. `lightbox`, or a service/perform-action object) |

--- a/RELEASE_NOTES_8.2.0.md
+++ b/RELEASE_NOTES_8.2.0.md
@@ -2,6 +2,17 @@
 
 > **Status: pre-release (beta).** 8.2.0 builds on 8.1.0.
 
+## Folder Gallery card — per-gallery action buttons (`gallery_type`)
+
+- **New `gallery_type` option** to force the fullscreen-preview action buttons
+  for a whole gallery, instead of guessing per image:
+  - `personal` → **Select** + **Delete**
+  - `favorites` → **Select** + **Unfavourite**
+  - `upload` → **Upload**
+  - omitted / `auto` → detect per image from the content-id prefix (previous
+    behaviour). Also available as a dropdown in the visual editor. Useful for an
+    upload folder of plain photos, which would otherwise be guessed per file.
+
 ## Folder Gallery card — more options in the visual editor
 
 - The card's visual editor now exposes, in addition to the basic fields:

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.2.0b3"
+  "version": "8.2.0b4"
 }

--- a/custom_components/samsungtv_smart/www/folder-gallery-card.js
+++ b/custom_components/samsungtv_smart/www/folder-gallery-card.js
@@ -68,6 +68,7 @@ class FolderGalleryCard extends HTMLElement {
       image_list: config.image_list || null, // Static list of images
       server_thumbnails: config.server_thumbnails !== false, // resize via integration
       thumbnail_width: config.thumbnail_width || 400,
+      gallery_type: config.gallery_type || null, // auto | personal | favorites | upload
       ...config
     };
     
@@ -736,17 +737,39 @@ class FolderGalleryCard extends HTMLElement {
     img.src = imageData.path;
     lightbox.classList.add('open');
 
-    const contentId = (imageData.content_id || imageData.name || '');
-    const upper = contentId.toUpperCase();
-    const isSam = upper.startsWith('SAM-') || upper.startsWith('SAM_');
-    const isMy = upper.startsWith('MY-') || upper.startsWith('MY_');
-    const isOther = !isSam && !isMy;
+    // Which action buttons to show. When `gallery_type` is set, it forces the
+    // button set for the whole gallery, so e.g. an upload folder always offers
+    // Upload even if a filename happens to look like a content id. Otherwise
+    // fall back to per-image detection from the content_id prefix.
+    let showSelect;
+    let showUnfavourite;
+    let showUpload;
+    let showDelete;
 
-    // SAM-: Select + Unfavourite
-    if (actionBtn) actionBtn.style.display = (isSam || isMy) ? 'inline-block' : 'none';
-    if (unfavouriteBtn) unfavouriteBtn.style.display = isSam ? 'inline-block' : 'none';
-    if (uploadBtn) uploadBtn.style.display = isOther ? 'inline-block' : 'none';
-    if (deleteBtn) deleteBtn.style.display = isMy ? 'inline-block' : 'none';
+    const gt = (this._config.gallery_type || 'auto').toLowerCase();
+    if (gt === 'personal') {
+      showSelect = true;  showUnfavourite = false; showUpload = false; showDelete = true;
+    } else if (gt === 'favorites' || gt === 'favourites') {
+      showSelect = true;  showUnfavourite = true;  showUpload = false; showDelete = false;
+    } else if (gt === 'upload') {
+      showSelect = false; showUnfavourite = false; showUpload = true;  showDelete = false;
+    } else {
+      // auto: infer from the content id
+      const contentId = imageData.content_id || imageData.name || '';
+      const upper = contentId.toUpperCase();
+      const isSam = upper.startsWith('SAM-') || upper.startsWith('SAM_');
+      const isMy = upper.startsWith('MY-') || upper.startsWith('MY_');
+      const isOther = !isSam && !isMy;
+      showSelect = isSam || isMy;
+      showUnfavourite = isSam;
+      showUpload = isOther;
+      showDelete = isMy;
+    }
+
+    if (actionBtn) actionBtn.style.display = showSelect ? 'inline-block' : 'none';
+    if (unfavouriteBtn) unfavouriteBtn.style.display = showUnfavourite ? 'inline-block' : 'none';
+    if (uploadBtn) uploadBtn.style.display = showUpload ? 'inline-block' : 'none';
+    if (deleteBtn) deleteBtn.style.display = showDelete ? 'inline-block' : 'none';
   }
 
   _getEntityId() {
@@ -1178,6 +1201,17 @@ class FolderGalleryCardEditor extends HTMLElement {
         <input type="text" id="image_height" value="${this._config.image_height || '150px'}">
       </div>
 
+      <div class="form-row">
+        <label>Gallery type (lightbox buttons)</label>
+        <select id="gallery_type">
+          <option value="auto" ${sel('auto', (this._config.gallery_type || 'auto'))}>Auto (detect per image)</option>
+          <option value="personal" ${sel('personal', this._config.gallery_type)}>Personal — Select + Delete</option>
+          <option value="favorites" ${sel('favorites', this._config.gallery_type)}>Favorites — Select + Unfavourite</option>
+          <option value="upload" ${sel('upload', this._config.gallery_type)}>Upload — Upload</option>
+        </select>
+        <span class="hint">Forces which action buttons appear in the fullscreen preview for the whole gallery.</span>
+      </div>
+
       <div class="section">Thumbnails</div>
       <div class="form-row">
         <label><input type="checkbox" id="server_thumbnails" ${this._config.server_thumbnails !== false ? 'checked' : ''}>Server-side resized thumbnails</label>
@@ -1224,6 +1258,7 @@ class FolderGalleryCardEditor extends HTMLElement {
       'folder_sensor',
       'columns',
       'image_height',
+      'gallery_type',
       'server_thumbnails',
       'thumbnail_width',
       '_tv_entity',
@@ -1252,6 +1287,8 @@ class FolderGalleryCardEditor extends HTMLElement {
     cfg.image_height = g('image_height').value || '150px';
     cfg.server_thumbnails = g('server_thumbnails').checked;
     cfg.thumbnail_width = parseInt(g('thumbnail_width').value, 10) || 400;
+    const gt = g('gallery_type').value;
+    cfg.gallery_type = gt && gt !== 'auto' ? gt : undefined;
 
     const tv = g('_tv_entity').value.trim();
     const selectAction = this._buildSelectAction(tv);


### PR DESCRIPTION
## Summary
Lets you declare what a gallery is for, so the fullscreen-preview action buttons match — instead of guessing per image from the content-id prefix.

New `gallery_type` option:
- `personal` → **Select** + **Delete**
- `favorites` → **Select** + **Unfavourite**
- `upload` → **Upload**
- omitted / `auto` → per-image detection (previous behaviour)

Also exposed as a **Gallery type** dropdown in the visual editor, and documented in `Frame_Art_Gallery.md` (options table + editor/notes). Particularly useful for an upload folder of plain photos, which auto-detection would otherwise classify file by file.

## Test plan
- [ ] `gallery_type: personal` → preview shows only Select + Delete
- [ ] `gallery_type: favorites` → Select + Unfavourite
- [ ] `gallery_type: upload` → Upload only
- [ ] no `gallery_type` → unchanged per-image behaviour
- [ ] Visual editor dropdown reflects and writes the value


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_