### PR TITLE
Matte selects: apply instantly on the panel, auto-sync, composition fixes

### DIFF
--- a/RELEASE_NOTES_8.3.0.md
+++ b/RELEASE_NOTES_8.3.0.md
@@ -14,6 +14,29 @@ If this project is useful to you, you can support its development:
 > the new `frame_tv_entity` key so the fullscreen-preview buttons work — see the
 > *lightbox buttons* note below.
 
+## Frame Art — matte selects apply instantly and stay in sync (8.3.0b16)
+
+- **Changing Matte Type / Matte Color now takes effect on the panel
+  immediately** — no helper automation needed anymore. `change_matte` alone
+  updates the stored matte but (on 2024 Frames at least) the panel keeps
+  showing the old frame until the artwork is re-selected; the selects now
+  re-select the current artwork automatically after the change, **only while
+  Art Mode is actively displaying** (so a matte change can't wake a sleeping
+  panel).
+- **The two selects stay in sync with the TV**: they now follow the Frame Art
+  sensor's `current_matte_id` (already refreshed every few seconds by the art
+  coordinator — zero extra TV traffic), so a matte changed on the TV itself or
+  via the other select is reflected within ~30 s. Sync helper automations can
+  be removed.
+- **Correctness fixes**: matte ids reported upper-cased by the TV
+  (`SHADOWBOX_POLAR`) no longer produce mixed-case ids on write; picking a
+  *color* while the matte type is `none` now raises a clear "select a matte
+  type first" error instead of sending an invalid `none_<color>` id; errors
+  surface in the UI instead of being silently logged.
+- If you had an automation like *"apply matte on select change"* (calling
+  `art_change_matte` + `art_select_image`), **delete it** — keeping it would
+  double-apply every change.
+
 ## Media player — the volume slider hides when audio goes to an external device (8.3.0b15)
 
 - **When the Speaker Select reports an external output** (HDMI-eARC receiver,

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0b15"
+  "version": "8.3.0b16"
 }

--- a/custom_components/samsungtv_smart/select.py
+++ b/custom_components/samsungtv_smart/select.py
@@ -979,7 +979,10 @@ class SamsungTVMatteSelectBase(SelectEntity):
         self._device_unique_id = device_unique_id
         self._attr_options: list[str] = []
         self._attr_current_option: str | None = None
-        self._attr_should_poll = False
+        # Poll (default 30s): async_update reads the Frame Art sensor's
+        # already-published current_matte_id — no extra TV traffic — so a matte
+        # changed on the TV or through the sibling select syncs by itself.
+        self._attr_should_poll = True
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -1007,6 +1010,56 @@ class SamsungTVMatteSelectBase(SelectEntity):
                 self.async_write_ha_state()
         except Exception as ex:
             _LOGGER.debug("Could not refresh current matte: %s", ex)
+
+    async def async_update(self) -> None:
+        """Sync from the Frame Art sensor's published matte (no TV call).
+
+        The Frame Art coordinator already polls get_current_artwork every few
+        seconds and publishes ``current_matte_id`` on its sensor; reading that
+        state keeps both matte selects in step with TV-side changes without
+        issuing any extra request.
+        """
+        state = self._frame_art_sensor_state()
+        if state is None or state.state in ("unavailable", "unknown"):
+            return
+        matte_id = state.attributes.get("current_matte_id")
+        if isinstance(matte_id, str) and matte_id:
+            self._parse_matte_id(matte_id)
+
+    def _frame_art_sensor_state(self):
+        """Return the Frame Art sensor's HA state object, or None."""
+        registry = er.async_get(self.hass)
+        sensor_id = registry.async_get_entity_id(
+            "sensor", DOMAIN, f"{self._entry.entry_id}_frame_art"
+        )
+        return self.hass.states.get(sensor_id) if sensor_id else None
+
+    def _art_is_displaying(self) -> bool:
+        """True when the panel is actively displaying Art Mode.
+
+        The art WebSocket's own cache can be None (invalidated); the Frame Art
+        sensor's state layers every source (IP Control, WS, SmartThings), so
+        trust either signal saying "on".
+        """
+        if self._art_api.art_mode:
+            return True
+        state = self._frame_art_sensor_state()
+        return bool(state and state.state == "on")
+
+    async def _apply_matte(self, content_id: str, new_matte_id: str) -> None:
+        """Send the matte to the TV and force the panel to redisplay it.
+
+        ``change_matte`` alone updates the stored matte but (on 2024 Frames at
+        least) the panel keeps showing the old frame until the artwork is
+        re-selected — so when Art Mode is actively displaying, re-select the
+        same content with ``show=True`` after a short settle delay. When art
+        is NOT being displayed, skip the re-select: ``show=True`` could wake
+        the panel into Art Mode as a side effect.
+        """
+        await self._art_api.change_matte(content_id=content_id, matte_id=new_matte_id)
+        if self._art_is_displaying():
+            await asyncio.sleep(1)
+            await self._art_api.select_image(content_id, show=True)
 
     def _parse_matte_id(self, matte_id: str) -> None:
         """To be implemented by subclass."""
@@ -1043,11 +1096,14 @@ class SamsungTVMatteTypeSelect(SamsungTVMatteSelectBase):
         try:
             current = await self._art_api.get_current()
             if not current:
-                _LOGGER.warning("Cannot change matte type: no current artwork")
-                return
+                raise HomeAssistantError(
+                    "Cannot change the matte: no current artwork (is the TV on?)."
+                )
 
             content_id: str = current.get("content_id", "")
-            existing_matte: str = current.get("matte_id", "none_polar")
+            # The TV may report the matte upper-cased (SHADOWBOX_POLAR);
+            # normalize so the composed id is always lower-case.
+            existing_matte: str = (current.get("matte_id") or "none_polar").lower()
 
             if "_" in existing_matte:
                 color_part = existing_matte.rsplit("_", 1)[1]
@@ -1056,17 +1112,16 @@ class SamsungTVMatteTypeSelect(SamsungTVMatteSelectBase):
 
             new_matte_id = f"{option}_{color_part}" if option != "none" else "none"
 
-            await self._art_api.change_matte(
-                content_id=content_id, matte_id=new_matte_id
-            )
+            await self._apply_matte(content_id, new_matte_id)
             self._attr_current_option = option
             self.async_write_ha_state()
             _LOGGER.debug(
                 "Matte type changed to %s (full id: %s)", option, new_matte_id
             )
-
+        except HomeAssistantError:
+            raise
         except Exception as ex:
-            _LOGGER.error("Error changing matte type: %s", ex)
+            raise HomeAssistantError(f"Error changing matte type: {ex}") from ex
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
@@ -1100,30 +1155,38 @@ class SamsungTVMatteColorSelect(SamsungTVMatteSelectBase):
         try:
             current = await self._art_api.get_current()
             if not current:
-                _LOGGER.warning("Cannot change matte color: no current artwork")
-                return
+                raise HomeAssistantError(
+                    "Cannot change the matte: no current artwork (is the TV on?)."
+                )
 
             content_id: str = current.get("content_id", "")
-            existing_matte: str = current.get("matte_id", "none")
+            existing_matte: str = (current.get("matte_id") or "none").lower()
 
             if "_" in existing_matte:
                 type_part = existing_matte.rsplit("_", 1)[0]
             else:
-                type_part = existing_matte or "shadowbox"
+                type_part = existing_matte
+
+            if type_part in ("", "none"):
+                # A color without a frame is meaningless: "none_<color>" is not
+                # a valid matte id. Tell the user instead of sending garbage.
+                raise HomeAssistantError(
+                    "Select a matte type first — the color only applies when a "
+                    "frame (matte type) is set."
+                )
 
             new_matte_id = f"{type_part}_{option}"
 
-            await self._art_api.change_matte(
-                content_id=content_id, matte_id=new_matte_id
-            )
+            await self._apply_matte(content_id, new_matte_id)
             self._attr_current_option = option
             self.async_write_ha_state()
             _LOGGER.debug(
                 "Matte color changed to %s (full id: %s)", option, new_matte_id
             )
-
+        except HomeAssistantError:
+            raise
         except Exception as ex:
-            _LOGGER.error("Error changing matte color: %s", ex)
+            raise HomeAssistantError(f"Error changing matte color: {ex}") from ex
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()


### PR DESCRIPTION
`8.3.0b16` — one commit on top of `v8.3-dev`.

## Problem
The Matte Type / Matte Color selects already send `change_matte`, but on 2024 Frames the panel **keeps displaying the old frame until the artwork is re-selected** — so users needed a helper automation (`art_change_matte` + delay + `art_select_image`) to actually see the change. They also drifted out of sync with TV-side changes (needing a second sync automation), and the composition logic had correctness gaps.

## Changes
1. **Apply instantly** — new `_apply_matte()`: after `change_matte`, re-select the current artwork with `show=True` (1 s settle), **only while Art Mode is actively displaying** (art-WS cache OR the Frame Art sensor's layered state), so a matte change can never wake a sleeping panel as a side effect.
2. **Auto-sync** — the selects now poll (default 30 s) by reading the Frame Art sensor's already-published `current_matte_id` (refreshed every few seconds by the art coordinator) — **zero extra TV traffic**. A matte changed on the TV or via the sibling select reflects automatically.
3. **Composition fixes**:
   - matte ids reported upper-cased by the TV (`SHADOWBOX_POLAR`) are normalized before composing (previously produced mixed-case ids like `modern_POLAR`);
   - picking a **color while the type is `none`** now raises a clear *"select a matte type first"* error instead of sending an invalid `none_<color>` id;
   - failures raise `HomeAssistantError` (visible in the UI) instead of being silently logged.

## Upgrade note
Users with an *"apply matte on select change"* automation should **delete it** after updating — keeping it would double-apply every change (the built-in selects now do the full job).

## Testing
- `flake8` / `isort` / `black` clean.
- On a Frame displaying art: change Matte Type → the frame updates on the panel within ~1–2 s; change Matte Color → same; set type to `none` then try a color → clear error; change the matte from the TV → both selects re-sync within ~30 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_