### PR TITLE
Frame Art: faster current-artwork updates (8.3.0b4)

### DIFF
--- a/RELEASE_NOTES_8.3.0.md
+++ b/RELEASE_NOTES_8.3.0.md
@@ -2,6 +2,24 @@
 
 > **Status: pre-release (beta).** 8.3.0 builds on 8.2.0.
 
+## Frame Art — current artwork updates much faster (8.3.0b4)
+
+- **A manual / gallery art change now shows up in the Frame Art sensor and
+  `current.jpg` in ~1–2 s instead of up to ~30 s.** Two things caused the lag:
+  the art coordinator polled every 15 s, and a *changed* `content_id` had to be
+  seen on **two consecutive polls** before being trusted (a guard against
+  spurious one-off readings from the TV) — so a change took up to two full
+  intervals to surface.
+  - The art coordinator now polls every **5 s** (the cheap `get_current_artwork`
+    read; the heavier content-list fetch stays throttled separately).
+  - When the change arrives as a **WebSocket art broadcast** (`image_selected`,
+    matte/slideshow/favorite/rotation) — which is definitive, not a glitch — the
+    new `content_id` is **trusted immediately**, skipping the two-poll
+    confirmation. The glitch guard still applies to unsolicited TV-side reads.
+  - Note: a slow `current.jpg` can still occur if the TV itself returns
+    `SYSTEM_FAIL` on the thumbnail request (a firmware issue); the integration
+    retries and falls back to a cached copy.
+
 ## Folder Gallery card — fullscreen-preview buttons work again in lightbox mode (8.3.0b3)
 
 - **Fix: the lightbox buttons (Display on TV / Unfavourite / Delete / Upload)

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0b3"
+  "version": "8.3.0b4"
 }

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -251,8 +251,15 @@ IP_CONTROL_STATE_SENSORS: tuple[SamsungIPControlSensorDescription, ...] = (
     ),
 )
 
-# Update interval for the Frame Art sensor (reduced for faster manual updates)
+# Default scan interval for the plain SmartThings child sensors
+# (illuminance / brightness — they self-throttle to the ST cadence anyway).
 SCAN_INTERVAL = timedelta(seconds=15)
+
+# The Frame Art coordinator polls the (cheap, local) art WebSocket for the
+# current artwork; keep it snappy so a manual/gallery art change shows up fast.
+# The heavier get_content_list call is throttled separately
+# (CONF_CONTENT_LIST_INTERVAL), so this short cadence stays cheap.
+FRAME_ART_SCAN_INTERVAL = timedelta(seconds=5)
 
 
 async def async_setup_entry(
@@ -339,12 +346,17 @@ async def async_setup_entry(
 
         # Create the coordinator
         coordinator = FrameArtCoordinator(hass, art_api, entry)
+
         # Refresh immediately on artwork/matte/slideshow/favorite/rotation
-        # broadcasts instead of waiting up to SCAN_INTERVAL for the change
-        # to be picked up by the next poll.
-        art_api.register_art_content_callback(
-            lambda: hass.async_create_task(coordinator.async_request_refresh())
-        )
+        # broadcasts instead of waiting up to the scan interval for the change
+        # to be picked up by the next poll. The broadcast is a definitive change,
+        # so let that refresh trust a new content_id right away (skip the
+        # two-poll confirmation that only exists to filter spurious glitches).
+        def _on_art_content() -> None:
+            coordinator._trust_next_content_id = True
+            hass.async_create_task(coordinator.async_request_refresh())
+
+        art_api.register_art_content_callback(_on_art_content)
 
         # Add Frame Art sensor
         entities.append(
@@ -585,12 +597,17 @@ class FrameArtCoordinator(DataUpdateCoordinator):
             hass,
             self._log,
             name=f"Frame Art {entry.title}",
-            update_interval=SCAN_INTERVAL,
+            update_interval=FRAME_ART_SCAN_INTERVAL,
         )
         self._art_api = art_api
         self._entry = entry
         self._hass = hass
         self._last_content_id: str | None = None
+        # Set by the art content-event callback (image_selected / matte / etc.):
+        # a WS broadcast is a definitive change, so the next poll may trust a new
+        # content_id immediately instead of waiting for the two-poll confirmation
+        # that guards against spurious get_current_artwork glitches.
+        self._trust_next_content_id = False
         # content_id that the saved current.jpg actually represents. Tracked
         # separately from "does current.jpg exist on disk" so a stale file from
         # a previous artwork cannot masquerade as the current content's
@@ -1047,6 +1064,13 @@ class FrameArtCoordinator(DataUpdateCoordinator):
         if raw_content_id is None:
             # Failed/empty poll: don't disturb the trusted value or pending state.
             return None
+        if self._trust_next_content_id:
+            # This poll was triggered by a definitive WS art broadcast — trust
+            # the reported id immediately, no two-poll confirmation needed.
+            self._trust_next_content_id = False
+            self._confirmed_content_id = raw_content_id
+            self._pending_content_id = None
+            return raw_content_id
         if raw_content_id == self._confirmed_content_id:
             # Steady state: clear any half-seen pending change.
             self._pending_content_id = None


### PR DESCRIPTION
## Summary

Fixes the ~15–30 s lag before a manual / gallery art change appears in `sensor.<tv>_frame_art` and `current.jpg`.

**Root cause (from the user's logs):** two compounding delays —
1. the Frame Art coordinator polled every **15 s**, and
2. a *changed* `content_id` had to be seen on **two consecutive polls** before being trusted (`_confirm_content_id`, a guard against spurious one-off `get_current_artwork` readings during matte/select ops). So even though `image_selected` triggers an immediate refresh, that first poll only marked the id *pending*; the second poll (15 s later) confirmed it → up to ~30 s.

## Changes

- **Poll every 5 s** — new `FRAME_ART_SCAN_INTERVAL = 5s` for the coordinator (was the shared 15 s `SCAN_INTERVAL`). Only the cheap `get_current_artwork` runs at this cadence; the heavier `get_content_list` stays throttled via `CONF_CONTENT_LIST_INTERVAL` (default 300 s), so it stays cheap.
- **Trust WS broadcasts immediately** — the art content-event callback (`image_selected` / matte / slideshow / favorite / rotation) now sets a `_trust_next_content_id` flag, so the refresh it triggers **skips the two-poll confirmation** (a WS broadcast is definitive, not a glitch). Unsolicited TV-side reads still go through the two-poll guard.

Net effect: a gallery/manual art change surfaces in ~1–2 s instead of up to ~30 s.

> Note: a slow `current.jpg` can still happen if the TV returns `SYSTEM_FAIL` on the thumbnail request (firmware); the integration retries and falls back to a cached copy. That's TV-side and separate from this change.

## Test plan
- [ ] Select an artwork (gallery card or TV) → Frame Art sensor `content_id` updates within ~1–2 s
- [ ] `current.jpg` updates promptly when the TV serves the thumbnail
- [ ] A spurious one-off TV reading (not from a WS broadcast) is still debounced (no flicker)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_