### PR TITLE
Resync v8.2-dev into v8.3-dev (SmartThings pricing notice + funding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ Or manually add the custom repository in HACS:
 
 ### SmartThings Authentication
 
+> ⚠️ **Upcoming SmartThings API pricing change.** Samsung has announced that the
+> SmartThings API will move to paid tiers, with free access phasing out around
+> **October 2026** (a **$4.99/month "Personal" plan** with a monthly call quota
+> for individual/non-commercial developers, plus separate commercial tiers —
+> exact quotas not yet published). All SmartThings features of this integration
+> (picture mode, channel/app info, sound mode, etc.) call the SmartThings API
+> **under your own Samsung account**, so this may eventually apply to you, not
+> just to the project itself. Nothing changes today and no code changes are
+> required yet — this integration still works exactly as before. We're tracking
+> the published quotas and will document any impact (e.g. reducing polling
+> frequency) once Samsung releases the details. See the
+> [SmartThings blog post](https://blog.smartthings.com/smartthings-updates/a-new-enhanced-smartthings-api-experience/)
+> for the announcement.
+
 Three methods are available. Choose **one**.
 
 ---

--- a/RELEASE_NOTES_8.2.0.md
+++ b/RELEASE_NOTES_8.2.0.md
@@ -2,6 +2,16 @@
 
 > **Status: pre-release (beta).** 8.2.0 builds on 8.1.0.
 
+## README — heads-up about the upcoming SmartThings API pricing change
+
+- Added a notice in the SmartThings Authentication section: Samsung announced
+  the SmartThings API is moving to paid tiers (a $4.99/month "Personal" plan
+  with a monthly call quota, plus separate commercial tiers), with free access
+  phasing out around October 2026. Since this integration's SmartThings calls
+  run under each user's own Samsung account, this may eventually affect users
+  directly. No code changes are required today — this is purely informational
+  until Samsung publishes concrete quotas.
+
 ## Credits — channel logos source attribution
 
 - The README now credits [jaruba/channel-logos](https://github.com/jaruba/channel-logos)

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.2.0b8"
+  "version": "8.2.0b9"
 }


### PR DESCRIPTION
## Summary

Merges `v8.2-dev` into `v8.3-dev` to carry over the two things that landed on `v8.2-dev` **after** `v8.3-dev` was branched:

- the **SmartThings API pricing notice** in the README's SmartThings Authentication section (#121);
- the **Buy Me a Coffee** funding link / button (already partly present; the merge reconciles the latest version).

## Conflict resolution

- `manifest.json` → kept **`8.3.0b6`** (over the incoming `8.2.0b9`).
- `RELEASE_NOTES_8.2.0.md` → kept **deleted** (it was consolidated into `RELEASE_NOTES_8.3.0.md` in #127). Its one section not yet reflected there — the SmartThings API pricing heads-up — is added to the *"Also included from the 8.2.0 beta"* block of `RELEASE_NOTES_8.3.0.md`.
- `README.md` → auto-merged; the pricing notice is now present on `v8.3-dev`.

Docs/merge only — no code changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_