### PR TITLE
Art Mode: force immediate SmartThings poll on art transitions (8.3.0b2)

### DIFF
--- a/RELEASE_NOTES_8.3.0.md
+++ b/RELEASE_NOTES_8.3.0.md
@@ -2,6 +2,18 @@
 
 > **Status: pre-release (beta).** 8.3.0 builds on 8.2.0.
 
+## Art Mode is detected immediately again after the polling rework (8.3.0b2)
+
+On some models (notably 2024 Frames where IP Control can't report the art
+state and the TV's REST `PowerState` stays `on` while displaying art),
+entering/leaving **Art Mode** is only learned from SmartThings. After the ST
+poll was throttled (below), a `select_image` / Art Mode change could take up to
+the ST interval (~30 s) to show up in `art_mode_status` / the current art.
+The integration now **forces an immediate SmartThings poll on an art-mode
+transition** (the local Art WebSocket already broadcasts it), so Art Mode is
+reflected within a second or two again — without giving up the throttle for
+idle polling.
+
 ## SmartThings polling — local WebSocket first, far fewer cloud calls
 
 Ahead of Samsung's move to a **paid SmartThings API** (free access phasing out

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0b1"
+  "version": "8.3.0b2"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -1087,6 +1087,14 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         """
         self.async_write_ha_state()
         self.hass.async_create_task(self._refresh_ip_art_mode())
+        # Some models (e.g. 2024 Frames where IP Control cannot report the art
+        # state and REST PowerState stays "on" in art mode) only learn about an
+        # art-mode transition from SmartThings. Since the ST poll is throttled,
+        # force it on the next update so entering/leaving Art Mode is reflected
+        # within a couple of seconds instead of waiting up to the ST interval.
+        if self._st:
+            self._st_last_poll = 0.0
+            self.async_schedule_update_ha_state(True)
 
     async def _refresh_ip_art_mode(self, _now=None) -> None:
         """Refresh the cached Art Mode value via IP Control.


### PR DESCRIPTION
## Summary

Follow-up to the polling rework (#122), fixing a regression it introduced.

**Symptom (from user logs):** TV on `smart_hub`, do a `select_image` → `art_mode_status` / current-art take **20–35 s** to update.

**Root cause (traced in the logs for a 2024 Frame QE55LS03D):**
- `IP Control art-mode ... unchanged (None)` — IP Control can't report the art state on this model.
- REST `PowerState: 'on'` even while displaying art — local REST can't detect art mode either.
- So art-mode detection **falls back to SmartThings**. The flip happened at `32:44`, right after the throttled ST poll — **~32 s after the select at `32:12`**, matching the new 30 s ST throttle. Before the rework the ST poll was ~10 s, so the throttle tripled the lag.

The local Art WebSocket **already broadcasts the transition** immediately (`art_mode_changed` / `go_to_standby` → `_on_art_transition`, which fired at `32:13` in the logs). It just refreshed IP Control (which returns `None` here) and didn't poll ST because of the throttle.

## Fix

In `_on_art_transition`, force the next SmartThings poll (reset the throttle timestamp + schedule an update) so an art-mode transition is reflected within ~1–2 s again:

```python
if self._st:
    self._st_last_poll = 0.0
    self.async_schedule_update_ha_state(True)
```

- Guarded on `self._st` (only when SmartThings is configured — the source that would otherwise lag).
- `_on_art_transition` fires **only** on `art_mode_changed` / `go_to_standby` (verified in `api/art.py`) — image browsing (`image_selected`, slideshow…) uses a separate content callback — so this does **not** re-introduce per-event ST spam. The idle-polling throttle is untouched.

Version → `8.3.0b2`; release notes updated.

## Test plan
- [ ] TV on, `select_image` / toggle Art Mode → `art_mode_status`, current art and the media_player card update within ~1–2 s (not ~30 s)
- [ ] Browsing artworks in Art Mode does not cause a burst of ST calls (only enter/leave transitions do)
- [ ] Idle throttle unchanged: no extra ST calls while just sitting in Art Mode or off

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_