### PR TITLE
Picture mode: verify the TV applied it, retry via the other capability (#116)

### DIFF
--- a/RELEASE_NOTES_8.3.0.md
+++ b/RELEASE_NOTES_8.3.0.md
@@ -14,6 +14,22 @@ If this project is useful to you, you can support its development:
 > the new `frame_tv_entity` key so the fullscreen-preview buttons work — see the
 > *lightbox buttons* note below.
 
+## Picture mode — verify the TV applied it, retry via the other capability (8.3.0b11)
+
+- **Fix for picture-mode changes that SmartThings accepts but the TV silently
+  ignores** (issue #116, seen on an S90C and a Frame 2020 under self-published
+  OAuth app clients: `setPictureMode` returns `200 COMPLETED`, the official app
+  and a PAT actuate the panel fine, yet the command from the OAuth client does
+  nothing). Previously the integration fell back from `custom.picturemode` to
+  `samsungvd.pictureMode` only when the HTTP call *errored* — a lying
+  `COMPLETED` meant the fallback never fired. Now, after every accepted send,
+  the integration **reads the mode back (~5 s later) and, if the TV still
+  reports the old mode, re-sends through the other capability**. If neither
+  can be confirmed, a clear warning points at the cloud command channel
+  (a duplicate send of the same mode is harmless on TVs where the first one
+  worked). Verification is skipped rather than retried when the read-back
+  itself fails, so flaky cloud reads can't cause spurious double-sends.
+
 ## Picture calibration — stop the sliders flapping available/unavailable (8.3.0b10)
 
 - **Fix: the new Contrast/Brightness/Sharpness/Color/Tint sliders kept dropping

--- a/custom_components/samsungtv_smart/api/smartthings.py
+++ b/custom_components/samsungtv_smart/api/smartthings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from datetime import timedelta
 from enum import Enum
@@ -38,6 +39,13 @@ class _STLoggerAdapter(logging.LoggerAdapter):
 # SmartThings REST API
 API_BASEURL = "https://api.smartthings.com/v1"
 API_DEVICES = f"{API_BASEURL}/devices"
+
+# Seconds to wait after a setPictureMode + refresh before reading the mode
+# back to check the TV actually applied it. Long enough for the refresh to
+# propagate a fresh panel read to the cloud in the common case, short enough
+# that a wrongly-unconfirmed retry (a harmless duplicate send of the same
+# mode via the other capability) doesn't feel laggy.
+PICTURE_MODE_VERIFY_DELAY = 5
 
 # Device types
 DEVICE_TYPE_OCF = "OCF"
@@ -912,6 +920,14 @@ class SmartThingsTV:
         Tries both capability variants: some Samsung TVs accept commands
         on custom.picturemode but not samsungvd.pictureMode, or vice versa.
         We try the detected capability first, then fall back to the other.
+
+        A successful HTTP send is NOT enough to stop: some TVs answer
+        ``200 COMPLETED`` and then silently drop the command — observed with
+        ``custom.picturemode`` under self-published OAuth app clients (the
+        official app / a PAT actuate the same panel fine, issue #116). So
+        after each accepted send the mode is read back, and if the TV did
+        not apply it the other capability is tried too. A redundant send of
+        the same target mode is harmless.
         """
         if self._state != STStatus.STATE_ON:
             self._log.debug(
@@ -940,6 +956,7 @@ class SmartThingsTV:
         )
         capabilities_to_try = [primary, fallback]
 
+        any_sent = False
         for capability in capabilities_to_try:
             try:
                 await self._send_rest_command(
@@ -947,29 +964,96 @@ class SmartThingsTV:
                     command="setPictureMode",
                     arguments=[mode_id],
                 )
-                self._log.debug(
-                    "Picture mode '%s' (id: %s) sent via %s",
-                    mode,
-                    mode_id,
-                    capability,
-                )
-                self._picture_mode = mode
-
-                # Send a refresh command to force the TV to update its
-                # cached state in SmartThings cloud. Without this, the API
-                # returns stale values (e.g. always "Standard") until the
-                # SmartThings app is opened. Samsung confirmed this behavior
-                # and recommended the refresh workaround.
-                await self._async_refresh_device_status()
-                return
             except Exception as err:
                 self._log.debug(
                     "setPictureMode via %s failed: %s, trying fallback",
                     capability,
                     err,
                 )
+                continue
+            self._log.debug(
+                "Picture mode '%s' (id: %s) sent via %s",
+                mode,
+                mode_id,
+                capability,
+            )
+            any_sent = True
+            self._picture_mode = mode
 
-        self._log.error("Failed to set picture mode '%s' via both capabilities", mode)
+            # Send a refresh command to force the TV to update its
+            # cached state in SmartThings cloud. Without this, the API
+            # returns stale values (e.g. always "Standard") until the
+            # SmartThings app is opened. Samsung confirmed this behavior
+            # and recommended the refresh workaround.
+            await self._async_refresh_device_status()
+
+            # Read the mode back: COMPLETED does not guarantee the panel
+            # applied it (see docstring). None = could not verify — assume
+            # applied rather than blind-firing the other capability.
+            applied = await self._async_verify_picture_mode(mode_id)
+            if applied is not False:
+                return
+            self._log.warning(
+                "setPictureMode via %s was accepted (COMPLETED) but the TV "
+                "still reports another mode — trying the other capability",
+                capability,
+            )
+
+        if not any_sent:
+            self._log.error(
+                "Failed to set picture mode '%s' via both capabilities", mode
+            )
+        else:
+            # Both accepted-but-unapplied (or the second one unverifiable).
+            # Keep the optimistic value: the select entity holds the pending
+            # mode and reconciles with the cloud on its own grace window.
+            self._log.warning(
+                "Picture mode '%s' could not be confirmed on the TV via any "
+                "capability; if it did not change, the cloud command channel "
+                "likely cannot actuate this panel (see issue #116)",
+                mode,
+            )
+
+    async def _async_verify_picture_mode(self, mode_id: str) -> bool | None:
+        """Return whether the TV now reports ``mode_id``, None if unknown.
+
+        Waits a few seconds after the refresh command so the cloud has a
+        chance to re-read the panel, then GETs the capability status
+        directly. Returns None when the read fails — the caller must not
+        treat that as "not applied".
+        """
+        if not self._device_id or not self._session:
+            return None
+        await asyncio.sleep(PICTURE_MODE_VERIFY_DELAY)
+        capability = self._picture_mode_capability or "samsungvd.pictureMode"
+        url = (
+            f"{API_DEVICES}/{self._device_id}"
+            f"/components/main/capabilities/{capability}/status"
+        )
+        try:
+            async with self._session.get(
+                url,
+                headers={
+                    "Authorization": f"Bearer {self._get_api_key()}",
+                    "Accept": "application/json",
+                },
+            ) as resp:
+                if resp.status != 200:
+                    self._log.debug(
+                        "Picture mode verify read failed (status %s)", resp.status
+                    )
+                    return None
+                data = await resp.json()
+        except Exception as err:
+            self._log.debug("Picture mode verify read failed: %s", err)
+            return None
+        raw_mode = data.get("pictureMode", {}).get("value")
+        if not raw_mode:
+            return None
+        self._log.debug(
+            "Picture mode verify: TV reports '%s' (wanted '%s')", raw_mode, mode_id
+        )
+        return raw_mode == mode_id
 
     async def _async_refresh_device_status(self) -> None:
         """Send a 'refresh' command to force SmartThings to re-read TV state.

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0b10"
+  "version": "8.3.0b11"
 }


### PR DESCRIPTION
Fix for #116, `8.3.0b11` — one commit on top of `v8.3-dev`.

## Problem
Some TVs answer **`200 COMPLETED`** to `custom.picturemode/setPictureMode` and then silently drop the command. Confirmed by two reporters on #116 — an **S90C** and a **Frame 2020 32"** — both under **self-published OAuth app clients**, while the official SmartThings app, a PAT, and SmartThings Routines all actuate the same panel fine. So the TV supports remote actuation; Samsung appears to filter the *custom* capability command from unpublished OAuth clients while still acknowledging it (standard capabilities like volume/source go through).

The integration's capability fallback (`custom.picturemode` ↔ `samsungvd.pictureMode`) only fired on an HTTP *error* — a lying `COMPLETED` meant the other capability was never tried.

## Fix
`async_set_picture_mode` now **reads the mode back** after each accepted send (refresh command + ~5 s, direct REST GET of the capability status):
- **confirmed** (TV reports the requested mode) → done;
- **unverifiable** (read-back failed) → stop, as before — no blind double-sends on flaky cloud reads;
- **confirmed NOT applied** → re-send through the other capability, then verify again (a duplicate send of the same mode is harmless on TVs where the first one worked);
- **neither confirmed** → keep the optimistic value (the select's grace window reconciles) and log a clear warning pointing at the cloud command channel — no more silent failure.

Cost: ~5 s verification latency after a picture-mode change (~10 s worst case when both capabilities are tried).

## Testing
- `flake8` / `isort` / `black` clean.
- To be validated by the #116 reporters under OAuth: expected outcome is either `samsungvd.pictureMode` actuates the panel (issue solved), or the new warning replaces the silent failure and the documented workaround remains SmartThings Routines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_