### PR TITLE
Speaker output: settable select via IP Control, SmartThings fallback

### DIFF
--- a/IP_Control_Protocol_Reference.md
+++ b/IP_Control_Protocol_Reference.md
@@ -113,10 +113,11 @@ when calling each method with only the `AccessToken` (no extra params):
 | `pictureModeControl` | ❌ | `pictureMode` | — | Read-only via `getTVStates.pictureMode` on Frame 2024. |
 | `pictureSizeControl` | ❌ | `pictureSize` | — | Read-only via `getTVStates.pictureSize`. |
 | `soundModeControl` | ❌ | `soundMode` | — | Read-only via `getTVStates.soundMode`. |
-| `speakerSelectControl` | ❌ | `speakerSelect` | — | Read-only via `getTVStates.speakerSelect`. |
+| `speakerSelectControl` | ✅ | `speakerSelect` | `speakerSelect` | **Writable** (earlier "read-only" was wrong). Get with no params → capitalized value (`Internal`/`External`), unlike lowercase `getTVStates.speakerSelect`. Set accepts `Internal`, `AudioOut/Optical`; bare `External` is rejected — use `externalSpeakerControl`. |
+| `externalSpeakerControl` | ✅ | `deviceName` + `deviceId` | JSON **array** of `{deviceName, deviceId}` | Get with no params lists reachable external audio devices (e.g. `[{"deviceName":"CINEMA 60(HDMI-eARC)","deviceId":"RCV-1"}]`; `{}` when the receiver is off). Set with a listed device switches output to it; unknown/unreachable device → `-32002`. |
 | `contrastControl` / `brightnessControl` / `sharpnessControl` / `colorControl` / `tintControl` | ✅ | `<field>`: int | `<field>` | **Writable** (earlier "read-only" was wrong). Get with no params; set with `{"<field>": n}`. Ranges (Frame 2024/2025): contrast 0–50, color 0–50, sharpness 0–20, brightness −5…5, tint −15…15. Write is picture-mode gated → `-32002` in Dynamic/HDR-dynamic; Standard/Movie/Filmmaker accept it. |
 | `directChannelControl` | ❌ | `atvDtv` + `airCable` + `channelNum` | — | Not implemented on Frame 2024 (Frames have no tuner anyway). |
-| `USBSourceControl` / `RVUSourceControl` / `externalSpeakerControl` / `ambientModeControl` | ❌ | — | — | Not implemented on Frame 2024. May exist on other models. |
+| `USBSourceControl` / `RVUSourceControl` / `ambientModeControl` | ❌ | — | — | Not implemented on Frame 2024. May exist on other models. |
 
 ### RemoteKey values (`remoteKeyControl`)
 

--- a/RELEASE_NOTES_8.3.0.md
+++ b/RELEASE_NOTES_8.3.0.md
@@ -14,6 +14,26 @@ If this project is useful to you, you can support its development:
 > the new `frame_tv_entity` key so the fullscreen-preview buttons work — see the
 > *lightbox buttons* note below.
 
+## Speaker output — settable select, with your eARC receiver as an option (8.3.0b13)
+
+- **The read-only `Speaker Select` diagnostic sensor becomes a real `select`**,
+  with two paths:
+  - **IP Control (local, primary):** options are **Internal**,
+    **AudioOut/Optical**, plus **every external audio device the TV currently
+    lists** — e.g. an HDMI-eARC receiver appears by name ("CINEMA 60
+    (HDMI-eARC)") while it is reachable, and switching to it goes through the
+    TV's own `externalSpeakerControl` with the device id. This is *richer than
+    the SmartThings app*, which only offers internal/optical. Discovered live:
+    the receiver option comes and goes with the receiver's availability.
+  - **SmartThings (cloud fallback):** on TVs without IP Control paired, a
+    select backed by the `samsungvd.mediaOutput` capability
+    (`supportedOutputList` / `currentOutput` / `setOutput`) is created instead.
+    It stays unavailable until the TV populates the output list.
+- Polling is gated on the TV being on (a Frame in Art Mode keeps its select),
+  and all IP Control calls go through the per-host serialization lock.
+- The protocol reference was corrected: `speakerSelectControl` and
+  `externalSpeakerControl` were wrongly documented as read-only/absent.
+
 ## Picture mode — the working capability is memorized and tried first (8.3.0b12)
 
 - **Once a picture-mode change is *verified applied* through a given SmartThings

--- a/RELEASE_NOTES_8.3.0.md
+++ b/RELEASE_NOTES_8.3.0.md
@@ -14,6 +14,21 @@ If this project is useful to you, you can support its development:
 > the new `frame_tv_entity` key so the fullscreen-preview buttons work — see the
 > *lightbox buttons* note below.
 
+## Picture mode — the working capability is memorized and tried first (8.3.0b12)
+
+- **Once a picture-mode change is *verified applied* through a given SmartThings
+  capability, that capability is memorized and tried first on every later
+  change** — including after an HA restart (persisted in the config entry). So
+  on TVs where `custom.picturemode` returns a lying `COMPLETED` (issue #116),
+  the ~5–10 s verify-and-fallback cost is only paid on the *first* change;
+  subsequent ones go straight through the working `samsungvd.pictureMode`.
+  - The other capability always remains as fallback: if the panel's behaviour
+    ever changes (e.g. firmware update), a later verified apply through the
+    other capability simply overwrites the memory.
+  - Only a **verified** apply is memorized — an unverifiable send (flaky cloud
+    read) never updates the memory, so it can't learn the wrong capability.
+  - Persisting the learned capability does **not** reload the integration.
+
 ## Picture mode — verify the TV applied it, retry via the other capability (8.3.0b11)
 
 - **Fix for picture-mode changes that SmartThings accepts but the TV silently

--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -67,6 +67,7 @@ from .const import (
     CONF_SHOW_CHANNEL_NR,
     CONF_SOURCE_LIST,
     CONF_ST_ENTRY_UNIQUE_ID,
+    CONF_ST_PICTURE_MODE_CAPABILITY,
     CONF_ST_POLL_ON_INTERVAL,
     CONF_SUPPORTS_GET_BRIGHTNESS,
     CONF_SUPPORTS_GET_COLOR_TEMPERATURE,
@@ -1187,11 +1188,17 @@ _RELOAD_OPTIONS = (
     CONF_ST_POLL_ON_INTERVAL,
 )
 
+# entry.data keys persisted at RUNTIME as learned device facts, not connection
+# settings: writing them must NOT reload the integration (a reload would tear
+# down the very clients that just learned the fact — and reloads are exactly
+# what the verify-and-fallback logic runs right after a user action).
+_NO_RELOAD_DATA_KEYS = (CONF_ST_PICTURE_MODE_CAPABILITY,)
+
 
 def _reload_fingerprint(entry: ConfigEntry) -> tuple:
     """Snapshot the parts of an entry whose change requires a reload."""
     return (
-        dict(entry.data),
+        {k: v for k, v in entry.data.items() if k not in _NO_RELOAD_DATA_KEYS},
         tuple(entry.options.get(key) for key in _RELOAD_OPTIONS),
     )
 

--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -60,6 +60,14 @@ def _host_lock(host: str) -> asyncio.Lock:
 DEFAULT_IP_CONTROL_PORT = 1516
 JSONRPC_VERSION = "2.0"
 COLOR_TONE_OPTIONS = ("Cool", "Standard", "Warm1", "Warm2")
+# speakerSelectControl public values (verified on Frame 2024/2025). "External"
+# is REPORTED by the getter when an external device (e.g. HDMI-eARC receiver)
+# is active, but SELECTING a specific external device goes through
+# externalSpeakerControl with the device's name/id from its getter.
+SPEAKER_SELECT_OPTIONS = ("Internal", "External", "AudioOut/Optical")
+# Key under which _sync_request wraps JSON-array results (e.g. the external
+# speaker list) to keep its dict return contract.
+LIST_RESULT_KEY = "_list_result"
 
 CMD_TIMEOUT = 5  # seconds for normal commands
 PAIR_TIMEOUT = 30  # seconds: pairing waits for the on-screen acceptance
@@ -356,6 +364,62 @@ class SamsungIPControl:
                 f"invalid {field} response from {method}: {result!r}"
             ) from ex
 
+    async def async_get_speaker_select(self) -> str:
+        """Return the current speaker output ("Internal", "External", ...).
+
+        ``speakerSelectControl`` called with no params echoes the current
+        output, capitalized ("Internal"/"External") — unlike the mirror field
+        in ``getTVStates`` which reports it lowercase.
+        """
+        result = await self._async_request("speakerSelectControl")
+        value = result.get("speakerSelect")
+        if not isinstance(value, str) or not value:
+            raise SamsungIPControlError(f"no speakerSelect in response: {result!r}")
+        return value
+
+    async def async_set_speaker_select(self, value: str) -> None:
+        """Switch the speaker output to a public target.
+
+        Verified on Frame 2024/2025: "Internal" and "AudioOut/Optical" are
+        accepted; "External" alone is rejected — switching to a specific
+        external device (HDMI-eARC receiver, ...) must go through
+        :meth:`async_set_external_speaker` with the device's name/id.
+        """
+        if value not in SPEAKER_SELECT_OPTIONS:
+            raise SamsungIPControlError(
+                f"speakerSelect must be one of {', '.join(SPEAKER_SELECT_OPTIONS)}"
+            )
+        await self._async_request("speakerSelectControl", {"speakerSelect": value})
+
+    async def async_get_external_speakers(self) -> list[dict[str, str]]:
+        """Return the available external speakers as [{deviceName, deviceId}].
+
+        ``externalSpeakerControl`` called with no params returns a JSON array
+        of the currently available external audio devices (e.g.
+        ``[{"deviceName": "CINEMA 60(HDMI-eARC)", "deviceId": "RCV-1"}]``) —
+        or ``{}`` when none is reachable (receiver powered off).
+        """
+        result = await self._async_request("externalSpeakerControl")
+        devices = result.get(LIST_RESULT_KEY, [])
+        return [
+            dev
+            for dev in devices
+            if isinstance(dev, dict) and dev.get("deviceName") and dev.get("deviceId")
+        ]
+
+    async def async_set_external_speaker(self, name: str, device_id: str) -> None:
+        """Switch the speaker output to a specific external device.
+
+        Requires a device currently listed by
+        :meth:`async_get_external_speakers`; the TV answers ``-32002`` for an
+        unknown/unreachable device (raised as
+        :class:`SamsungIPControlModeLockedError`).
+        """
+        await self._async_request(
+            "externalSpeakerControl",
+            {"deviceName": name, "deviceId": device_id},
+        )
+
     async def async_get_mute(self) -> bool:
         """Return whether the TV is currently muted."""
         result = await self._async_request("muteControl")
@@ -552,6 +616,11 @@ class SamsungIPControl:
             raise SamsungIPControlError(f"TV returned error {code}: {message}")
 
         result = data.get("result")
+        if isinstance(result, list):
+            # A few getters (e.g. externalSpeakerControl) return a JSON array.
+            # Wrap it so the dict return contract holds for every caller;
+            # list-aware callers unwrap via LIST_RESULT_KEY.
+            return {LIST_RESULT_KEY: result}
         if not isinstance(result, dict):
             return {}
         return result

--- a/custom_components/samsungtv_smart/api/smartthings.py
+++ b/custom_components/samsungtv_smart/api/smartthings.py
@@ -114,9 +114,27 @@ class SmartThingsTV:
         # (varies by model: some use custom.picturemode, others samsungvd.pictureMode)
         self._picture_mode_capability = None
         self._sound_mode_capability = None
+        # Capability VERIFIED to actually actuate setPictureMode on this panel
+        # (learned by the verify-and-fallback in async_set_picture_mode; some
+        # TVs answer 200 COMPLETED on one capability without applying it).
+        # Seeded from persisted entry data at startup; tried first on every
+        # change, with the other capability kept as fallback.
+        self._verified_picture_mode_capability: str | None = None
+        # Optional callback (set by the media_player) invoked with the verified
+        # capability name so it can be persisted across HA restarts.
+        self.picture_mode_capability_persist_cb: Callable[[str], None] | None = None
 
         self._is_forced_val = False
         self._forced_count = 0
+
+    def set_verified_picture_mode_capability(self, capability: str | None) -> None:
+        """Seed the verified setPictureMode capability (from persisted data)."""
+        if capability in ("custom.picturemode", "samsungvd.pictureMode"):
+            self._verified_picture_mode_capability = capability
+        elif capability is not None:
+            self._log.debug(
+                "Ignoring unknown persisted picture mode capability: %s", capability
+            )
 
     def _get_api_key(self) -> str:
         """Get API key used to connect to SmartThings."""
@@ -945,16 +963,22 @@ class SmartThingsTV:
                 self._picture_mode_list,
             )
 
-        # Try detected capability first, fallback to the other.
-        # custom.picturemode returns 422 on some TVs (Frame 2024) which could
-        # interfere with the session, so we use the detected capability first.
+        # Order of attempts: the capability VERIFIED to actuate this panel (if
+        # already learned, possibly on a previous HA run) comes first, then the
+        # detected capability, then the other one — deduplicated, both always
+        # reachable as fallback. custom.picturemode returns 422 on some TVs
+        # (Frame 2024) which could interfere with the session, so the detected
+        # capability stays ahead of the blind alternative.
         primary = self._picture_mode_capability or "samsungvd.pictureMode"
         fallback = (
             "custom.picturemode"
             if primary == "samsungvd.pictureMode"
             else "samsungvd.pictureMode"
         )
-        capabilities_to_try = [primary, fallback]
+        capabilities_to_try = []
+        for capability in (self._verified_picture_mode_capability, primary, fallback):
+            if capability and capability not in capabilities_to_try:
+                capabilities_to_try.append(capability)
 
         any_sent = False
         for capability in capabilities_to_try:
@@ -991,7 +1015,12 @@ class SmartThingsTV:
             # applied it (see docstring). None = could not verify — assume
             # applied rather than blind-firing the other capability.
             applied = await self._async_verify_picture_mode(mode_id)
-            if applied is not False:
+            if applied:
+                # Confirmed on the panel: remember this capability so later
+                # changes try it first (and persist it across HA restarts).
+                self._remember_picture_mode_capability(capability)
+                return
+            if applied is None:
                 return
             self._log.warning(
                 "setPictureMode via %s was accepted (COMPLETED) but the TV "
@@ -1013,6 +1042,28 @@ class SmartThingsTV:
                 "likely cannot actuate this panel (see issue #116)",
                 mode,
             )
+
+    def _remember_picture_mode_capability(self, capability: str) -> None:
+        """Memorize (and persist) the capability confirmed to actuate the panel.
+
+        Only called after a VERIFIED apply — never on an unverifiable send — so
+        a flaky cloud read can't memorize the wrong capability. If the panel's
+        behaviour ever changes (e.g. a firmware update), a later verified apply
+        through the other capability simply overwrites the memory.
+        """
+        if capability == self._verified_picture_mode_capability:
+            return
+        self._log.debug(
+            "Picture mode capability verified working: %s (was: %s) — memorizing",
+            capability,
+            self._verified_picture_mode_capability,
+        )
+        self._verified_picture_mode_capability = capability
+        if self.picture_mode_capability_persist_cb is not None:
+            try:
+                self.picture_mode_capability_persist_cb(capability)
+            except Exception as err:  # pylint: disable=broad-except
+                self._log.debug("Could not persist picture mode capability: %s", err)
 
     async def _async_verify_picture_mode(self, mode_id: str) -> bool | None:
         """Return whether the TV now reports ``mode_id``, None if unknown.

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -69,6 +69,15 @@ MAX_ST_POLL_ON_INTERVAL = 600
 # the local WebSocket, without hammering the API during standby.
 ST_POLL_OFF_INTERVAL = 30
 
+# Persisted (entry.data): which SmartThings capability was VERIFIED to actually
+# actuate the panel for setPictureMode ("custom.picturemode" or
+# "samsungvd.pictureMode"). Learned at runtime by the verify-and-fallback logic
+# (some TVs answer 200 COMPLETED on one capability without applying it — issue
+# #116) and prioritized on later changes, surviving HA restarts. The other
+# capability is always kept as fallback. Excluded from the reload fingerprint
+# in __init__.py so persisting it never triggers an integration reload.
+CONF_ST_PICTURE_MODE_CAPABILITY = "st_picture_mode_capability"
+
 CONF_SLIDESHOW_API = "slideshow_api"  # Persisted: "slideshow" or "auto_rotation"
 LOCAL_LOGO_PATH = "local_logo_path"
 WS_PREFIX = "[Home Assistant]"

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0b11"
+  "version": "8.3.0b12"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0b12"
+  "version": "8.3.0b13"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -120,6 +120,7 @@ from .const import (
     CONF_SLIDESHOW_API,
     CONF_SOURCE_LIST,
     CONF_ST_ENTRY_UNIQUE_ID,
+    CONF_ST_PICTURE_MODE_CAPABILITY,
     CONF_ST_POLL_ON_INTERVAL,
     CONF_SUPPORTS_GET_BRIGHTNESS,
     CONF_SUPPORTS_GET_COLOR_TEMPERATURE,
@@ -713,6 +714,16 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 api_key_callback=api_key_callback if use_callbck else None,
                 host=self._host,
             )
+            # Seed the setPictureMode capability verified on a previous run
+            # (learned by verify-and-fallback, persisted in entry.data) and
+            # wire the persistence callback so a newly verified capability
+            # survives HA restarts.
+            self._st.set_verified_picture_mode_capability(
+                config.get(CONF_ST_PICTURE_MODE_CAPABILITY)
+            )
+            self._st.picture_mode_capability_persist_cb = (
+                self._persist_st_picture_mode_capability
+            )
 
         self._st_error_count = 0
         self._st_last_exc = None
@@ -880,6 +891,25 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             return
         self.hass.config_entries.async_update_entry(
             entry, data={**entry.data, key: value}
+        )
+
+    def _persist_st_picture_mode_capability(self, capability: str) -> None:
+        """Persist the verified setPictureMode capability to entry.data.
+
+        Called (on the event loop) by the SmartThings API after a picture-mode
+        change was VERIFIED applied on the panel, so later changes — including
+        after an HA restart — try the working capability first (issue #116:
+        some TVs answer 200 COMPLETED on one capability without applying it).
+        The key is excluded from the reload fingerprint in __init__.py, so this
+        write never triggers an integration reload.
+        """
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None or entry.data.get(CONF_ST_PICTURE_MODE_CAPABILITY) == (
+            capability
+        ):
+            return
+        self.hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_ST_PICTURE_MODE_CAPABILITY: capability}
         )
 
     def _persist_art_port(self, port: int) -> None:

--- a/custom_components/samsungtv_smart/select.py
+++ b/custom_components/samsungtv_smart/select.py
@@ -86,11 +86,16 @@ async def async_setup_entry(
             [
                 SamsungTVIPControlColorToneSelect(
                     hass, entry, host, device_name, device_unique_id
-                )
+                ),
+                SamsungTVIPControlSpeakerSelect(
+                    hass, entry, host, device_name, device_unique_id
+                ),
             ],
             True,
         )
-        _LOGGER.debug("IP Control color tone select created for %s", device_name)
+        _LOGGER.debug(
+            "IP Control color tone + speaker selects created for %s", device_name
+        )
 
     session = async_get_clientsession(hass)
 
@@ -152,6 +157,22 @@ async def async_setup_entry(
         )
         entities.append(picture_mode_select)
         _LOGGER.debug("Picture Mode select entity created for %s", device_name)
+        # Speaker output via SmartThings (samsungvd.mediaOutput) — cloud
+        # fallback only: when IP Control is paired the local select above
+        # already covers it (with richer options, e.g. eARC receivers).
+        if not _ip_control_active(entry):
+            entities.append(
+                SamsungTVSTMediaOutputSelect(
+                    hass=hass,
+                    entry=entry,
+                    device_name=device_name,
+                    device_unique_id=device_unique_id,
+                    api_key=api_key,
+                    device_id=device_id,
+                    session=session,
+                )
+            )
+            _LOGGER.debug("SmartThings media output select created for %s", device_name)
     else:
         picture_mode_select = None
         _LOGGER.debug(
@@ -579,6 +600,360 @@ class SamsungTVIPControlColorToneSelect(SelectEntity):
         """Expose no selected color tone until a live IP Control read succeeds."""
         self._attr_available = False
         self._attr_current_option = None
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# Speaker output select — IP Control primary, SmartThings fallback
+# ══════════════════════════════════════════════════════════════════════════
+
+# speakerSelectControl public targets that are directly selectable (verified on
+# Frame 2024/2025). "External" is only ever REPORTED by the getter; selecting a
+# specific external device goes through externalSpeakerControl with the
+# name/id discovered from its getter.
+_SPEAKER_BASE_OPTIONS = ("Internal", "AudioOut/Optical")
+
+
+class SamsungTVIPControlSpeakerSelect(SelectEntity):
+    """Speaker output select via IP Control (local).
+
+    Options are the two fixed public targets plus every external audio device
+    the TV currently lists (e.g. an HDMI-eARC receiver) — discovered live via
+    ``externalSpeakerControl``, so the receiver only appears while reachable.
+    This is richer than SmartThings, whose app only offers internal/optical.
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:speaker"
+    _attr_should_poll = True
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        host: str,
+        device_name: str,
+        device_unique_id: str,
+    ) -> None:
+        """Initialize the IP Control speaker output select."""
+        self.hass = hass
+        self._entry_id = entry.entry_id
+        self._host = host
+        self._device_name = device_name
+        self._device_unique_id = device_unique_id
+        self._ip_control: SamsungIPControl | None = None
+        self._ip_control_token: str | None = None
+        self._attr_unique_id = f"{device_unique_id}_ip_control_speaker_select"
+        self._attr_name = "Speaker Select"
+        self._attr_options = list(_SPEAKER_BASE_OPTIONS)
+        self._attr_current_option: str | None = None
+        self._attr_available = False
+        # deviceName -> deviceId of the external speakers currently listed.
+        self._external_devices: dict[str, str] = {}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Link this entity to the TV device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_unique_id)},
+            name=self._device_name,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Available only while IP Control is paired, enabled, and reachable."""
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        return bool(entry and _ip_control_active(entry) and self._attr_available)
+
+    def _device_title(self) -> str:
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        return entry.title if entry else (self._device_name or "this Samsung TV")
+
+    def _get_ip_control(self) -> SamsungIPControl | None:
+        """Return a live IP Control client if paired AND enabled."""
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None or not _ip_control_active(entry):
+            self._ip_control = None
+            self._ip_control_token = None
+            return None
+        token = entry.data.get(CONF_IP_CONTROL_TOKEN)
+        if self._ip_control is None or self._ip_control_token != token:
+            self._ip_control = SamsungIPControl(self.hass, self._host, token=token)
+            self._ip_control_token = token
+        return self._ip_control
+
+    def _tv_powered_off(self) -> bool:
+        """True when the linked TV is off (not showing Art) — skip the poll."""
+        registry = er.async_get(self.hass)
+        for entity in registry.entities.get_entries_for_config_entry_id(self._entry_id):
+            if entity.domain != "media_player":
+                continue
+            state = self.hass.states.get(entity.entity_id)
+            if state is None:
+                return False
+            if state.state not in (STATE_OFF, "unavailable"):
+                return False
+            return state.attributes.get("art_mode_status") != "on"
+        return False
+
+    def _rebuild_options(self) -> None:
+        """Options = fixed public targets + currently listed external devices."""
+        options = list(_SPEAKER_BASE_OPTIONS)
+        options.extend(self._external_devices)
+        # Keep a plain "External" entry only when the TV reports External but
+        # no device is listed (so the current option always exists in options).
+        if self._attr_current_option == "External" and not self._external_devices:
+            options.append("External")
+        self._attr_options = options
+
+    async def async_select_option(self, option: str) -> None:
+        """Switch the speaker output through IP Control."""
+        client = self._get_ip_control()
+        if client is None:
+            raise HomeAssistantError(
+                "IP Control is not paired or is disabled for this TV."
+            )
+
+        try:
+            if option in self._external_devices:
+                await client.async_set_external_speaker(
+                    option, self._external_devices[option]
+                )
+            elif option in _SPEAKER_BASE_OPTIONS:
+                await client.async_set_speaker_select(option)
+            else:
+                # The bare "External" placeholder (device list empty) — there
+                # is no target to switch to.
+                raise HomeAssistantError(
+                    "No external audio device is currently available — turn "
+                    "the receiver/soundbar on and try again."
+                )
+            self._attr_current_option = option
+            self._attr_available = True
+        except SamsungIPControlAuthError as ex:
+            self._mark_unavailable()
+            notify_token_problem(
+                self.hass, self._entry_id, METHOD_IP_CONTROL, self._device_title()
+            )
+            raise HomeAssistantError(
+                f"IP Control token rejected while setting speaker output: {ex}"
+            ) from ex
+        except SamsungIPControlModeLockedError as ex:
+            # Reversible TV-side condition (e.g. the external device just went
+            # away) — keep the entity available for the next attempt.
+            raise HomeAssistantError(
+                f"Speaker output can't be changed right now: {ex}"
+            ) from ex
+        except SamsungIPControlError as ex:
+            raise HomeAssistantError(
+                f"Failed to set speaker output via IP Control: {ex}"
+            ) from ex
+
+        clear_token_problem(self.hass, self._entry_id, METHOD_IP_CONTROL)
+        self.async_write_ha_state()
+
+    async def async_update(self) -> None:
+        """Read the current speaker output and the external device list."""
+        if self._tv_powered_off():
+            self._mark_unavailable()
+            return
+        client = self._get_ip_control()
+        if client is None:
+            self._mark_unavailable()
+            return
+
+        try:
+            current = await client.async_get_speaker_select()
+            self._external_devices = {
+                dev["deviceName"]: dev["deviceId"]
+                for dev in await client.async_get_external_speakers()
+            }
+        except SamsungIPControlAuthError as ex:
+            _LOGGER.warning(
+                "IP Control speaker read for %s: token rejected (%s) — "
+                "re-pair via the integration options",
+                self._host,
+                ex,
+            )
+            self._mark_unavailable()
+            notify_token_problem(
+                self.hass, self._entry_id, METHOD_IP_CONTROL, self._device_title()
+            )
+            return
+        except SamsungIPControlError as ex:
+            _LOGGER.debug(
+                "Could not refresh IP Control speaker output for %s: %s",
+                self._host,
+                ex,
+            )
+            self._mark_unavailable()
+            return
+
+        # "External" -> show the actual device when exactly one is listed.
+        if current == "External" and len(self._external_devices) == 1:
+            current = next(iter(self._external_devices))
+        self._attr_current_option = current
+        self._rebuild_options()
+        self._attr_available = True
+        clear_token_problem(self.hass, self._entry_id, METHOD_IP_CONTROL)
+
+    def _mark_unavailable(self) -> None:
+        """Expose no speaker output until a live IP Control read succeeds."""
+        self._attr_available = False
+        self._attr_current_option = None
+
+
+class SamsungTVSTMediaOutputSelect(SelectEntity):
+    """Speaker output select via SmartThings ``samsungvd.mediaOutput``.
+
+    Cloud fallback for TVs without IP Control paired. Options/current value
+    come from the capability's ``supportedOutputList`` / ``currentOutput``
+    attributes (the TV populates them on demand — the entity stays unavailable
+    until they appear); switching sends the ``setOutput`` command.
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:speaker"
+    _attr_should_poll = True
+
+    _CAPABILITY = "samsungvd.mediaOutput"
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        device_name: str,
+        device_unique_id: str,
+        api_key: str,
+        device_id: str,
+        session,
+    ) -> None:
+        """Initialize the SmartThings media output select."""
+        self.hass = hass
+        self._entry = entry
+        self._device_name = device_name
+        self._device_unique_id = device_unique_id
+        self._api_key = api_key
+        self._device_id = device_id
+        self._session = session
+        self._attr_unique_id = f"{device_unique_id}_st_media_output"
+        self._attr_name = "Speaker Select"
+        self._attr_options: list[str] = []
+        self._attr_current_option: str | None = None
+        # Cooldown: skip polls briefly after a change (cloud lags behind).
+        self._skip_poll_until: float = 0
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Link this entity to the TV device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_unique_id)},
+            name=self._device_name,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Only available once the TV has populated the output list."""
+        return len(self._attr_options) > 0
+
+    def _get_api_key(self) -> str:
+        """Get current API key, refreshing from entry data for OAuth."""
+        entry = self.hass.config_entries.async_get_entry(self._entry.entry_id)
+        if entry:
+            oauth_token = entry.data.get(CONF_OAUTH_TOKEN)
+            if isinstance(oauth_token, dict):
+                new_key = oauth_token.get("access_token")
+                if new_key:
+                    self._api_key = new_key
+                    return new_key
+            api_key = entry.data.get(CONF_API_KEY)
+            if api_key:
+                self._api_key = api_key
+        return self._api_key
+
+    def _tv_powered_off(self) -> bool:
+        """True when the linked TV is off (not showing Art) — skip ST poll."""
+        registry = er.async_get(self.hass)
+        for entity in registry.entities.get_entries_for_config_entry_id(
+            self._entry.entry_id
+        ):
+            if entity.domain != "media_player":
+                continue
+            state = self.hass.states.get(entity.entity_id)
+            if state is None:
+                return False
+            if state.state not in (STATE_OFF, "unavailable"):
+                return False
+            return state.attributes.get("art_mode_status") != "on"
+        return False
+
+    async def async_update(self) -> None:
+        """Poll current output + supported list from SmartThings."""
+        if time.time() < self._skip_poll_until:
+            return
+        if self._tv_powered_off():
+            return
+        url = (
+            f"{_API_DEVICES}/{self._device_id}"
+            f"/components/main/capabilities/{self._CAPABILITY}/status"
+        )
+        try:
+            async with self._session.get(
+                url,
+                headers={
+                    "Authorization": f"Bearer {self._get_api_key()}",
+                    "Accept": "application/json",
+                },
+            ) as resp:
+                if resp.status != 200:
+                    return
+                data = await resp.json()
+        except Exception as ex:  # pylint: disable=broad-except
+            _LOGGER.debug("Error fetching media output status: %s", ex)
+            return
+
+        supported = data.get("supportedOutputList", {}).get("value")
+        if isinstance(supported, list) and supported:
+            self._attr_options = [str(item) for item in supported]
+        current = data.get("currentOutput", {}).get("value")
+        if current:
+            self._attr_current_option = str(current)
+
+    async def async_select_option(self, option: str) -> None:
+        """Switch the speaker output through SmartThings setOutput."""
+        url = f"{_API_DEVICES}/{self._device_id}/commands"
+        body = {
+            "commands": [
+                {
+                    "component": "main",
+                    "capability": self._CAPABILITY,
+                    "command": "setOutput",
+                    "arguments": [option],
+                }
+            ]
+        }
+        try:
+            async with self._session.post(
+                url,
+                json=body,
+                headers={
+                    "Authorization": f"Bearer {self._get_api_key()}",
+                    "Accept": "application/json",
+                },
+            ) as resp:
+                if resp.status != 200:
+                    raise HomeAssistantError(
+                        f"SmartThings rejected setOutput (status {resp.status})."
+                    )
+        except HomeAssistantError:
+            raise
+        except Exception as ex:  # pylint: disable=broad-except
+            raise HomeAssistantError(
+                f"Failed to set speaker output via SmartThings: {ex}"
+            ) from ex
+        # Optimistic + short poll cooldown: the cloud lags behind the panel.
+        self._attr_current_option = option
+        self._skip_poll_until = time.time() + 10
+        self.async_write_ha_state()
 
 
 # ══════════════════════════════════════════════════════════════════════════

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -216,13 +216,9 @@ IP_CONTROL_STATE_SENSORS: tuple[SamsungIPControlSensorDescription, ...] = (
         icon="mdi:aspect-ratio",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SamsungIPControlSensorDescription(
-        key="speakerSelect",
-        source="tv",
-        name="Speaker Select",
-        icon="mdi:speaker",
-        entity_category=EntityCategory.DIAGNOSTIC,
-    ),
+    # NOTE: speakerSelect is NOT exposed here — it is a settable `select`
+    # entity (SamsungTVIPControlSpeakerSelect / SamsungTVSTMediaOutputSelect in
+    # select.py), switched via speakerSelectControl / externalSpeakerControl.
     SamsungIPControlSensorDescription(
         key="mute",
         source="tv",


### PR DESCRIPTION
`8.3.0b13`. Stacked on #132 (memorized picture-mode capability) — once #132 merges, this PR shows only the speaker-select commit.

## What it does
The read-only **Speaker Select** diagnostic sensor becomes a real **`select`**, with two backends:

### IP Control (local, primary)
Confirmed by live CLI probes on a Frame 2024 (`QE55LS03D`):
- `speakerSelectControl` — getter echoes the current output (`Internal`/`External`, capitalized); setter accepts **`Internal`** and **`AudioOut/Optical`** (bare `External` is rejected by design).
- `externalSpeakerControl` — getter returns a **JSON array** of reachable external audio devices (`[{"deviceName":"CINEMA 60(HDMI-eARC)","deviceId":"RCV-1"}]`, `{}` when the receiver is off); setter switches to a listed device by name/id.

The select's options are the two fixed targets **plus every external device the TV currently lists** — the eARC receiver appears by name while reachable and disappears when off. This is richer than the SmartThings app, which only offers internal/optical. Selecting the receiver goes through the TV's own `externalSpeakerControl`.

### SmartThings (cloud fallback)
On TVs **without IP Control paired**, a select backed by `samsungvd.mediaOutput` (`supportedOutputList` / `currentOutput`, command `setOutput`) is created instead. The capability's attributes are populated on demand by the TV (empty in the user's status dump), so the entity stays unavailable until they appear. Only one of the two selects is created per TV.

## Implementation notes
- `ipcontrol.py`: new getters/setters; `_sync_request` now wraps JSON-**array** results under `LIST_RESULT_KEY` — they were silently swallowed into `{}` before, which would have made the device list unreadable.
- Poll gated on the TV being on (Art Mode keeps polling off for this control), and every IP call goes through the per-host serialization lock from #130.
- `sensor.py`: the read-only `speakerSelect` diagnostic sensor is removed (replaced by the select).
- `IP_Control_Protocol_Reference.md`: corrected — `speakerSelectControl` was wrongly documented read-only and `externalSpeakerControl` as not implemented.

## Testing
- `flake8` / `isort` / `black` clean on the whole package.
- To validate on the Salon Frame (`.161` + Denon eARC): with the AVR on, the select should offer `Internal / AudioOut/Optical / CINEMA 60(HDMI-eARC)` and show the receiver as current; switching Internal ↔ receiver should actuate; with the AVR off the receiver option disappears.
- The ST fallback's `setOutput` command name follows the published `samsungvd.mediaOutput` capability; worth a quick confirm on a TV without IP Control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_