### PR TITLE
Folder Gallery: fix lightbox action buttons in preview mode (8.3.0b3)

### DIFF
--- a/RELEASE_NOTES_8.3.0.md
+++ b/RELEASE_NOTES_8.3.0.md
@@ -2,6 +2,18 @@
 
 > **Status: pre-release (beta).** 8.3.0 builds on 8.2.0.
 
+## Folder Gallery card — fullscreen-preview buttons work again in lightbox mode (8.3.0b3)
+
+- **Fix: the lightbox buttons (Display on TV / Unfavourite / Delete / Upload)
+  did nothing** when the single tap was set to *Open preview (lightbox)* in the
+  visual editor. That mode cleared the card's `action`, but the buttons rely on
+  it for the Frame TV entity and the service to call, so every button silently
+  no-op'd. The editor now keeps the gallery type's primary action in lightbox
+  mode, and the Frame TV entity is also persisted on its own `frame_tv_entity`
+  key so the buttons always resolve a target.
+  - After updating, **re-open the card in the visual editor and save once** (or
+    re-select the Frame TV entity) so the new `frame_tv_entity` is written.
+
 ## Art Mode is detected immediately again after the polling rework (8.3.0b2)
 
 On some models (notably 2024 Frames where IP Control can't report the art

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0b2"
+  "version": "8.3.0b3"
 }

--- a/custom_components/samsungtv_smart/www/folder-gallery-card.js
+++ b/custom_components/samsungtv_smart/www/folder-gallery-card.js
@@ -1139,7 +1139,10 @@ class FolderGalleryCard extends HTMLElement {
       return this._config.action.target.entity_id;
     if (this._config.action && this._config.action.data && this._config.action.data.entity_id)
       return this._config.action.data.entity_id;
-    return '';
+    // Fallback to the dedicated Frame TV entity, so the lightbox buttons still
+    // resolve a target even when no `action` is configured (e.g. tap opens the
+    // lightbox and there is no separate tap action).
+    return this._config.frame_tv_entity || this._config.tv_entity || '';
   }
 
   _callUnfavourite(imageData) {
@@ -1507,6 +1510,8 @@ class FolderGalleryCardEditor extends HTMLElement {
         ? a.target.entity_id
         : null;
     return (
+      this._config.frame_tv_entity ||
+      this._config.tv_entity ||
       from(this._config.action) ||
       from(this._config.double_tap_action) ||
       from(this._config.hold_action) ||
@@ -1729,6 +1734,9 @@ class FolderGalleryCardEditor extends HTMLElement {
     cfg.gallery_type = gt && gt !== 'auto' ? gt : undefined;
 
     const tv = g('_tv_entity').value.trim();
+    // Persist the Frame TV entity on its own key so the lightbox buttons can
+    // always resolve a target, even when there is no `action` configured.
+    cfg.frame_tv_entity = tv || undefined;
 
     // Only keep gesture kinds that are valid for the selected gallery type
     // (e.g. switching to "upload" drops a stale "select"/"delete" choice).
@@ -1740,7 +1748,15 @@ class FolderGalleryCardEditor extends HTMLElement {
     const tapKind = clamp(g('_tap_kind').value, validTap);
     if (tapKind === 'lightbox') {
       cfg.tap_action = 'lightbox';
-      cfg.action = undefined;
+      // The fullscreen-preview buttons (Display on TV / Unfavourite / Delete /
+      // Upload) need a Frame TV entity + service to dispatch: the Select/Upload
+      // buttons run `config.action` and Unfavourite/Delete read the entity from
+      // it. Build the gallery type's primary action instead of clearing it,
+      // otherwise the lightbox opens but every button silently does nothing.
+      const gt = (cfg.gallery_type || 'auto').toLowerCase();
+      const primary = gt === 'upload' ? 'upload' : 'select';
+      const act = this._buildAction(primary, tv);
+      cfg.action = act || undefined;
     } else if (tapKind !== 'none') {
       const act = this._buildAction(tapKind, tv);
       cfg.tap_action = act ? 'action' : undefined;
@@ -1785,7 +1801,7 @@ window.customCards.push({
 });
 
 console.info(
-  '%c FOLDER-GALLERY-CARD %c v1.4.0 ',
+  '%c FOLDER-GALLERY-CARD %c v1.5.0 ',
   'color: white; background: #03a9f4; font-weight: bold;',
   'color: #03a9f4; background: white; font-weight: bold;'
 );


### PR DESCRIPTION
## Summary

Fix: in the Folder Gallery card, the fullscreen-preview (lightbox) buttons **Display on TV / Unfavourite / Delete / Upload** did nothing.

**Root cause:** when the single tap is set to *Open preview (lightbox)* in the visual editor, `_emit()` set `config.action = undefined`. But every lightbox button depends on `config.action`:
- Select/Upload run `executeAction(...)` → `config.action` (service + target).
- Unfavourite/Delete read the Frame TV entity via `_getEntityId()`, which only looked at `config.action.target.entity_id`.

With no action, `_getEntityId()` returned `''` and `executeAction` bailed out — so the lightbox opened but its buttons silently no-op'd (no service call ever reached HA, confirmed in the user's logs).

## Fix

- **Editor:** in lightbox mode, build the gallery type's **primary action** (`select`, or `upload` for upload galleries) instead of clearing it — so the buttons have a target + service.
- **Persist the Frame TV entity** on its own `frame_tv_entity` config key. `_getEntityId()` and the editor's entity field now fall back to it, so the buttons resolve a target even when there's no `action` at all. This also future-proofs against this whole class of bug.

## Upgrade note

Existing cards saved with *Open preview* have `action` already cleared and no `frame_tv_entity`. **Re-open the card in the visual editor and save once** (re-selecting the Frame TV entity) so the new key is written.

## Test plan
- [ ] Card with single tap = *Open preview (lightbox)*, gallery type Personal → Display on TV + Delete work
- [ ] Favorites gallery → Display on TV + Unfavourite work
- [ ] Upload gallery → Upload works (incl. multi-Frame chooser)
- [ ] Existing card: after re-saving in the editor, buttons work

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_