### PR TITLE
Release 8.3.0: speaker select Art-Mode gate + finalize version

### DIFF
--- a/RELEASE_NOTES_8.3.0.md
+++ b/RELEASE_NOTES_8.3.0.md
@@ -4,15 +4,24 @@ If this project is useful to you, you can support its development:
 
 # <a href="https://buymeacoffee.com/thefab21" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-black.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
-> **Status: pre-release (beta).** 8.3.0 is the next stable line after **8.1.0**.
+> **Status: stable release.** 8.3.0 is the next stable release after **8.1.0**.
 > The 8.2.0 beta was never shipped as a stable release, so **8.3.0 includes
 > everything from 8.2.0 as well** — those changes are listed under
 > *"Also included from the 8.2.0 beta"* at the bottom.
+> Field-validated over several days on two Frame TVs (2024 + 2020, OAuth and
+> PAT) through the 8.3.0b1–b16 beta series.
 
 > ℹ️ **Folder Gallery card users:** after updating, **re-open your card in the
 > visual editor and save once** (re-selecting the Frame TV entity). This writes
 > the new `frame_tv_entity` key so the fullscreen-preview buttons work — see the
 > *lightbox buttons* note below.
+
+## Speaker output — no more pointless polls in Art Mode (8.3.0 final)
+
+- The Speaker Select now skips its IP Control poll (and refuses switching, with
+  a clear message) while the TV is off or displaying Art — the speaker methods
+  answer `-32601` in Art Mode, the same firmware ambiguity as the picture
+  calibration. The select goes cleanly unavailable and recovers on its own.
 
 ## Frame Art — matte selects apply instantly and stay in sync (8.3.0b16)
 

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0b16"
+  "version": "8.3.0"
 }

--- a/custom_components/samsungtv_smart/select.py
+++ b/custom_components/samsungtv_smart/select.py
@@ -681,16 +681,20 @@ class SamsungTVIPControlSpeakerSelect(SelectEntity):
             self._ip_control_token = token
         return self._ip_control
 
-    def _tv_powered_off(self) -> bool:
-        """True when the linked TV is off (not showing Art) — skip the poll."""
+    def _tv_normal_viewing(self) -> bool:
+        """True when the TV is on for normal viewing (not off, not Art Mode).
+
+        The speaker methods answer -32601 while the panel displays Art (same
+        firmware ambiguity as the picture calibration methods), so only poll —
+        and only allow switching — during normal viewing. Field-observed: 50
+        pointless -32601 reads per art session before this gate.
+        """
         registry = er.async_get(self.hass)
         for entity in registry.entities.get_entries_for_config_entry_id(self._entry_id):
             if entity.domain != "media_player":
                 continue
             state = self.hass.states.get(entity.entity_id)
-            if state is None:
-                return False
-            if state.state not in (STATE_OFF, "unavailable"):
+            if state is None or state.state in (STATE_OFF, "unavailable", "unknown"):
                 return False
             return state.attributes.get("art_mode_status") != "on"
         return False
@@ -707,6 +711,13 @@ class SamsungTVIPControlSpeakerSelect(SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Switch the speaker output through IP Control."""
+        # Guardrail: the speaker methods answer -32601 while the TV is off or
+        # displaying Art — don't even hit the TV, give a clear message.
+        if not self._tv_normal_viewing():
+            raise HomeAssistantError(
+                "Cannot change the speaker output: the TV must be on and out "
+                "of Art Mode."
+            )
         client = self._get_ip_control()
         if client is None:
             raise HomeAssistantError(
@@ -753,7 +764,7 @@ class SamsungTVIPControlSpeakerSelect(SelectEntity):
 
     async def async_update(self) -> None:
         """Read the current speaker output and the external device list."""
-        if self._tv_powered_off():
+        if not self._tv_normal_viewing():
             self._mark_unavailable()
             return
         client = self._get_ip_control()


### PR DESCRIPTION
Final commit for the `8.3.0` stable release.

## Log review (b11→b16 field validation)
Analyzed today's full debug log (07:08–13:00, both Frames, running b16):
- **0 `samsungtv_smart` errors** (the only ERRORs are pychromecast reconnects from the Cast integration, unrelated).
- **0 `Connection reset by peer` / TLS errors** — the per-host IP Control lock (b10) holds.
- Restart at 12:32 set up cleanly; matte selects populated; no Art-Mode command storms; 4582 SmartThings polls skipped while the TVs were off.
- One cosmetic finding, fixed here: the Speaker Select polled during Art Mode and collected ~50 `-32601` debug reads per art session (the speaker methods share the picture-calibration firmware ambiguity).

## Changes
- **Speaker Select gated on normal viewing** (on + out of Art Mode): the poll is skipped (entity goes cleanly unavailable and recovers on its own) and a switch attempted during art/off gets a clear message instead of a TV round-trip.
- `manifest.json` → **`8.3.0`** (stable), release-notes banner switched from *pre-release* to *stable*.

## Release checklist (after merging this PR)
1. Merge `v8.3-dev` → `master`.
2. Publish GitHub release **`8.3.0`** from `master`, marked **latest** (not pre-release), body from `RELEASE_NOTES_8.3.0.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_