### PR TITLE
Remove ghost "unavailable" entries of sensors replaced by settable controls

### DIFF
--- a/RELEASE_NOTES_8.3.0.md
+++ b/RELEASE_NOTES_8.3.0.md
@@ -14,6 +14,16 @@ If this project is useful to you, you can support its development:
 > the new `frame_tv_entity` key so the fullscreen-preview buttons work — see the
 > *lightbox buttons* note below.
 
+## Cleanup — ghost "unavailable" diagnostic sensors are removed automatically (8.3.0b14)
+
+- **The old read-only sensors that were replaced by settable controls no longer
+  linger as "unavailable" ghosts.** When `Contrast / Brightness / Sharpness /
+  Color / Tint` (→ sliders, b8) and `Speaker Select` (→ select, b13) were
+  replaced, Home Assistant kept their registry entries and showed them as
+  *Indisponible* next to the working replacements. The integration now removes
+  those stale registry entries automatically at startup — no manual deletion
+  needed.
+
 ## Speaker output — settable select, with your eARC receiver as an option (8.3.0b13)
 
 - **The read-only `Speaker Select` diagnostic sensor becomes a real `select`**,

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0b13"
+  "version": "8.3.0b14"
 }

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -271,6 +271,31 @@ async def async_setup_entry(
 
     session = async_get_clientsession(hass)
 
+    # Clean up registry leftovers of the read-only IP Control sensors that were
+    # replaced by settable entities (contrast/brightness/sharpness/color/tint →
+    # number sliders in 8.3.0b8; speakerSelect → select in 8.3.0b13). A removed
+    # entity otherwise lingers in the registry forever as a "restored" /
+    # unavailable ghost next to its working replacement.
+    from homeassistant.helpers import entity_registry as er
+
+    _replaced_sensor_keys = (
+        "contrast",
+        "brightness",
+        "sharpness",
+        "color",
+        "tint",
+        "speakerSelect",
+    )
+    ent_reg = er.async_get(hass)
+    for _key in _replaced_sensor_keys:
+        _stale_unique_id = f"{device_unique_id}_ip_control_{_key}"
+        if _stale_id := ent_reg.async_get_entity_id("sensor", DOMAIN, _stale_unique_id):
+            ent_reg.async_remove(_stale_id)
+            _LOGGER.debug(
+                "Removed stale registry entry %s (replaced by a settable entity)",
+                _stale_id,
+            )
+
     entities = []
 
     # Reuse the shared Art API instance (created in __init__.py) so all


### PR DESCRIPTION
`8.3.0b14` — one small commit on top of `v8.3-dev`.

## Problem
After replacing the read-only IP Control sensors with settable controls — `Contrast/Brightness/Sharpness/Color/Tint` → number sliders (b8), `Speaker Select` → select (b13) — the old `sensor.*` entities remain in the entity registry as **"restored" / *Indisponible* ghosts** next to their working replacements (Home Assistant keeps registry entries when an integration stops providing an entity). Seen on the user's device page: the new slider/select work fine while a grey duplicate of each shows *Indisponible*.

## Fix
`sensor.py` setup now removes the six stale registry entries at startup, matched by their old unique_ids (`<device>_ip_control_{contrast,brightness,sharpness,color,tint,speakerSelect}`) on the `sensor` domain only — the replacement `number`/`select` entities share the same unique_id pattern but live on other domains, so they are untouched. Existing installs are cleaned automatically on the first restart after updating; no manual deletion needed.

## Testing
- `flake8` / `isort` / `black` clean.
- After update + restart: the *Indisponible* Brightness/Color/Contrast/Sharpness/Tint/Speaker Select sensor ghosts disappear from the device page; the sliders and the speaker select keep working (unique_ids untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_