### PR TITLE
Art identification: auto sensor + multilingual metadata + off-network art-mode bail-fast (v8.4)

### DIFF
--- a/RELEASE_NOTES_8.4.0.md
+++ b/RELEASE_NOTES_8.4.0.md
@@ -41,6 +41,45 @@ Costs are tiny: Google Vision is free under ~1000 requests/month, and — since
 the same few dozen artworks rotate — the cache serves almost everything after a
 short warm-up, so the LLM is rarely called.
 
-_Coming next: automatic identification on every artwork change + a
-`sensor.<tv>_art_metadata` (title as state; artist/date/bio/confidence as
-attributes) + a ready-made Lovelace card._
+## Automatic identification + metadata sensor (8.4.0b2)
+
+When the feature is enabled, a new **`sensor.<tv>_art_metadata`** is created. It
+watches the artwork on screen and, on every change (debounced ~8 s so a fast
+slideshow doesn't fire per frame), runs the pipeline automatically and
+publishes:
+
+- **state** = the artwork title (or `Unidentified`);
+- **attributes** = `artist`, `date`, `artist_biography`, `artwork_description`,
+  `visual_description`, `confidence`, `matched_candidate`,
+  `suggested_search_query`, `source` (`cache`/`fresh`), `content_id`.
+
+The sensor and the manual `art_identify` service share one cache, so a title
+seen once is instant (and free) forever after. Enabling/disabling the feature
+adds/removes this sensor (a reload); editing an API key does not reload.
+
+### Ready-made Lovelace card
+
+A Markdown card that shows the current artwork thumbnail with its title, artist
+and bio underneath (replace `samsung_hacs` with your entity):
+
+```yaml
+type: markdown
+content: >
+  {% set m = 'sensor.samsung_hacs_art_metadata' %}
+  {% set thumb = state_attr('sensor.samsung_hacs_frame_art', 'current_thumbnail_url') %}
+  {% if thumb %}![art]({{ thumb }}){% endif %}
+
+
+  {% if is_state_attr(m, 'identified', true) %}
+  ## {{ states(m) }}
+
+  **{{ state_attr(m, 'artist') }}** · {{ state_attr(m, 'date') }}
+
+
+  {{ state_attr(m, 'artist_biography') }}
+  {% else %}
+  _Artwork not identified_
+  {% endif %}
+```
+
+A richer `custom:button-card` / picture-glance version can be built if wanted.

--- a/RELEASE_NOTES_8.4.0.md
+++ b/RELEASE_NOTES_8.4.0.md
@@ -83,3 +83,19 @@ content: >
 ```
 
 A richer `custom:button-card` / picture-glance version can be built if wanted.
+
+### Troubleshooting (8.4.0b3)
+
+Debug logging now traces the whole pipeline — the gating decision, the
+thumbnail read, the **Vision candidates**, the **raw LLM reply**, cache
+hit/miss, timing, and each sensor trigger. Enable it with:
+
+```yaml
+logger:
+  logs:
+    custom_components.samsungtv_smart.art_identify: debug
+    custom_components.samsungtv_smart.sensor: debug
+```
+
+Typical lines: `Vision candidates best_guess=[…]`, `LLM (anthropic/…) raw
+reply: {…}`, `identified=True title=… in 6.3s`, `cache HIT (…)`.

--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -56,7 +56,6 @@ from .const import (
     AUTH_METHOD_OAUTH,
     AUTH_METHOD_ST_ENTRY,
     CONF_APP_LIST,
-    CONF_ART_IDENTIFY_ENABLE,
     CONF_ART_IDENTIFY_PERSONAL,
     CONF_ART_LLM_API_KEY,
     CONF_ART_LLM_MODEL,
@@ -1200,9 +1199,10 @@ _RELOAD_OPTIONS = (
 # what the verify-and-fallback logic runs right after a user action).
 _NO_RELOAD_DATA_KEYS = (
     CONF_ST_PICTURE_MODE_CAPABILITY,
-    # Art-identification config (keys/toggles/model): read live by the service
-    # and coordinator, so persisting it shouldn't tear the integration down.
-    CONF_ART_IDENTIFY_ENABLE,
+    # Art-identification config read live by the service/sensor: persisting it
+    # shouldn't tear the integration down. NOTE: CONF_ART_IDENTIFY_ENABLE is
+    # deliberately NOT here — toggling it creates/removes the Art Metadata
+    # sensor, which requires a reload.
     CONF_ART_IDENTIFY_PERSONAL,
     CONF_ART_VISION_API_KEY,
     CONF_ART_LLM_PROVIDER,

--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -354,6 +354,7 @@ async def async_llm_confirm(
         raw = "".join(p.get("text", "") for p in parts)
     else:
         raw = (data.get("choices") or [{}])[0].get("message", {}).get("content", "")
+    _LOGGER.debug("LLM (%s/%s) raw reply: %s", provider, model, raw[:600])
     parsed = _parse_llm_json(raw)
     # Normalize to the known schema so downstream is predictable.
     return {k: parsed.get(k) for k in RESULT_KEYS}
@@ -382,15 +383,37 @@ async def async_identify(
     key = derive_key(content_id, image_bytes)
 
     if force:
+        _LOGGER.debug("Artwork %s: force=True, bypassing cache", key)
         await cache.async_invalidate(key)
     else:
         hit = cache.get(key)
         if hit is not None:
+            _LOGGER.debug(
+                "Artwork %s: cache HIT (identified=%s title=%s)",
+                key,
+                hit.get("identified"),
+                hit.get("title"),
+            )
             return hit
+    _LOGGER.debug(
+        "Artwork %s: cache miss — running pipeline (%d bytes, %s/%s)",
+        key,
+        len(image_bytes),
+        provider,
+        model,
+    )
 
     img_b64 = base64.b64encode(image_bytes).decode()
+    started = time.monotonic()
     try:
         candidates = await async_vision_web_detection(session, vision_key, img_b64)
+        _LOGGER.debug(
+            "Artwork %s: Vision candidates best_guess=%s | entities=%s | pages=%s",
+            key,
+            candidates.get("best_guess"),
+            candidates.get("entities"),
+            candidates.get("pages"),
+        )
         result = await async_llm_confirm(
             session, provider, llm_key, model, img_b64, candidates
         )
@@ -405,10 +428,13 @@ async def async_identify(
     await cache.async_put(key, result)
     result["source"] = "fresh"
     _LOGGER.debug(
-        "Artwork %s identified=%s title=%s (via %s/%s)",
+        "Artwork %s identified=%s title=%s artist=%s conf=%s in %.1fs (via %s/%s)",
         key,
         result.get("identified"),
         result.get("title"),
+        result.get("artist"),
+        result.get("confidence"),
+        time.monotonic() - started,
         provider,
         model,
     )
@@ -464,6 +490,14 @@ async def async_identify_for_entry(
         return {"error": "Vision and LLM API keys must be set in the options"}
 
     is_store = bool(content_id and content_id.startswith("SAM-"))
+    _LOGGER.debug(
+        "Art identify: content_id=%s store=%s provider=%s model=%s force=%s",
+        content_id,
+        is_store,
+        provider,
+        model,
+        force,
+    )
     if not is_store and not data.get(CONF_ART_IDENTIFY_PERSONAL):
         return {
             "skipped": "personal artwork identification is disabled",
@@ -478,6 +512,7 @@ async def async_identify_for_entry(
             "error": f"thumbnail not available yet ({ex}); wait for the Frame "
             "Art sensor to download current.jpg"
         }
+    _LOGGER.debug("Art identify: read thumbnail %s (%d bytes)", path, len(image_bytes))
 
     session = async_get_clientsession(hass)
     result = await async_identify(

--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -271,10 +271,14 @@ async def async_llm_confirm(
             "Authorization": f"Bearer {api_key}",
             "content-type": "application/json",
         }
+        # max_completion_tokens (not the deprecated max_tokens) — the gpt-5 /
+        # o-series models reject max_tokens outright; it works for gpt-4o too.
+        # temperature is intentionally omitted: the reasoning models only
+        # accept the default, and the reverse-search candidates + json_object
+        # already constrain the answer, so determinism isn't needed here.
         body = {
             "model": model,
-            "max_tokens": 700,
-            "temperature": 0.1,
+            "max_completion_tokens": 700,
             "response_format": {"type": "json_object"},
             "messages": [
                 {

--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -41,10 +41,25 @@ from typing import Any
 
 from aiohttp import ClientError, ClientSession
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.storage import Store
 
-from .const import ART_CACHE_TTL_HIT, ART_CACHE_TTL_MISS
+from .const import (
+    ART_CACHE_TTL_HIT,
+    ART_CACHE_TTL_MISS,
+    CONF_ART_IDENTIFY_ENABLE,
+    CONF_ART_IDENTIFY_PERSONAL,
+    CONF_ART_LLM_API_KEY,
+    CONF_ART_LLM_MODEL,
+    CONF_ART_LLM_PROVIDER,
+    CONF_ART_VISION_API_KEY,
+    DATA_ART_CACHE,
+    DEFAULT_ART_LLM_MODEL,
+    DEFAULT_ART_LLM_PROVIDER,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -397,4 +412,85 @@ async def async_identify(
         provider,
         model,
     )
+    return result
+
+
+def _read_file_bytes(path: str) -> bytes:
+    """Read a file's bytes (runs in the executor). Raises OSError if missing."""
+    with open(path, "rb") as handle:
+        return handle.read()
+
+
+def get_shared_cache(hass: HomeAssistant, entry_id: str) -> ArtIdentifyCache:
+    """Return the per-entry ArtIdentifyCache, creating it once.
+
+    Shared between the manual service and the metadata sensor so both hit the
+    same in-memory cache within a session.
+    """
+    store = hass.data[DOMAIN][entry_id]
+    cache = store.get(DATA_ART_CACHE)
+    if cache is None:
+        cache = ArtIdentifyCache(hass, entry_id)
+        store[DATA_ART_CACHE] = cache
+    return cache
+
+
+async def async_identify_for_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    content_id: str | None,
+    *,
+    cache: ArtIdentifyCache,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Resolve config + thumbnail for a config entry and run identification.
+
+    The single entry point shared by the ``art_identify`` service and the
+    metadata sensor. Returns the identification dict, or a dict with an
+    ``error`` / ``skipped`` key describing why nothing ran (disabled, missing
+    keys, personal artwork with the toggle off, thumbnail not downloaded yet).
+    """
+    data = entry.data
+    if not data.get(CONF_ART_IDENTIFY_ENABLE):
+        return {
+            "error": "Art identification is disabled — enable it in the "
+            "integration options (Configure → Art Identification)"
+        }
+    vision_key = data.get(CONF_ART_VISION_API_KEY)
+    llm_key = data.get(CONF_ART_LLM_API_KEY)
+    provider = data.get(CONF_ART_LLM_PROVIDER) or DEFAULT_ART_LLM_PROVIDER
+    model = data.get(CONF_ART_LLM_MODEL) or DEFAULT_ART_LLM_MODEL.get(provider)
+    if not vision_key or not llm_key:
+        return {"error": "Vision and LLM API keys must be set in the options"}
+
+    is_store = bool(content_id and content_id.startswith("SAM-"))
+    if not is_store and not data.get(CONF_ART_IDENTIFY_PERSONAL):
+        return {
+            "skipped": "personal artwork identification is disabled",
+            "content_id": content_id,
+        }
+
+    path = hass.config.path("www", "frame_art", entry.entry_id, "current.jpg")
+    try:
+        image_bytes = await hass.async_add_executor_job(_read_file_bytes, path)
+    except OSError as ex:
+        return {
+            "error": f"thumbnail not available yet ({ex}); wait for the Frame "
+            "Art sensor to download current.jpg"
+        }
+
+    session = async_get_clientsession(hass)
+    result = await async_identify(
+        hass,
+        session,
+        cache,
+        content_id,
+        image_bytes,
+        vision_key=vision_key,
+        provider=provider,
+        llm_key=llm_key,
+        model=model,
+        force=force,
+    )
+    result["content_id"] = content_id
     return result

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -38,6 +38,7 @@ DATA_CFG_YAML = "cfg_yaml"
 DATA_OPTIONS = "options"
 DATA_ENTRY_DATA = "entry_data"  # Snapshot of entry.data to detect data changes
 DATA_ART_API = "art_api"  # Shared Frame Art API instance
+DATA_ART_CACHE = "art_cache"  # Shared ArtIdentifyCache instance (per entry)
 CONF_IS_FRAME_TV = "is_frame_tv"  # Persisted flag: TV confirmed as Frame TV
 # V7: persisted capability flags for the dedicated brightness / colour-temp
 # WebSocket requests. On TVs that don't respond (e.g. Frame 2024) we learn

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.4.0b1"
+  "version": "8.4.0b2"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.4.0b2"
+  "version": "8.4.0b3"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -103,12 +103,6 @@ from .const import (
     CONF_APP_LAUNCH_METHOD,
     CONF_APP_LIST,
     CONF_APP_LOAD_METHOD,
-    CONF_ART_IDENTIFY_ENABLE,
-    CONF_ART_IDENTIFY_PERSONAL,
-    CONF_ART_LLM_API_KEY,
-    CONF_ART_LLM_MODEL,
-    CONF_ART_LLM_PROVIDER,
-    CONF_ART_VISION_API_KEY,
     CONF_AUTH_METHOD,
     CONF_CHANNEL_LIST,
     CONF_DUMP_APPS,
@@ -144,8 +138,6 @@ from .const import (
     DATA_CFG,
     DATA_OPTIONS,
     DEFAULT_APP,
-    DEFAULT_ART_LLM_MODEL,
-    DEFAULT_ART_LLM_PROVIDER,
     DEFAULT_PORT,
     DEFAULT_SOURCE_LIST,
     DEFAULT_ST_POLL_ON_INTERVAL,
@@ -473,12 +465,6 @@ async def async_setup_entry(
         },
         "async_art_set_auto_rotation",
     )
-
-
-def _read_file_bytes(path: str) -> bytes:
-    """Read a file's bytes (runs in the executor). Raises OSError if missing."""
-    with open(path, "rb") as handle:
-        return handle.read()
 
 
 def _get_default_app_info(app_id):
@@ -3403,68 +3389,27 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
     async def async_art_identify(self, force: bool = False) -> dict:
         """Identify the currently displayed artwork (reverse search + LLM).
 
-        Opt-in pipeline (v8.4). Reads the resolved config from entry.data,
-        runs the cache-first identification on the byte-stable current.jpg the
-        Frame Art coordinator downloaded, and returns the result dict (usable
-        via a service ``response_variable``). Manual entry point; the automatic
-        per-artwork trigger arrives in a later slice.
+        Opt-in pipeline (v8.4). Resolves the current content_id, then delegates
+        to the shared entry point (config resolve + cache-first identification
+        on the byte-stable current.jpg). Returns the result dict, usable via a
+        service ``response_variable``. The automatic per-artwork trigger lives
+        on the Art Metadata sensor.
         """
-        from .art_identify import ArtIdentifyCache, async_identify
+        from .art_identify import async_identify_for_entry, get_shared_cache
 
         entry = self.hass.config_entries.async_get_entry(self._entry_id)
         if entry is None:
             return {"error": "config entry not found"}
-        data = entry.data
-        if not data.get(CONF_ART_IDENTIFY_ENABLE):
-            return {
-                "error": "Art identification is disabled — enable it in the "
-                "integration options (Configure → Art identification)"
-            }
-        vision_key = data.get(CONF_ART_VISION_API_KEY)
-        llm_key = data.get(CONF_ART_LLM_API_KEY)
-        provider = data.get(CONF_ART_LLM_PROVIDER) or DEFAULT_ART_LLM_PROVIDER
-        model = data.get(CONF_ART_LLM_MODEL) or DEFAULT_ART_LLM_MODEL.get(provider)
-        if not vision_key or not llm_key:
-            return {"error": "Vision and LLM API keys must be set in the options"}
-
         try:
             current = await self._art_api.get_current()
         except Exception as ex:  # noqa: BLE001 — surfaced to the caller
             return {"error": f"could not read current artwork: {ex}"}
         content_id = (current or {}).get("content_id")
 
-        is_store = bool(content_id and content_id.startswith("SAM-"))
-        if not is_store and not data.get(CONF_ART_IDENTIFY_PERSONAL):
-            return {
-                "skipped": "personal artwork identification is disabled",
-                "content_id": content_id,
-            }
-
-        path = self.hass.config.path("www", "frame_art", self._entry_id, "current.jpg")
-        try:
-            image_bytes = await self.hass.async_add_executor_job(_read_file_bytes, path)
-        except OSError as ex:
-            return {
-                "error": f"thumbnail not available yet ({ex}); wait for the "
-                "Frame Art sensor to download current.jpg"
-            }
-
-        cache = ArtIdentifyCache(self.hass, self._entry_id)
-        session = async_get_clientsession(self.hass)
-        result = await async_identify(
-            self.hass,
-            session,
-            cache,
-            content_id,
-            image_bytes,
-            vision_key=vision_key,
-            provider=provider,
-            llm_key=llm_key,
-            model=model,
-            force=force,
+        cache = get_shared_cache(self.hass, self._entry_id)
+        return await async_identify_for_entry(
+            self.hass, entry, content_id, cache=cache, force=force
         )
-        result["content_id"] = content_id
-        return result
 
     async def _ensure_art_mode_ready(self) -> bool:
         """Ensure TV is on and in Art Mode. Turn it on and activate Art Mode if needed.

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -1645,6 +1645,11 @@ class FrameArtMetadataSensor(SensorEntity):
         )
         if not content_id or content_id == self._handled_content_id:
             return
+        _LOGGER.debug(
+            "Art metadata: artwork changed to %s (was %s) — scheduling identify",
+            content_id,
+            self._handled_content_id,
+        )
         self._schedule_identify(content_id)
 
     @callback
@@ -1655,6 +1660,11 @@ class FrameArtMetadataSensor(SensorEntity):
             self._debounce_unsub()
         self._debounce_unsub = async_call_later(
             self.hass, ART_IDENTIFY_DEBOUNCE, self._async_debounce_fire
+        )
+        _LOGGER.debug(
+            "Art metadata: identify for %s debounced %ss",
+            content_id,
+            ART_IDENTIFY_DEBOUNCE,
         )
 
     @callback
@@ -1695,6 +1705,13 @@ class FrameArtMetadataSensor(SensorEntity):
                 self._schedule_identify(content_id)
             return
         identified = bool(result.get("identified"))
+        _LOGGER.debug(
+            "Art metadata updated: %s -> identified=%s title=%s source=%s",
+            content_id,
+            identified,
+            result.get("title"),
+            result.get("source"),
+        )
         self._attr_native_value = result.get("title") if identified else "Unidentified"
         self._attr_extra_state_attributes = {
             "identified": identified,

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -29,10 +29,12 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfPower,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later, async_track_state_change_event
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -48,7 +50,9 @@ from .api.ipcontrol import (
     SamsungIPControlTransportError,
 )
 from .const import (
+    ART_IDENTIFY_DEBOUNCE,
     CONF_API_KEY,
+    CONF_ART_IDENTIFY_ENABLE,
     CONF_DEVICE_ID,
     CONF_ENABLE_IP_CONTROL,
     CONF_IP_CONTROL_TOKEN,
@@ -251,7 +255,7 @@ SCAN_INTERVAL = timedelta(seconds=15)
 FRAME_ART_SCAN_INTERVAL = timedelta(seconds=5)
 
 
-async def async_setup_entry(
+async def async_setup_entry(  # noqa: C901
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
@@ -376,6 +380,13 @@ async def async_setup_entry(
         entities.append(
             FrameArtSensor(coordinator, entry, art_api, device_name, device_unique_id)
         )
+
+        # Art metadata sensor (opt-in): auto-identifies each artwork.
+        if entry.data.get(CONF_ART_IDENTIFY_ENABLE):
+            entities.append(
+                FrameArtMetadataSensor(entry, device_name, device_unique_id)
+            )
+            _LOGGER.debug("Art metadata sensor created for %s", device_name)
 
         # Add folder sensors for each thumbnail subdirectory.
         # These mirror HA's platform:folder format (file_list, path, bytes…)
@@ -1554,6 +1565,135 @@ class FrameArtCoordinator(DataUpdateCoordinator):
             self.async_set_updated_data(self.data)
 
         return promoted
+
+
+class FrameArtMetadataSensor(SensorEntity):
+    """Auto-identify the artwork on screen and expose its metadata (opt-in).
+
+    Watches the Frame Art sensor's ``current_content_id`` and, on a (debounced)
+    change, runs the reverse-search + LLM pipeline via the shared entry point.
+    State = artwork title (or "Unidentified"); the artist, date, biography,
+    confidence, source and content_id land in the attributes (no 255-char
+    limit). No polling — it is driven purely by the Frame Art sensor's state.
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:image-frame"
+    _attr_should_poll = False
+
+    def __init__(
+        self, entry: ConfigEntry, device_name: str, device_unique_id: str
+    ) -> None:
+        """Initialize the art metadata sensor."""
+        self._entry_id = entry.entry_id
+        self._device_name = device_name
+        self._device_unique_id = device_unique_id
+        self._attr_unique_id = f"{entry.entry_id}_art_metadata"
+        self._attr_name = "Art Metadata"
+        self._attr_native_value: str | None = None
+        self._attr_extra_state_attributes: dict[str, Any] = {}
+        self._frame_art_entity_id: str | None = None
+        self._identified_content_id: str | None = None
+        self._pending_content_id: str | None = None
+        self._debounce_unsub = None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Link this entity to the TV device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_unique_id)},
+            name=self._device_name,
+        )
+
+    def _find_frame_art_entity(self) -> str | None:
+        registry = er.async_get(self.hass)
+        return registry.async_get_entity_id(
+            "sensor", DOMAIN, f"{self._entry_id}_frame_art"
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to the Frame Art sensor and kick an initial identification."""
+        await super().async_added_to_hass()
+        self._frame_art_entity_id = self._find_frame_art_entity()
+        if not self._frame_art_entity_id:
+            return
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, [self._frame_art_entity_id], self._async_frame_art_changed
+            )
+        )
+        state = self.hass.states.get(self._frame_art_entity_id)
+        content_id = state.attributes.get("current_content_id") if state else None
+        if content_id:
+            self._schedule_identify(content_id)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel any pending debounced identification."""
+        if self._debounce_unsub is not None:
+            self._debounce_unsub()
+            self._debounce_unsub = None
+
+    @callback
+    def _async_frame_art_changed(self, event) -> None:
+        new_state = event.data.get("new_state")
+        content_id = (
+            new_state.attributes.get("current_content_id") if new_state else None
+        )
+        if not content_id or content_id == self._identified_content_id:
+            return
+        self._schedule_identify(content_id)
+
+    @callback
+    def _schedule_identify(self, content_id: str) -> None:
+        """Debounce: coalesce rapid slideshow flips into one identification."""
+        self._pending_content_id = content_id
+        if self._debounce_unsub is not None:
+            self._debounce_unsub()
+        self._debounce_unsub = async_call_later(
+            self.hass, ART_IDENTIFY_DEBOUNCE, self._async_debounce_fire
+        )
+
+    @callback
+    def _async_debounce_fire(self, _now) -> None:
+        self._debounce_unsub = None
+        content_id = self._pending_content_id
+        if content_id:
+            self.hass.async_create_task(self._async_run_identify(content_id))
+
+    async def _async_run_identify(self, content_id: str) -> None:
+        from .art_identify import async_identify_for_entry, get_shared_cache
+
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None:
+            return
+        cache = get_shared_cache(self.hass, self._entry_id)
+        result = await async_identify_for_entry(
+            self.hass, entry, content_id, cache=cache
+        )
+        if result.get("error") or result.get("skipped"):
+            _LOGGER.debug(
+                "Art metadata: %s (content_id=%s)",
+                result.get("error") or result.get("skipped"),
+                content_id,
+            )
+            return
+        self._identified_content_id = content_id
+        identified = bool(result.get("identified"))
+        self._attr_native_value = result.get("title") if identified else "Unidentified"
+        self._attr_extra_state_attributes = {
+            "identified": identified,
+            "confidence": result.get("confidence"),
+            "artist": result.get("artist"),
+            "date": result.get("date"),
+            "artist_biography": result.get("artist_biography"),
+            "artwork_description": result.get("artwork_description"),
+            "visual_description": result.get("visual_description"),
+            "matched_candidate": result.get("matched_candidate"),
+            "suggested_search_query": result.get("suggested_search_query"),
+            "source": result.get("source"),
+            "content_id": content_id,
+        }
+        self.async_write_ha_state()
 
 
 class FrameArtFolderSensor(SensorEntity):

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -1593,7 +1593,11 @@ class FrameArtMetadataSensor(SensorEntity):
         self._attr_native_value: str | None = None
         self._attr_extra_state_attributes: dict[str, Any] = {}
         self._frame_art_entity_id: str | None = None
-        self._identified_content_id: str | None = None
+        # content_id already acted on (any outcome) — dedup guard so unrelated
+        # Frame-Art attribute churn can't re-trigger the same identification.
+        self._handled_content_id: str | None = None
+        # one-shot retry flag for the startup thumbnail-not-ready race.
+        self._retried_content_id: str | None = None
         self._pending_content_id: str | None = None
         self._debounce_unsub = None
 
@@ -1639,7 +1643,7 @@ class FrameArtMetadataSensor(SensorEntity):
         content_id = (
             new_state.attributes.get("current_content_id") if new_state else None
         )
-        if not content_id or content_id == self._identified_content_id:
+        if not content_id or content_id == self._handled_content_id:
             return
         self._schedule_identify(content_id)
 
@@ -1666,18 +1670,30 @@ class FrameArtMetadataSensor(SensorEntity):
         entry = self.hass.config_entries.async_get_entry(self._entry_id)
         if entry is None:
             return
+        # Mark handled BEFORE the call so a persistent error (bad key, quota)
+        # can't be retried on every unrelated Frame-Art attribute change — that
+        # would hammer the API. Recovery paths: the artwork changing, or the
+        # manual art_identify service with force: true.
+        self._handled_content_id = content_id
         cache = get_shared_cache(self.hass, self._entry_id)
         result = await async_identify_for_entry(
             self.hass, entry, content_id, cache=cache
         )
-        if result.get("error") or result.get("skipped"):
-            _LOGGER.debug(
-                "Art metadata: %s (content_id=%s)",
-                result.get("error") or result.get("skipped"),
-                content_id,
-            )
+        if result.get("skipped"):
+            _LOGGER.debug("Art metadata skipped: %s", result.get("skipped"))
             return
-        self._identified_content_id = content_id
+        if result.get("error"):
+            _LOGGER.debug("Art metadata error: %s", result.get("error"))
+            # Startup race: current.jpg not downloaded yet — allow ONE delayed
+            # retry for this artwork (no storm: guarded per content_id).
+            if (
+                "thumbnail not available" in result["error"]
+                and self._retried_content_id != content_id
+            ):
+                self._retried_content_id = content_id
+                self._handled_content_id = None
+                self._schedule_identify(content_id)
+            return
         identified = bool(result.get("identified"))
         self._attr_native_value = result.get("title") if identified else "Unidentified"
         self._attr_extra_state_attributes = {


### PR DESCRIPTION
Follow-up to #146 (merged at `8.4.0b1` — engine + config + service). These commits landed on the branch after #146 was merged. `8.4.0b4`. Base `v8.4-dev`.

## What's here (not yet in v8.4-dev)
1. **OpenAI `max_completion_tokens`** — gpt-5/o-series 400 fix (temperature dropped).
2. **Automatic metadata sensor** — `sensor.<tv>_art_metadata` (opt-in): watches `current_content_id`, debounced ~8 s, runs the pipeline, publishes metadata. Shared `async_identify_for_entry()` + `get_shared_cache()`; the service delegates.
3. **API retry-storm guard** — the sensor marks each `content_id` handled *before* the call.
4. **Rich debug logging** across the pipeline.
5. **Multilingual metadata (5 languages)** — the LLM returns title + descriptions in `en/fr/es/it/pt-BR` in one call. Language-independent fields (artist/date/confidence/…) stay top-level; the per-language prose goes in a `translations` dict, with English fallback for any language the model omits. The sensor exposes the **instance-language** copy (plain cards) **plus the full `translations` attribute** so a frontend card renders **each viewer's own browser/UI language** — a FR user and an EN user on the same dashboard each read the description in their language. Cache renamed `_v2` (old English-only entries re-identify into all languages). A per-viewer `custom:button-card` is in the release notes.
6. **Art-mode off-network bail-fast** — when the art-mode switch powers on an off TV that never becomes reachable (deep standby / dropped Wi-Fi), it now **aborts instead of the 8s wait + 5× retry loop** (~60 s of futile hammering). Tames the art-mode "vrille" a spurious art-on command triggers on an off Salon TV (see log analysis on #116 / the maintainer's reports).

## Testing
- `flake8` / `isort` / `black` clean; offline unit checks for key-derivation, JSON parsing, Gemini, and the multilingual normalization (missing-language → English fallback) pass.
- Live (via the merged service): identifies Store works and photographs; `fresh` → `cache`.

## Notes
- Enabling/disabling the feature adds/removes the sensor (reload); editing keys doesn't reload.
- The off-network guard preserves cold-boot (a TV that answers within the ready window proceeds normally); it only aborts when the TV never responds to power-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2