### PR TITLE
Picture mode: send the display name, not the internal id (#116 root cause)

### DIFF
--- a/RELEASE_NOTES_8.3.1.md
+++ b/RELEASE_NOTES_8.3.1.md
@@ -4,6 +4,23 @@ If this project is useful to you, you can support its development:
 
 # <a href="https://buymeacoffee.com/thefab21" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-black.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
+## Picture mode — send the display NAME, not the internal id (8.3.1b2, #116)
+
+- **Root cause of #116 found (credit: @androidnerd's SmartThings CLI
+  forensics): `custom.picturemode:setPictureMode` expects the display NAME
+  (`"Movie"`), not the internal id (`"modeMovie"`).** Sending the id returns
+  `200 COMPLETED` while doing nothing on the panel; sending the name actuates
+  it. This also demystifies the "PAT worked, OAuth didn't" symptom: the legacy
+  PAT-era code sent plain names, and the name→id mapping was introduced
+  together with OAuth support — correlation, not an OAuth block.
+- The integration now tries each capability with the **name first, then the
+  id**, verifying each accepted send as before, and **memorizes the verified
+  (capability + argument form) pair** (persisted across restarts) so the
+  matrix cost is only paid on the first change.
+- Verification now accepts both representations of the target: some models
+  report `pictureMode` as the display name (Frame 2024: `"Dynamique"`), others
+  as the id — both are normalized through the name↔id map.
+
 ## Art Mode Brightness / Color Temperature — unavailable outside Art Mode (8.3.1b1)
 
 - **The two Art Mode sliders are now *unavailable* whenever the panel is not

--- a/custom_components/samsungtv_smart/api/smartthings.py
+++ b/custom_components/samsungtv_smart/api/smartthings.py
@@ -128,10 +128,22 @@ class SmartThingsTV:
         self._forced_count = 0
 
     def set_verified_picture_mode_capability(self, capability: str | None) -> None:
-        """Seed the verified setPictureMode capability (from persisted data)."""
-        if capability in ("custom.picturemode", "samsungvd.pictureMode"):
+        """Seed the verified setPictureMode capability (from persisted data).
+
+        Accepts either the legacy bare capability ("custom.picturemode") or the
+        newer "capability|form" pair (form: "name" or "id"), e.g.
+        "custom.picturemode|name".
+        """
+        if capability is None:
+            return
+        cap, _, form = capability.partition("|")
+        if cap in ("custom.picturemode", "samsungvd.pictureMode") and form in (
+            "",
+            "name",
+            "id",
+        ):
             self._verified_picture_mode_capability = capability
-        elif capability is not None:
+        else:
             self._log.debug(
                 "Ignoring unknown persisted picture mode capability: %s", capability
             )
@@ -963,43 +975,68 @@ class SmartThingsTV:
                 self._picture_mode_list,
             )
 
-        # Order of attempts: the capability VERIFIED to actuate this panel (if
-        # already learned, possibly on a previous HA run) comes first, then the
-        # detected capability, then the other one — deduplicated, both always
-        # reachable as fallback. custom.picturemode returns 422 on some TVs
-        # (Frame 2024) which could interfere with the session, so the detected
-        # capability stays ahead of the blind alternative.
+        # Attempt matrix: (capability × argument form). Field testing on #116
+        # proved the argument FORM matters as much as the capability: on an
+        # S90C, custom.picturemode answers 200 COMPLETED for the internal id
+        # ("modeMovie") while doing NOTHING, but actuates the panel when sent
+        # the display NAME ("Movie") — and samsungvd.pictureMode 422s outright.
+        # (This is also why the legacy PAT/REST era "worked": it sent names;
+        # the name->id map landed together with OAuth support.) So each
+        # capability is tried with the NAME first, then the id, each send
+        # verified; the verified (capability, form) pair is memorized.
         primary = self._picture_mode_capability or "samsungvd.pictureMode"
         fallback = (
             "custom.picturemode"
             if primary == "samsungvd.pictureMode"
             else "samsungvd.pictureMode"
         )
-        capabilities_to_try = []
-        for capability in (self._verified_picture_mode_capability, primary, fallback):
-            if capability and capability not in capabilities_to_try:
-                capabilities_to_try.append(capability)
+        forms = {"name": mode, "id": mode_id}
+        attempts: list[tuple[str, str]] = []  # (capability, form)
+
+        def _add(capability: str | None, form: str) -> None:
+            if not capability:
+                return
+            if forms["name"] == forms["id"] and form == "id":
+                return  # no map: both forms identical, one attempt is enough
+            if (capability, form) not in attempts:
+                attempts.append((capability, form))
+
+        verified = self._verified_picture_mode_capability
+        if verified:
+            v_cap, _, v_form = verified.partition("|")
+            if v_form in forms:
+                _add(v_cap, v_form)
+            else:  # legacy memory: bare capability, form unknown
+                _add(v_cap, "name")
+                _add(v_cap, "id")
+        for capability in (primary, fallback):
+            _add(capability, "name")
+            _add(capability, "id")
 
         any_sent = False
-        for capability in capabilities_to_try:
+        for capability, form in attempts:
+            argument = forms[form]
             try:
                 await self._send_rest_command(
                     capability=capability,
                     command="setPictureMode",
-                    arguments=[mode_id],
+                    arguments=[argument],
                 )
             except Exception as err:
                 self._log.debug(
-                    "setPictureMode via %s failed: %s, trying fallback",
+                    "setPictureMode via %s (%s=%s) failed: %s, trying next",
                     capability,
+                    form,
+                    argument,
                     err,
                 )
                 continue
             self._log.debug(
-                "Picture mode '%s' (id: %s) sent via %s",
+                "Picture mode '%s' sent via %s (%s form: %s)",
                 mode,
-                mode_id,
                 capability,
+                form,
+                argument,
             )
             any_sent = True
             self._picture_mode = mode
@@ -1013,33 +1050,34 @@ class SmartThingsTV:
 
             # Read the mode back: COMPLETED does not guarantee the panel
             # applied it (see docstring). None = could not verify — assume
-            # applied rather than blind-firing the other capability.
-            applied = await self._async_verify_picture_mode(mode_id)
+            # applied rather than blind-firing the remaining attempts.
+            applied = await self._async_verify_picture_mode(mode, mode_id)
             if applied:
-                # Confirmed on the panel: remember this capability so later
-                # changes try it first (and persist it across HA restarts).
-                self._remember_picture_mode_capability(capability)
+                # Confirmed on the panel: remember this (capability, form) so
+                # later changes go straight through (persisted across restarts).
+                self._remember_picture_mode_capability(f"{capability}|{form}")
                 return
             if applied is None:
                 return
             self._log.warning(
-                "setPictureMode via %s was accepted (COMPLETED) but the TV "
-                "still reports another mode — trying the other capability",
+                "setPictureMode via %s (%s form) was accepted (COMPLETED) but "
+                "the TV still reports another mode — trying the next variant",
                 capability,
+                form,
             )
 
         if not any_sent:
             self._log.error(
-                "Failed to set picture mode '%s' via both capabilities", mode
+                "Failed to set picture mode '%s' via any capability/form", mode
             )
         else:
-            # Both accepted-but-unapplied (or the second one unverifiable).
+            # All accepted-but-unapplied (or the last one unverifiable).
             # Keep the optimistic value: the select entity holds the pending
             # mode and reconciles with the cloud on its own grace window.
             self._log.warning(
                 "Picture mode '%s' could not be confirmed on the TV via any "
-                "capability; if it did not change, the cloud command channel "
-                "likely cannot actuate this panel (see issue #116)",
+                "capability/argument form; if it did not change, the cloud "
+                "command channel likely cannot actuate this panel (see #116)",
                 mode,
             )
 
@@ -1065,13 +1103,16 @@ class SmartThingsTV:
             except Exception as err:  # pylint: disable=broad-except
                 self._log.debug("Could not persist picture mode capability: %s", err)
 
-    async def _async_verify_picture_mode(self, mode_id: str) -> bool | None:
-        """Return whether the TV now reports ``mode_id``, None if unknown.
+    async def _async_verify_picture_mode(self, mode: str, mode_id: str) -> bool | None:
+        """Return whether the TV now reports the requested mode, None if unknown.
 
         Waits a few seconds after the refresh command so the cloud has a
         chance to re-read the panel, then GETs the capability status
-        directly. Returns None when the read fails — the caller must not
-        treat that as "not applied".
+        directly. The ``pictureMode`` attribute reports the display NAME on
+        some models (Frame 2024: "Dynamique") and the internal id on others —
+        both representations of the target are accepted (normalized through
+        the name<->id map). Returns None when the read fails — the caller
+        must not treat that as "not applied".
         """
         if not self._device_id or not self._session:
             return None
@@ -1102,9 +1143,22 @@ class SmartThingsTV:
         if not raw_mode:
             return None
         self._log.debug(
-            "Picture mode verify: TV reports '%s' (wanted '%s')", raw_mode, mode_id
+            "Picture mode verify: TV reports '%s' (wanted '%s' / id '%s')",
+            raw_mode,
+            mode,
+            mode_id,
         )
-        return raw_mode == mode_id
+        if raw_mode in (mode, mode_id):
+            return True
+        # Normalize through the map: raw may be a name where we hold the id,
+        # or vice versa.
+        if self._picture_mode_map:
+            if self._picture_mode_map.get(raw_mode) == mode_id:
+                return True  # raw is the name of our target id
+            reverse = {v: k for k, v in self._picture_mode_map.items()}
+            if reverse.get(raw_mode) == mode:
+                return True  # raw is the id of our target name
+        return False
 
     async def _async_refresh_device_status(self) -> None:
         """Send a 'refresh' command to force SmartThings to re-read TV state.

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.3.1b1"
+  "version": "8.3.1b2"
 }


### PR DESCRIPTION
`8.3.1b2` — fixes #116 at its actual root cause, found by @androidnerd's SmartThings CLI forensics.

## Root cause
`custom.picturemode:setPictureMode` expects the **display name** (`"Movie"`), **not the internal id** (`"modeMovie"`):
- id → `200 COMPLETED`, panel does **nothing** (a lying success);
- name → `200 COMPLETED`, panel **actuates**;
- `samsungvd.pictureMode` → `422` on the S90C for either form.

The integration resolved name→id through `supportedPictureModesMap` and always sent the id — so every send was a confirmed no-op on affected models. This also demystifies the *"PAT worked, OAuth didn't"* red herring: the legacy PAT-era code sent plain names, and the name→id mapping was introduced together with OAuth support. Correlation, not an OAuth block — Samsung never filtered anything.

## Fix
- **Attempt matrix (capability × argument form)**: each capability is tried with the **name first, then the id**, every accepted send verified by reading the mode back (the b11 machinery). The first verified combination is **memorized as `capability|form` and persisted** across restarts (b12 machinery, extended) — the matrix cost is only paid on the first change. Legacy bare-capability memories are still accepted and expand to both forms.
- **Verification accepts both representations**: some models report `pictureMode` as the display name (Frame 2024 reports `"Dynamique"`), others as the id — both are normalized through the name↔id map, fixing a latent false-negative that could have triggered pointless re-sends on name-reporting TVs.

## Expected on the S90C / Frame 2020 (OAuth)
First change after update: up to ~10–20 s while the matrix walks to `custom.picturemode|name`, then the panel changes and the log shows `Picture mode capability verified working: custom.picturemode|name … — memorizing`. Every later change goes straight through with no delay.

## Testing
- `flake8` / `isort` / `black` clean.
- To be confirmed by the #116 reporters on 8.3.1b2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_