### PR TITLE
Credit jaruba/channel-logos in README (8.2.0b8)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://buymeacoffee.com/thefab21"]

--- a/README.md
+++ b/README.md
@@ -705,6 +705,8 @@ Once a firmware update reports `artModeControl` correctly again, you can re-enab
 
 This project was a fork of [ollo69/ha-samsungtv-smart](https://github.com/ollo69/ha-samsungtv-smart), itself based on work by [@jaruba](https://github.com/jaruba) and [@screwdgeh](https://github.com/screwdgeh).
 
+Channel logos provided by [jaruba/channel-logos](https://github.com/jaruba/channel-logos) by [@jaruba](https://github.com/jaruba) — used by the media-player logo feature.
+
 Frame Art API based on [xchwarze/samsung-tv-ws-api](https://github.com/xchwarze/samsung-tv-ws-api) (art-updates branch), with contributions from Matthew Garrett and Nick Waterton.
 
 WebSocket library: [websocket-client](https://github.com/websocket-client/websocket-client) / [Xchwarze](https://github.com/Xchwarze).

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 [![Version](https://img.shields.io/github/v/release/TheFab21/ha-samsungtv-smart?style=flat&color=blue)](https://github.com/TheFab21/ha-samsungtv-smart/releases/latest)
 [![HA Version](https://img.shields.io/badge/Home%20Assistant-%3E%3D2025.6.0-green.svg)](https://www.home-assistant.io)
 [![License: LGPL v2.1](https://img.shields.io/badge/License-LGPL%20v2.1-yellow.svg)](https://www.gnu.org/licenses/lgpl-2.1)
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-ffdd00.svg?logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/thefab21)
 
 A custom integration for Home Assistant to control Samsung Smart TVs (Tizen OS), based on the excellent work of [ollo69/ha-samsungtv-smart](https://github.com/ollo69/ha-samsungtv-smart).
+
+If this project is useful to you, you can support its development: [buymeacoffee.com/thefab21](https://buymeacoffee.com/thefab21) ☕
 
 This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode support, picture mode and source selection fixes for 2024 Frame TVs, and OAuth2 authentication for SmartThings.
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 [![Version](https://img.shields.io/github/v/release/TheFab21/ha-samsungtv-smart?style=flat&color=blue)](https://github.com/TheFab21/ha-samsungtv-smart/releases/latest)
 [![HA Version](https://img.shields.io/badge/Home%20Assistant-%3E%3D2025.6.0-green.svg)](https://www.home-assistant.io)
 [![License: LGPL v2.1](https://img.shields.io/badge/License-LGPL%20v2.1-yellow.svg)](https://www.gnu.org/licenses/lgpl-2.1)
-[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-ffdd00.svg?logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/thefab21)
 
 A custom integration for Home Assistant to control Samsung Smart TVs (Tizen OS), based on the excellent work of [ollo69/ha-samsungtv-smart](https://github.com/ollo69/ha-samsungtv-smart).
 
-If this project is useful to you, you can support its development: [buymeacoffee.com/thefab21](https://buymeacoffee.com/thefab21) ☕
+If this project is useful to you, you can support its development:
+
+<a href="https://buymeacoffee.com/thefab21" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
 This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode support, picture mode and source selection fixes for 2024 Frame TVs, and OAuth2 authentication for SmartThings.
 

--- a/RELEASE_NOTES_8.2.0.md
+++ b/RELEASE_NOTES_8.2.0.md
@@ -2,6 +2,13 @@
 
 > **Status: pre-release (beta).** 8.2.0 builds on 8.1.0.
 
+## Credits — channel logos source attribution
+
+- The README now credits [jaruba/channel-logos](https://github.com/jaruba/channel-logos)
+  explicitly as the source of the channel logos used by the media-player logo
+  feature (`logo.py` fetches them from `jaruba.github.io/channel-logos`). It was
+  previously only mentioned indirectly as part of the fork lineage.
+
 ## Picture mode select — no longer reverts to the old mode after a change
 
 - **Setting the picture mode (e.g. via `select.select_option` or the Picture

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.2.0b7"
+  "version": "8.2.0b8"
 }


### PR DESCRIPTION
## Summary

`logo.py` fetches the channel logos from `https://jaruba.github.io/channel-logos/`
(the [jaruba/channel-logos](https://github.com/jaruba/channel-logos) data set),
but the README only credited @jaruba indirectly as part of the fork lineage —
not as the source of the logo data actively used by the media-player logo
feature.

This adds an explicit attribution line to the **Credits** section:

> Channel logos provided by [jaruba/channel-logos](https://github.com/jaruba/channel-logos) by [@jaruba](https://github.com/jaruba) — used by the media-player logo feature.

Version bumped to `8.2.0b8`; RELEASE_NOTES_8.2.0.md updated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_