### PR TITLE
Frame Art: use already-downloaded thumbnail for current.jpg first (8.3.0b5)

### DIFF
--- a/RELEASE_NOTES_8.3.0.md
+++ b/RELEASE_NOTES_8.3.0.md
@@ -2,6 +2,17 @@
 
 > **Status: pre-release (beta).** 8.3.0 builds on 8.2.0.
 
+## Frame Art — `current.jpg` uses the already-downloaded thumbnail first (8.3.0b5)
+
+- **When the artwork changes, `current.jpg` is now taken from the local copy we
+  already downloaded (personal/store/other) *first*, and the TV is only queried
+  if we don't have it.** Previously the card did the flaky live TV fetch first
+  (which returns `SYSTEM_FAIL` on some Frame models), retried three times over
+  ~8 s, and only *then* fell back to the cached copy — so `current.jpg` could
+  lag ~30–45 s even for artworks whose thumbnail was already on disk. Downloaded
+  thumbnails don't change, so the local copy is both instant and more reliable.
+  Genuinely new artwork (no local copy yet) still falls back to a live fetch.
+
 ## Frame Art — current artwork updates much faster (8.3.0b4)
 
 - **A manual / gallery art change now shows up in the Frame Art sensor and

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0b4"
+  "version": "8.3.0b5"
 }

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -1281,6 +1281,14 @@ class FrameArtCoordinator(DataUpdateCoordinator):
         """
         import os
 
+        # Fast path: if this artwork's thumbnail was already downloaded in a
+        # previous cycle (personal/store/other), promote that local copy to
+        # current.jpg straight away and skip the live TV fetch. Downloaded
+        # thumbnails don't change, and the live fetch is flaky (SYSTEM_FAIL on
+        # some Frame models), so the local copy is both faster and more reliable.
+        if await self._restore_current_from_cache(content_id):
+            return
+
         self._log.info("Frame Art: Starting thumbnail fetch for %s", content_id)
 
         # Art Store (SAM-S*) thumbnails only exist once the TV has materialized
@@ -1403,7 +1411,7 @@ class FrameArtCoordinator(DataUpdateCoordinator):
         # valid — so an earlier copy is a much better fallback than a generic
         # "image unavailable" placeholder.
         # (Fallback approach contributed by @PrestonMcAfee.)
-        if await self._restore_current_from_cache(content_id):
+        if await self._restore_current_from_cache(content_id, after_failure=True):
             return
 
         # Art Store content the TV hasn't materialized yet: the failure is
@@ -1464,12 +1472,16 @@ class FrameArtCoordinator(DataUpdateCoordinator):
             return "store"
         return "other"
 
-    async def _restore_current_from_cache(self, content_id: str) -> bool:
+    async def _restore_current_from_cache(
+        self, content_id: str, after_failure: bool = False
+    ) -> bool:
         """Reuse a previously-downloaded thumbnail as current.jpg.
 
-        When the live thumbnail fetch fails (a transient TV/WebSocket issue),
-        fall back to the copy saved under personal/store/other during an
-        earlier successful download, instead of showing an error placeholder.
+        Used both as the fast path (before any live fetch — a downloaded copy is
+        authoritative and doesn't change) and as the fallback when a live
+        thumbnail fetch fails, instead of showing an error placeholder. The
+        copy lives under personal/store/other from an earlier successful
+        download. ``after_failure`` only tunes the log wording.
 
         Returns True if a cached copy was found and promoted to current.jpg.
         """
@@ -1508,12 +1520,20 @@ class FrameArtCoordinator(DataUpdateCoordinator):
             return False
 
         if promoted:
-            self._log.info(
-                "Frame Art: live thumbnail fetch failed for %s; reused cached "
-                "copy from %s/ as current.jpg",
-                content_id,
-                subdir,
-            )
+            if after_failure:
+                self._log.info(
+                    "Frame Art: live thumbnail fetch failed for %s; reused cached "
+                    "copy from %s/ as current.jpg",
+                    content_id,
+                    subdir,
+                )
+            else:
+                self._log.debug(
+                    "Frame Art: used already-downloaded copy of %s from %s/ as "
+                    "current.jpg (skipped live fetch)",
+                    content_id,
+                    subdir,
+                )
             self._thumbnail_failures = 0
             self._current_thumbnail_content_id = content_id
             self._clear_store_retry(content_id)


### PR DESCRIPTION
## Summary

Implements the inversion you suggested: for `current.jpg`, **use the local copy we already downloaded first, and only query the TV if we don't have it.**

**Before:** on an art change, `_fetch_and_save_thumbnail` did the live TV `get_thumbnail` **first** — which returns `SYSTEM_FAIL` on some Frame models (seen repeatedly in your logs) — retried 3× over ~8 s, and only *then* fell back to the cached copy under `personal/store/other`. So `current.jpg` could lag ~30–45 s even though the thumbnail was already on disk (`Thumbnail already exists for MY_F0001, skipping download`).

**After:** promote the already-downloaded local copy to `current.jpg` **first** (instant, no network), and only fall back to the live fetch when there's no local copy (genuinely new artwork). Downloaded thumbnails don't change, so the local copy is both faster and more reliable.

## Implementation

Reuses the existing `_restore_current_from_cache()` — it already does exactly the promote-cached-copy work, it was just called too late (only after the failed live fetch). It's now called:
- as the **fast path** at the top of `_fetch_and_save_thumbnail` (skip the live fetch on a cache hit), and
- as before, as the **post-failure fallback**.

An `after_failure` flag only tunes the log wording (debug on the fast path, the existing info line on the fallback).

## Test plan
- [ ] Change to an artwork whose thumbnail is already downloaded → `current.jpg` updates ~instantly, no `SYSTEM_FAIL` retry storm in the log
- [ ] Change to a brand-new artwork (no local copy) → still fetched live, then saved
- [ ] `current.jpg` still reflects the correct artwork (no stale image)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_