### PR TITLE
Media player: hide the volume slider when the speaker output is external

### DIFF
--- a/RELEASE_NOTES_8.3.0.md
+++ b/RELEASE_NOTES_8.3.0.md
@@ -14,6 +14,16 @@ If this project is useful to you, you can support its development:
 > the new `frame_tv_entity` key so the fullscreen-preview buttons work — see the
 > *lightbox buttons* note below.
 
+## Cleanup — ghost "unavailable" diagnostic sensors are removed automatically (8.3.0b14)
+
+- **The old read-only sensors that were replaced by settable controls no longer
+  linger as "unavailable" ghosts.** When `Contrast / Brightness / Sharpness /
+  Color / Tint` (→ sliders, b8) and `Speaker Select` (→ select, b13) were
+  replaced, Home Assistant kept their registry entries and showed them as
+  *Indisponible* next to the working replacements. The integration now removes
+  those stale registry entries automatically at startup — no manual deletion
+  needed.
+
 ## Speaker output — settable select, with your eARC receiver as an option (8.3.0b13)
 
 - **The read-only `Speaker Select` diagnostic sensor becomes a real `select`**,

--- a/RELEASE_NOTES_8.3.0.md
+++ b/RELEASE_NOTES_8.3.0.md
@@ -14,6 +14,22 @@ If this project is useful to you, you can support its development:
 > the new `frame_tv_entity` key so the fullscreen-preview buttons work — see the
 > *lightbox buttons* note below.
 
+## Media player — the volume slider hides when audio goes to an external device (8.3.0b15)
+
+- **When the Speaker Select reports an external output** (HDMI-eARC receiver,
+  optical, Bluetooth soundbar), **the media player drops the absolute volume
+  slider (`volume_set`)** — that command only targets the TV's internal
+  speakers and was a silent no-op with an external output.
+- **Volume up/down and mute are kept**: the TV relays those keys to the
+  external device over CEC/ARC (confirmed with an eARC AVR), and the same
+  relay applies to Bluetooth soundbars. So remote-style volume keeps working;
+  only the dead slider disappears.
+- A `volume_set` service call issued anyway (e.g. by an old automation) logs a
+  clear warning instead of failing silently, and legacy automations don't
+  error out.
+- When the speaker output is unknown (no Speaker Select entity, or it is
+  unavailable), the slider stays — no behaviour change.
+
 ## Cleanup — ghost "unavailable" diagnostic sensors are removed automatically (8.3.0b14)
 
 - **The old read-only sensors that were replaced by settable controls no longer

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0b13"
+  "version": "8.3.0b14"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0b14"
+  "version": "8.3.0b15"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -54,6 +54,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_platform
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -2312,6 +2313,27 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             self._local_image_url.get_image_url, media_title, logo_file
         )
 
+    def _speaker_output_is_internal(self) -> bool | None:
+        """Return whether the TV's speaker output is its internal speakers.
+
+        Read from the Speaker Select entity's published state (IP Control or
+        SmartThings variant — whichever this entry created). Returns None when
+        unknown (no such entity, or it is unavailable), so callers keep the
+        default behaviour instead of guessing.
+        """
+        registry = er.async_get(self.hass)
+        for entity in registry.entities.get_entries_for_config_entry_id(self._entry_id):
+            if entity.domain != "select" or not (
+                entity.unique_id.endswith("_ip_control_speaker_select")
+                or entity.unique_id.endswith("_st_media_output")
+            ):
+                continue
+            state = self.hass.states.get(entity.entity_id)
+            if state is None or state.state in ("unavailable", "unknown"):
+                return None
+            return "internal" in state.state.lower()
+        return None
+
     @property
     def supported_features(self) -> int:
         """Flag media player features that are supported."""
@@ -2320,6 +2342,14 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             features |= MediaPlayerEntityFeature.BROWSE_MEDIA
         if self._st:
             features |= MediaPlayerEntityFeature.SELECT_SOUND_MODE
+        # Absolute volume (the slider) only targets the TV's internal volume:
+        # with an external output (HDMI-eARC receiver, optical, BT soundbar)
+        # UPnP/SmartThings setvolume is a no-op, so drop VOLUME_SET to hide the
+        # dead slider. VOLUME_STEP and VOLUME_MUTE are KEPT: the TV relays the
+        # up/down/mute keys to the external device over CEC/ARC (confirmed by a
+        # user with an eARC AVR), and the same relay applies to BT soundbars.
+        if self._speaker_output_is_internal() is False:
+            features &= ~MediaPlayerEntityFeature.VOLUME_SET
         return features
 
     def _smartthings_reports_art(self) -> bool:
@@ -2762,6 +2792,18 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         if self._state != MediaPlayerState.ON:
             return
         if self.volume_level is None:
+            return
+        # Absolute volume only reaches the TV's internal speakers; with an
+        # external output the command is silently ignored by the TV. Warn
+        # (rather than raise, to keep legacy automations from erroring) and
+        # skip the pointless call. Use volume_up/down instead — the TV relays
+        # those to the external device over CEC/ARC.
+        if self._speaker_output_is_internal() is False:
+            self._log.warning(
+                "volume_set ignored: the TV's speaker output is external "
+                "(receiver/soundbar) and absolute volume only targets the "
+                "internal speakers — use volume_up/volume_down instead"
+            )
             return
         if self._st and self._setvolumebyst:
             await self._st.async_send_command("setvolume", int(volume * 100))

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -271,6 +271,31 @@ async def async_setup_entry(
 
     session = async_get_clientsession(hass)
 
+    # Clean up registry leftovers of the read-only IP Control sensors that were
+    # replaced by settable entities (contrast/brightness/sharpness/color/tint →
+    # number sliders in 8.3.0b8; speakerSelect → select in 8.3.0b13). A removed
+    # entity otherwise lingers in the registry forever as a "restored" /
+    # unavailable ghost next to its working replacement.
+    from homeassistant.helpers import entity_registry as er
+
+    _replaced_sensor_keys = (
+        "contrast",
+        "brightness",
+        "sharpness",
+        "color",
+        "tint",
+        "speakerSelect",
+    )
+    ent_reg = er.async_get(hass)
+    for _key in _replaced_sensor_keys:
+        _stale_unique_id = f"{device_unique_id}_ip_control_{_key}"
+        if _stale_id := ent_reg.async_get_entity_id("sensor", DOMAIN, _stale_unique_id):
+            ent_reg.async_remove(_stale_id)
+            _LOGGER.debug(
+                "Removed stale registry entry %s (replaced by a settable entity)",
+                _stale_id,
+            )
+
     entities = []
 
     # Reuse the shared Art API instance (created in __init__.py) so all


### PR DESCRIPTION
`8.3.0b15`. Stacked on #134 (ghost-sensor cleanup) — once #134 merges, this PR shows only the volume-guard commit.

## Problem
`media_player.volume_set` (absolute volume, via UPnP/SmartThings) only targets the TV's **internal** speakers. With the audio routed to an external output (HDMI-eARC receiver, optical, Bluetooth soundbar) the command is a **silent no-op** — yet the volume slider stayed active and misleading on the media player card.

## Fix
- New `_speaker_output_is_internal()` on the media player: reads the **Speaker Select** entity's published state (works with both the IP Control and the SmartThings variant, matched by unique_id through the entity registry).
- `supported_features` **drops `VOLUME_SET`** when the output is known-external → the slider disappears from the card.
- **`VOLUME_STEP` and `VOLUME_MUTE` are deliberately kept**: the TV relays the up/down/mute keys to the external device over CEC/ARC — confirmed by the eARC-AVR user in #116 (`volume_up`/`volume_down` work, `volume_set` doesn't) — and the same key relay applies to Bluetooth soundbars. This is why the guard doesn't need a BT-specific case: only the absolute-set path is dead on any external output, and that's the only thing removed.
- A `volume_set` service call issued anyway (legacy automation) logs a **clear warning** and skips the pointless call — no raise, so existing automations don't start erroring.
- Unknown output (no Speaker Select entity, or unavailable — e.g. TV off) → slider stays, zero behaviour change.

## Testing
- `flake8` / `isort` / `black` clean.
- Salon Frame + Denon eARC: switch Speaker Select to `CINEMA 60(HDMI-eARC)` → the volume slider disappears from the media player card, volume up/down/mute still drive the AVR; switch back to `Internal` → the slider returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_