### PR TITLE
Art Mode Brightness/Color Temp: unavailable outside Art Mode (fix phantom 100%)

### DIFF
--- a/RELEASE_NOTES_8.3.1.md
+++ b/RELEASE_NOTES_8.3.1.md
@@ -1,0 +1,30 @@
+# Release notes — 8.3.1
+
+If this project is useful to you, you can support its development:
+
+# <a href="https://buymeacoffee.com/thefab21" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-black.png" alt="Buy Me A Coffee" height="41" width="174"></a>
+
+## Art Mode Brightness / Color Temperature — unavailable outside Art Mode (8.3.1b1)
+
+- **The two Art Mode sliders are now *unavailable* whenever the panel is not
+  actually displaying Art Mode**, instead of holding (and graphing) a value
+  that no longer means anything. These settings only apply to the art display;
+  outside Art Mode the TV either can't answer or answers with bogus defaults.
+- **Fixes phantom jumps to 100 %**: debug logs showed a standby read right
+  after an integration reload returning `brightness = 10` (the TV's max) while
+  the panel was off — the slider then displayed 100 % even though nobody set
+  it. The art-mode gate is now cross-checked against the Frame Art sensor
+  (which correctly knew the TV was off during that window), so stale
+  media-player state right after a reload can no longer let a bogus read
+  through.
+- History becomes honest: gaps while the TV is off/normal viewing, real values
+  while art is displayed.
+- ⚠️ **Automations note**: if you have automations that set the Art Mode
+  brightness on a schedule, add a condition that Art Mode is actually on
+  (`art_mode_status == "on"` / the Frame Art switch) — setting the value while
+  the entity is unavailable is pointless (the panel isn't showing art) and may
+  be skipped by Home Assistant.
+- Known Samsung behaviour, unchanged by this release: some 2024 Frames reset
+  the art brightness to maximum on their own after a power cycle. If that
+  bothers you, an opt-in "re-apply last brightness on Art Mode entry" can be
+  added later — open an issue.

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.0"
+  "version": "8.3.1b1"
 }

--- a/custom_components/samsungtv_smart/number.py
+++ b/custom_components/samsungtv_smart/number.py
@@ -630,13 +630,28 @@ class SamsungTVArtNumberBase(RestoreNumber):
             name=self._device_name,
         )
 
-    def _is_tv_in_art_mode(self) -> bool:
-        """Return True only if the media_player is on and in Art Mode.
+    @property
+    def available(self) -> bool:
+        """Only available while the panel is actually displaying Art Mode.
 
-        Checks the HA state of the media_player entity for this config entry.
-        This avoids hitting the WebSocket Art API when the TV is off/standby,
-        which would cause async_update to block for the full timeout duration
-        and trigger HA's '> 10 seconds' warning.
+        Brightness / color temperature only apply to the art display; outside
+        Art Mode the TV either can't answer or answers with bogus defaults
+        (observed: a standby read returning brightness=10 right after a
+        reload, showing a phantom 100 %). Going unavailable both blocks the
+        dead slider in the UI and keeps the history honest.
+        """
+        return self._is_tv_in_art_mode()
+
+    def _is_tv_in_art_mode(self) -> bool:
+        """Return True only if the TV is actually displaying Art Mode.
+
+        Checks the HA state of the media_player entity for this config entry
+        (avoids hitting the WebSocket Art API when the TV is off/standby),
+        CROSS-CHECKED against the Frame Art sensor: right after a reload the
+        media_player can briefly restore a stale art_mode_status='on' while
+        the art coordinator already knows the TV is powered off — that stale
+        window let a bogus standby read (brightness=10 → phantom 100 %)
+        through. The sensor state must not contradict the attribute.
         """
         if self._media_player_entity_id is None:
             entity_registry = er.async_get(self.hass)
@@ -661,7 +676,7 @@ class SamsungTVArtNumberBase(RestoreNumber):
         # "art_mode_status" attribute set to "on" (HA convention) — so the
         # attribute is the authoritative signal, checked BEFORE the state.
         if state.attributes.get("art_mode_status") == "on":
-            return True
+            return not self._frame_art_sensor_says_off()
 
         if state.state in ("off", "unavailable", "unknown"):
             return False
@@ -670,6 +685,24 @@ class SamsungTVArtNumberBase(RestoreNumber):
         # polling when the attribute is absent entirely (e.g. older firmware
         # or attribute not yet populated) so we don't go permanently blind.
         return "art_mode_status" not in state.attributes
+
+    def _frame_art_sensor_says_off(self) -> bool:
+        """True when the Frame Art sensor explicitly reports art NOT displaying.
+
+        Used only as a veto: when the sensor is missing or unavailable it
+        returns False (no veto), so TVs without the sensor keep the
+        media_player-based behaviour.
+        """
+        registry = er.async_get(self.hass)
+        sensor_id = registry.async_get_entity_id(
+            "sensor", DOMAIN, f"{self._entry.entry_id}_frame_art"
+        )
+        if not sensor_id:
+            return False
+        state = self.hass.states.get(sensor_id)
+        if state is None or state.state in ("unavailable", "unknown"):
+            return False
+        return state.state != "on"
 
 
 # ══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
`8.3.1b1` — first fix after the 8.3.0 stable release.

## Problem (from field debug logs)
The Art Mode Brightness slider kept jumping to **100 %** with nobody setting it. Log forensics on a 2024 Frame:
- 13:58 — TV in art, reads `brightness=2` (user's 20 %) ✓
- 13:58→15:49 — TV left art, no polls (gate working)
- **15:49:02 — a single read during an integration reload returned `brightness=10` (TV max)** while the Frame Art coordinator was simultaneously reporting *"TV is powered off"*. The media_player had briefly restored a **stale `art_mode_status='on'`** during the reload window, which let the poll through — a standby read answers with bogus defaults.
- The slider then displayed a phantom 100 %.

Scale was verified from the TV's own payload (`min=0, max=10`) — the ×10 mapping is correct; no scaling bug.

## Fix (design per the maintainer)
- **The two art sliders are now `unavailable` whenever the panel isn't actually displaying Art Mode.** These settings only apply to the art display; outside it the TV can't answer meaningfully. UI shows a greyed slider, history shows honest gaps instead of misleading values.
- **The art-mode gate is cross-checked against the Frame Art sensor**, used as a *veto only* (a missing/unavailable sensor keeps the previous media_player-based behaviour, so older TVs aren't bricked). The stale-state reload window can no longer let a bogus read through.

## Notes
- Automations that set art brightness on a schedule should condition on Art Mode being on (see release notes).
- Separate, unchanged: some 2024 Frames genuinely reset art brightness to max after a power cycle (real TV-side value, confirmed over ~215 consecutive polls). An opt-in "re-apply last brightness on art entry" can be added later if wanted.

## Testing
- `flake8` / `isort` / `black` clean.
- TV in normal viewing or off → both sliders greyed out; enter Art Mode → they come back with live values; reload the integration while the TV is off → no phantom 100 % any more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_