### PR TITLE
Picture mode: memorize the verified-working capability, persist across restarts (#116)

### DIFF
--- a/RELEASE_NOTES_8.3.0.md
+++ b/RELEASE_NOTES_8.3.0.md
@@ -14,6 +14,21 @@ If this project is useful to you, you can support its development:
 > the new `frame_tv_entity` key so the fullscreen-preview buttons work — see the
 > *lightbox buttons* note below.
 
+## Picture mode — the working capability is memorized and tried first (8.3.0b12)
+
+- **Once a picture-mode change is *verified applied* through a given SmartThings
+  capability, that capability is memorized and tried first on every later
+  change** — including after an HA restart (persisted in the config entry). So
+  on TVs where `custom.picturemode` returns a lying `COMPLETED` (issue #116),
+  the ~5–10 s verify-and-fallback cost is only paid on the *first* change;
+  subsequent ones go straight through the working `samsungvd.pictureMode`.
+  - The other capability always remains as fallback: if the panel's behaviour
+    ever changes (e.g. firmware update), a later verified apply through the
+    other capability simply overwrites the memory.
+  - Only a **verified** apply is memorized — an unverifiable send (flaky cloud
+    read) never updates the memory, so it can't learn the wrong capability.
+  - Persisting the learned capability does **not** reload the integration.
+
 ## Picture mode — verify the TV applied it, retry via the other capability (8.3.0b11)
 
 - **Fix for picture-mode changes that SmartThings accepts but the TV silently

--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -67,6 +67,7 @@ from .const import (
     CONF_SHOW_CHANNEL_NR,
     CONF_SOURCE_LIST,
     CONF_ST_ENTRY_UNIQUE_ID,
+    CONF_ST_PICTURE_MODE_CAPABILITY,
     CONF_ST_POLL_ON_INTERVAL,
     CONF_SUPPORTS_GET_BRIGHTNESS,
     CONF_SUPPORTS_GET_COLOR_TEMPERATURE,
@@ -1187,11 +1188,17 @@ _RELOAD_OPTIONS = (
     CONF_ST_POLL_ON_INTERVAL,
 )
 
+# entry.data keys persisted at RUNTIME as learned device facts, not connection
+# settings: writing them must NOT reload the integration (a reload would tear
+# down the very clients that just learned the fact — and reloads are exactly
+# what the verify-and-fallback logic runs right after a user action).
+_NO_RELOAD_DATA_KEYS = (CONF_ST_PICTURE_MODE_CAPABILITY,)
+
 
 def _reload_fingerprint(entry: ConfigEntry) -> tuple:
     """Snapshot the parts of an entry whose change requires a reload."""
     return (
-        dict(entry.data),
+        {k: v for k, v in entry.data.items() if k not in _NO_RELOAD_DATA_KEYS},
         tuple(entry.options.get(key) for key in _RELOAD_OPTIONS),
     )
 

--- a/custom_components/samsungtv_smart/api/smartthings.py
+++ b/custom_components/samsungtv_smart/api/smartthings.py
@@ -114,9 +114,27 @@ class SmartThingsTV:
         # (varies by model: some use custom.picturemode, others samsungvd.pictureMode)
         self._picture_mode_capability = None
         self._sound_mode_capability = None
+        # Capability VERIFIED to actually actuate setPictureMode on this panel
+        # (learned by the verify-and-fallback in async_set_picture_mode; some
+        # TVs answer 200 COMPLETED on one capability without applying it).
+        # Seeded from persisted entry data at startup; tried first on every
+        # change, with the other capability kept as fallback.
+        self._verified_picture_mode_capability: str | None = None
+        # Optional callback (set by the media_player) invoked with the verified
+        # capability name so it can be persisted across HA restarts.
+        self.picture_mode_capability_persist_cb: Callable[[str], None] | None = None
 
         self._is_forced_val = False
         self._forced_count = 0
+
+    def set_verified_picture_mode_capability(self, capability: str | None) -> None:
+        """Seed the verified setPictureMode capability (from persisted data)."""
+        if capability in ("custom.picturemode", "samsungvd.pictureMode"):
+            self._verified_picture_mode_capability = capability
+        elif capability is not None:
+            self._log.debug(
+                "Ignoring unknown persisted picture mode capability: %s", capability
+            )
 
     def _get_api_key(self) -> str:
         """Get API key used to connect to SmartThings."""
@@ -945,16 +963,22 @@ class SmartThingsTV:
                 self._picture_mode_list,
             )
 
-        # Try detected capability first, fallback to the other.
-        # custom.picturemode returns 422 on some TVs (Frame 2024) which could
-        # interfere with the session, so we use the detected capability first.
+        # Order of attempts: the capability VERIFIED to actuate this panel (if
+        # already learned, possibly on a previous HA run) comes first, then the
+        # detected capability, then the other one — deduplicated, both always
+        # reachable as fallback. custom.picturemode returns 422 on some TVs
+        # (Frame 2024) which could interfere with the session, so the detected
+        # capability stays ahead of the blind alternative.
         primary = self._picture_mode_capability or "samsungvd.pictureMode"
         fallback = (
             "custom.picturemode"
             if primary == "samsungvd.pictureMode"
             else "samsungvd.pictureMode"
         )
-        capabilities_to_try = [primary, fallback]
+        capabilities_to_try = []
+        for capability in (self._verified_picture_mode_capability, primary, fallback):
+            if capability and capability not in capabilities_to_try:
+                capabilities_to_try.append(capability)
 
         any_sent = False
         for capability in capabilities_to_try:
@@ -991,7 +1015,12 @@ class SmartThingsTV:
             # applied it (see docstring). None = could not verify — assume
             # applied rather than blind-firing the other capability.
             applied = await self._async_verify_picture_mode(mode_id)
-            if applied is not False:
+            if applied:
+                # Confirmed on the panel: remember this capability so later
+                # changes try it first (and persist it across HA restarts).
+                self._remember_picture_mode_capability(capability)
+                return
+            if applied is None:
                 return
             self._log.warning(
                 "setPictureMode via %s was accepted (COMPLETED) but the TV "
@@ -1013,6 +1042,28 @@ class SmartThingsTV:
                 "likely cannot actuate this panel (see issue #116)",
                 mode,
             )
+
+    def _remember_picture_mode_capability(self, capability: str) -> None:
+        """Memorize (and persist) the capability confirmed to actuate the panel.
+
+        Only called after a VERIFIED apply — never on an unverifiable send — so
+        a flaky cloud read can't memorize the wrong capability. If the panel's
+        behaviour ever changes (e.g. a firmware update), a later verified apply
+        through the other capability simply overwrites the memory.
+        """
+        if capability == self._verified_picture_mode_capability:
+            return
+        self._log.debug(
+            "Picture mode capability verified working: %s (was: %s) — memorizing",
+            capability,
+            self._verified_picture_mode_capability,
+        )
+        self._verified_picture_mode_capability = capability
+        if self.picture_mode_capability_persist_cb is not None:
+            try:
+                self.picture_mode_capability_persist_cb(capability)
+            except Exception as err:  # pylint: disable=broad-except
+                self._log.debug("Could not persist picture mode capability: %s", err)
 
     async def _async_verify_picture_mode(self, mode_id: str) -> bool | None:
         """Return whether the TV now reports ``mode_id``, None if unknown.

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -69,6 +69,15 @@ MAX_ST_POLL_ON_INTERVAL = 600
 # the local WebSocket, without hammering the API during standby.
 ST_POLL_OFF_INTERVAL = 30
 
+# Persisted (entry.data): which SmartThings capability was VERIFIED to actually
+# actuate the panel for setPictureMode ("custom.picturemode" or
+# "samsungvd.pictureMode"). Learned at runtime by the verify-and-fallback logic
+# (some TVs answer 200 COMPLETED on one capability without applying it — issue
+# #116) and prioritized on later changes, surviving HA restarts. The other
+# capability is always kept as fallback. Excluded from the reload fingerprint
+# in __init__.py so persisting it never triggers an integration reload.
+CONF_ST_PICTURE_MODE_CAPABILITY = "st_picture_mode_capability"
+
 CONF_SLIDESHOW_API = "slideshow_api"  # Persisted: "slideshow" or "auto_rotation"
 LOCAL_LOGO_PATH = "local_logo_path"
 WS_PREFIX = "[Home Assistant]"

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0b11"
+  "version": "8.3.0b12"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -120,6 +120,7 @@ from .const import (
     CONF_SLIDESHOW_API,
     CONF_SOURCE_LIST,
     CONF_ST_ENTRY_UNIQUE_ID,
+    CONF_ST_PICTURE_MODE_CAPABILITY,
     CONF_ST_POLL_ON_INTERVAL,
     CONF_SUPPORTS_GET_BRIGHTNESS,
     CONF_SUPPORTS_GET_COLOR_TEMPERATURE,
@@ -713,6 +714,16 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 api_key_callback=api_key_callback if use_callbck else None,
                 host=self._host,
             )
+            # Seed the setPictureMode capability verified on a previous run
+            # (learned by verify-and-fallback, persisted in entry.data) and
+            # wire the persistence callback so a newly verified capability
+            # survives HA restarts.
+            self._st.set_verified_picture_mode_capability(
+                config.get(CONF_ST_PICTURE_MODE_CAPABILITY)
+            )
+            self._st.picture_mode_capability_persist_cb = (
+                self._persist_st_picture_mode_capability
+            )
 
         self._st_error_count = 0
         self._st_last_exc = None
@@ -880,6 +891,25 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             return
         self.hass.config_entries.async_update_entry(
             entry, data={**entry.data, key: value}
+        )
+
+    def _persist_st_picture_mode_capability(self, capability: str) -> None:
+        """Persist the verified setPictureMode capability to entry.data.
+
+        Called (on the event loop) by the SmartThings API after a picture-mode
+        change was VERIFIED applied on the panel, so later changes — including
+        after an HA restart — try the working capability first (issue #116:
+        some TVs answer 200 COMPLETED on one capability without applying it).
+        The key is excluded from the reload fingerprint in __init__.py, so this
+        write never triggers an integration reload.
+        """
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None or entry.data.get(CONF_ST_PICTURE_MODE_CAPABILITY) == (
+            capability
+        ):
+            return
+        self.hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_ST_PICTURE_MODE_CAPABILITY: capability}
         )
 
     def _persist_art_port(self, port: int) -> None:


### PR DESCRIPTION
Follow-up to #131 (verify-and-fallback), `8.3.0b12` — one commit on top of `v8.3-dev`.

## What it does
Once a picture-mode change is **verified applied** through a given SmartThings capability, that capability is **memorized and tried first** on every later change — **persisted in the config entry, so it survives HA restarts**. On TVs where `custom.picturemode` returns a lying `COMPLETED` (#116), the ~5–10 s verify-and-fallback cost is only paid on the **first** change; subsequent ones go straight through the working `samsungvd.pictureMode`.

## Design points
- **Attempt order:** verified capability → detected capability → the other one (deduplicated) — the fallback is always kept, so if the panel's behaviour ever changes (e.g. firmware update), a later verified apply through the other capability simply overwrites the memory (self-healing).
- **Only a VERIFIED apply is memorized.** An unverifiable send (flaky cloud read-back) never updates the memory, so it can't learn the wrong capability.
- **No reload on persist.** The key (`st_picture_mode_capability` in `entry.data`) is excluded from the reload fingerprint via a new `_NO_RELOAD_DATA_KEYS` — the previous fingerprint hashed all of `entry.data`, so persisting a learned device fact right after a user action would have torn down the integration mid-flow.

## Changes
- `api/smartthings.py` — `_verified_picture_mode_capability` + `set_verified_picture_mode_capability()` (seed, validated against the two known capabilities), attempt-order logic, `_remember_picture_mode_capability()` (memorize + persist callback, called only on verified apply).
- `media_player.py` — seeds from `entry.data` at client creation and wires `_persist_st_picture_mode_capability` (same pattern as `_persist_art_port`).
- `__init__.py` — `_NO_RELOAD_DATA_KEYS` excluded from `_reload_fingerprint`.
- `const.py` — new `CONF_ST_PICTURE_MODE_CAPABILITY` entry.data key.

## Testing
- `flake8` / `isort` / `black` clean on the whole package.
- Expected on an affected TV (#116): first change after update logs `Picture mode capability verified working: samsungvd.pictureMode … — memorizing`; subsequent changes apply with no fallback delay, including after an HA restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_