### PR TITLE
Picture mode select: hold set value until cloud confirms (8.1.1b1)

### DIFF
--- a/RELEASE_NOTES_8.1.1.md
+++ b/RELEASE_NOTES_8.1.1.md
@@ -1,0 +1,14 @@
+# Release notes — 8.1.1 (since 8.1.0)
+
+> **Status: pre-release (beta).**
+
+## Picture mode select — no longer reverts to the old mode after a change
+
+- **Setting the picture mode (e.g. via `select.select_option` or the Picture
+  Mode select) no longer snaps back to the previous value.** SmartThings lags
+  ~30-45s before it reports the new mode, but the select only skipped polling
+  for 5s — so the next poll read the *old* mode from the cloud and reverted the
+  selection (issue #116). The select now **holds the mode you set until the
+  cloud confirms it** (up to a 60s grace window); if the cloud still hasn't
+  confirmed after that, it accepts the cloud's value (so a change made on the TV
+  itself is still reflected).

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.1.0"
+  "version": "8.1.1b1"
 }

--- a/custom_components/samsungtv_smart/select.py
+++ b/custom_components/samsungtv_smart/select.py
@@ -944,6 +944,11 @@ class SamsungTVPictureModeSelect(SelectEntity):
         self._capability: str | None = None
         # Cooldown: skip polls briefly after setting a mode
         self._skip_poll_until: float = 0
+        # After a set, remember the desired mode and hold it until the cloud
+        # confirms it — SmartThings lags ~30-45s, so a plain short skip lets a
+        # stale "old mode" poll revert the selection (issue #116).
+        self._pending_mode: str | None = None
+        self._pending_until: float = 0
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -1082,10 +1087,14 @@ class SamsungTVPictureModeSelect(SelectEntity):
 
             self._attr_current_option = option
             self.async_write_ha_state()
-            # Skip polls for 5 seconds to let the TV apply the change;
-            # without this, the next async_update() reads the OLD mode
-            # from the TV (which hasn't switched yet) and overwrites ours.
-            self._skip_poll_until = time.time() + 5
+            # Short blind skip to let the TV apply the change, then hold the
+            # desired value until SmartThings actually reports it (cloud lag
+            # can be 30-45s). Without the hold, a poll in between reads the OLD
+            # mode and reverts the selection (issue #116).
+            now = time.time()
+            self._skip_poll_until = now + 5
+            self._pending_mode = option
+            self._pending_until = now + 60
 
         except Exception as ex:
             _LOGGER.error("Error setting picture mode to %s: %s", option, ex)
@@ -1136,6 +1145,28 @@ class SamsungTVPictureModeSelect(SelectEntity):
             self._attr_options = [*self._attr_options, new_mode]
             if raw_mode != new_mode:
                 self._mode_map[new_mode] = raw_mode
+
+        # Hold the just-set mode until the cloud confirms it. While a set is
+        # pending: if the cloud now reports our desired mode, it's confirmed;
+        # if it still reports the old value (cloud lag), keep our selection
+        # instead of reverting. After the grace window we accept whatever the
+        # cloud says (covers a genuine change made on the TV itself).
+        if self._pending_mode is not None:
+            if new_mode == self._pending_mode:
+                self._pending_mode = None
+                self._pending_until = 0
+            elif time.time() < self._pending_until:
+                _LOGGER.debug(
+                    "Picture mode: cloud still reports %s, holding pending %s",
+                    new_mode,
+                    self._pending_mode,
+                )
+                return
+            else:
+                # Grace expired without confirmation — give up on the pending
+                # value and accept the cloud's reading below.
+                self._pending_mode = None
+                self._pending_until = 0
 
         if new_mode != self._attr_current_option:
             _LOGGER.debug(


### PR DESCRIPTION
Superseded — the fix belongs on the active `v8.2-dev` line, not the 8.1.x line. Reopening as a PR targeting `v8.2-dev`.