### PR TITLE
Multilingual art metadata + off-network bail-fast/deferred re-apply + token-budget fix (v8.4)

### DIFF
--- a/RELEASE_NOTES_8.4.0.md
+++ b/RELEASE_NOTES_8.4.0.md
@@ -41,6 +41,50 @@ Costs are tiny: Google Vision is free under ~1000 requests/month, and — since
 the same few dozen artworks rotate — the cache serves almost everything after a
 short warm-up, so the LLM is rarely called.
 
+## Multilingual metadata + off-network art-mode guard (8.4.0b4)
+
+- **The metadata is now produced in 5 languages** (`en`, `fr`, `es`, `it`,
+  `pt-BR`) in a single LLM call. The `sensor.<tv>_art_metadata` exposes the
+  descriptive fields (`title`, `artwork_description`, `artist_biography`,
+  `visual_description`) in the Home Assistant instance language for a plain
+  card, **plus a full `translations` attribute** `{lang: {…}}` so a frontend
+  card can show each viewer the description **in their own browser/UI
+  language** — a FR user and an EN user looking at the same dashboard each read
+  it in their language. `artist`/`date`/`confidence` stay language-independent.
+  (The cache is rebuilt once — old English-only entries re-identify into all
+  languages.)
+- **Art-mode switch: stop thrashing an off-network TV.** When `switch.…_art_mode`
+  is turned on while the TV is off and the TV never becomes reachable after the
+  power-on (deep standby / dropped Wi-Fi), the switch now **aborts instead of
+  running the 8s stabilise wait + 5× retry loop** (~60s of futile hammering).
+  This tames the "art mode went haywire" episodes triggered by an automation
+  commanding art-on on an off Salon TV.
+
+### Per-viewer language Lovelace card
+
+`custom:button-card` reads the viewer's language from `hass` and picks the
+matching translation (replace `samsung_hacs`):
+
+```yaml
+type: custom:button-card
+entity: sensor.samsung_hacs_art_metadata
+show_icon: false
+show_entity_picture: true
+entity_picture: >
+  [[[ return states['sensor.samsung_hacs_frame_art'].attributes.current_thumbnail_url ]]]
+name: |
+  [[[
+    const a = entity.attributes;
+    if (!a.identified) return 'Artwork not identified';
+    const lang = (hass.language || 'en').split('-')[0];
+    const t = (a.translations && (a.translations[lang] || a.translations.en)) || {};
+    return `${t.title}\n${a.artist} · ${a.date}\n\n${t.artist_biography || ''}`;
+  ]]]
+styles:
+  card: [{ padding: 12px }]
+  name: [{ white-space: pre-line }, { font-size: 13px }]
+```
+
 ## Automatic identification + metadata sensor (8.4.0b2)
 
 When the feature is enabled, a new **`sensor.<tv>_art_metadata`** is created. It

--- a/RELEASE_NOTES_8.4.0.md
+++ b/RELEASE_NOTES_8.4.0.md
@@ -53,12 +53,16 @@ short warm-up, so the LLM is rarely called.
   it in their language. `artist`/`date`/`confidence` stay language-independent.
   (The cache is rebuilt once — old English-only entries re-identify into all
   languages.)
-- **Art-mode switch: stop thrashing an off-network TV.** When `switch.…_art_mode`
-  is turned on while the TV is off and the TV never becomes reachable after the
-  power-on (deep standby / dropped Wi-Fi), the switch now **aborts instead of
-  running the 8s stabilise wait + 5× retry loop** (~60s of futile hammering).
-  This tames the "art mode went haywire" episodes triggered by an automation
-  commanding art-on on an off Salon TV.
+- **Art-mode switch: stop thrashing an off-network TV, re-apply when it's
+  back.** When `switch.…_art_mode` is turned on while the TV is off and it never
+  becomes reachable after the power-on (deep standby / dropped Wi-Fi), the
+  switch now **aborts instead of running the 8s stabilise wait + 5× retry
+  loop** (~60s of futile hammering). The request is **not lost**: it is
+  remembered and **re-applied automatically the moment the media_player reports
+  the TV back online** (no reliance on an automation re-firing). The deferred
+  request is dropped if Art Mode is turned off in the meantime, or superseded
+  by a new explicit turn-on. This tames the "art mode went haywire" episodes an
+  automation commanding art-on on an off Salon TV used to trigger.
 
 ### Per-viewer language Lovelace card
 

--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -84,19 +84,30 @@ _GEMINI_URL_TMPL = (
 _CACHE_STORE_VERSION = 1
 _HTTP_TIMEOUT = 45  # seconds per external call
 
-# Keys of the identification dict returned to callers / stored in the cache.
-RESULT_KEYS = (
+# Languages the metadata is produced in, so each viewer can be shown the
+# artwork description in their own UI language (the Lovelace card picks by the
+# browser/user language). Keep 'en' first — it's the universal fallback.
+LANGS = ("en", "fr", "es", "it", "pt-BR")
+
+# Language-independent fields (kept once): identity + confidence.
+TOP_LEVEL_KEYS = (
     "identified",
     "confidence",
     "matched_candidate",
-    "title",
     "artist",
     "date",
-    "visual_description",
-    "artwork_description",
-    "artist_biography",
     "suggested_search_query",
 )
+# Fields produced per language (prose + the possibly-translated title).
+TRANSLATED_FIELDS = (
+    "title",
+    "artwork_description",
+    "artist_biography",
+    "visual_description",
+)
+# Full set stored/returned: the top-level keys plus a 'translations' dict
+# {lang: {translated field: value}}.
+RESULT_KEYS = (*TOP_LEVEL_KEYS, "translations")
 
 
 def derive_key(content_id: str | None, img_bytes: bytes) -> str:
@@ -120,8 +131,11 @@ class ArtIdentifyCache:
     """
 
     def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        # _v2 = multilingual schema; the old single-language cache file is left
+        # untouched but no longer read, so entries re-identify once into all
+        # languages instead of surfacing a partial (English-only) result.
         self._store: Store = Store(
-            hass, _CACHE_STORE_VERSION, f"samsungtv_smart_art_cache_{entry_id}"
+            hass, _CACHE_STORE_VERSION, f"samsungtv_smart_art_cache_v2_{entry_id}"
         )
         self._data: dict[str, dict[str, Any]] = {}
         self._loaded = False
@@ -210,7 +224,13 @@ async def async_vision_web_detection(
 
 
 def _build_llm_prompt(candidates: dict[str, list[str]]) -> str:
-    """Prompt that hands the reverse-search candidates to the LLM for checking."""
+    """Prompt that hands the reverse-search candidates to the LLM for checking.
+
+    Asks for the descriptive fields in every language of ``LANGS`` so each
+    viewer can be shown the metadata in their own UI language from a single
+    call (cheaper and consistent vs one call per language).
+    """
+    langs = ", ".join(LANGS)
     return (
         "This image is the thumbnail of the artwork currently displayed on a "
         "Samsung The Frame TV. A reverse image search returned these CANDIDATES "
@@ -220,14 +240,21 @@ def _build_llm_prompt(candidates: dict[str, list[str]]) -> str:
         f"- Page titles: {' | '.join(candidates.get('pages') or []) or '(none)'}\n\n"
         "Your task: confirm the identification ONLY if a candidate is consistent "
         "with what you actually SEE in the image. If none matches, set "
-        '"identified": false and leave title/artist/date/artist_biography null. '
+        '"identified": false and leave artist/date null and translations {}. '
         "Do NOT invent facts. Separate the visual description from the factual "
         "identification. confidence is a number from 0 to 1.\n"
+        f"Provide title, artwork_description, artist_biography and "
+        f"visual_description in ALL these languages: {langs}. artist, date and "
+        "suggested_search_query stay in one language (English). Translate the "
+        "prose naturally, don't just transliterate.\n"
         "Reply with ONLY valid JSON (no prose, no markdown fences), schema:\n"
         '{"identified": false, "confidence": 0.0, "matched_candidate": null, '
-        '"title": null, "artist": null, "date": null, "visual_description": "", '
-        '"artwork_description": null, "artist_biography": null, '
-        '"suggested_search_query": null}'
+        '"artist": null, "date": null, "suggested_search_query": null, '
+        '"translations": {"en": {"title": null, "artwork_description": null, '
+        '"artist_biography": null, "visual_description": ""}, '
+        '"fr": {"title": null, "artwork_description": null, '
+        '"artist_biography": null, "visual_description": ""}, '
+        '"es": {...}, "it": {...}, "pt-BR": {...}}}'
     )
 
 
@@ -356,8 +383,29 @@ async def async_llm_confirm(
         raw = (data.get("choices") or [{}])[0].get("message", {}).get("content", "")
     _LOGGER.debug("LLM (%s/%s) raw reply: %s", provider, model, raw[:600])
     parsed = _parse_llm_json(raw)
-    # Normalize to the known schema so downstream is predictable.
-    return {k: parsed.get(k) for k in RESULT_KEYS}
+    return _normalize_result(parsed)
+
+
+def _normalize_result(parsed: dict[str, Any]) -> dict[str, Any]:
+    """Coerce an LLM reply to the multilingual schema.
+
+    Guarantees a ``translations`` dict with every ``LANGS`` entry present (each
+    with the ``TRANSLATED_FIELDS`` keys), falling back to English for any
+    language the model omitted so a viewer never gets an empty description.
+    """
+    result = {k: parsed.get(k) for k in TOP_LEVEL_KEYS}
+    raw_tr = parsed.get("translations")
+    if not isinstance(raw_tr, dict):
+        raw_tr = {}
+    en = raw_tr.get("en") if isinstance(raw_tr.get("en"), dict) else {}
+    translations: dict[str, dict[str, Any]] = {}
+    for lang in LANGS:
+        block = raw_tr.get(lang) if isinstance(raw_tr.get(lang), dict) else {}
+        translations[lang] = {
+            field: block.get(field) or en.get(field) for field in TRANSLATED_FIELDS
+        }
+    result["translations"] = translations
+    return result
 
 
 async def async_identify(
@@ -431,7 +479,7 @@ async def async_identify(
         "Artwork %s identified=%s title=%s artist=%s conf=%s in %.1fs (via %s/%s)",
         key,
         result.get("identified"),
-        result.get("title"),
+        (result.get("translations") or {}).get("en", {}).get("title"),
         result.get("artist"),
         result.get("confidence"),
         time.monotonic() - started,

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.4.0b4"
+  "version": "8.4.0b5"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.4.0b3"
+  "version": "8.4.0b4"
 }

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -1705,26 +1705,34 @@ class FrameArtMetadataSensor(SensorEntity):
                 self._schedule_identify(content_id)
             return
         identified = bool(result.get("identified"))
+        translations = result.get("translations") or {}
+        # Convenience copy in the HA instance language (fallback English) so a
+        # plain Markdown card works; full 'translations' is exposed too so a
+        # frontend card can pick the viewer's own browser/user language.
+        lang = (self.hass.config.language or "en").split("-")[0]
+        local = translations.get(lang) or translations.get("en") or {}
         _LOGGER.debug(
-            "Art metadata updated: %s -> identified=%s title=%s source=%s",
+            "Art metadata updated: %s -> identified=%s title=%s source=%s langs=%s",
             content_id,
             identified,
-            result.get("title"),
+            local.get("title"),
             result.get("source"),
+            list(translations),
         )
-        self._attr_native_value = result.get("title") if identified else "Unidentified"
+        self._attr_native_value = local.get("title") if identified else "Unidentified"
         self._attr_extra_state_attributes = {
             "identified": identified,
             "confidence": result.get("confidence"),
             "artist": result.get("artist"),
             "date": result.get("date"),
-            "artist_biography": result.get("artist_biography"),
-            "artwork_description": result.get("artwork_description"),
-            "visual_description": result.get("visual_description"),
+            "artist_biography": local.get("artist_biography"),
+            "artwork_description": local.get("artwork_description"),
+            "visual_description": local.get("visual_description"),
             "matched_candidate": result.get("matched_candidate"),
             "suggested_search_query": result.get("suggested_search_query"),
             "source": result.get("source"),
             "content_id": content_id,
+            "translations": translations,
         }
         self.async_write_ha_state()
 

--- a/custom_components/samsungtv_smart/switch.py
+++ b/custom_components/samsungtv_smart/switch.py
@@ -424,12 +424,24 @@ class FrameArtModeSwitch(SwitchEntity):
                 )
                 return
 
-            # Wait for TV to be ready
+            # Wait for TV to be ready. If it never becomes reachable within the
+            # window, it did not respond to power-on — it is off the network
+            # (deep standby / dropped Wi-Fi), not merely cold-booting. Bail out
+            # instead of "trying anyway": the following 8s stabilise wait plus
+            # the 5x art-mode retry loop would otherwise thrash for ~60s against
+            # a TV that cannot answer (observed after a spurious art-mode-on
+            # command on an off Salon TV — issue #116 follow-up).
             tv_was_off = True
             if not await self._wait_for_tv_ready(max_wait=20):
                 self._log.warning(
-                    "TV may not be fully ready, attempting Art Mode anyway..."
+                    "Art Mode ON aborted for %s: TV did not become reachable "
+                    "after power-on (likely off the network) — not retrying",
+                    self._device_name,
                 )
+                self._set_optimistic(False)
+                self._available = True
+                self.async_write_ha_state()
+                return
 
             # Additional delay for TV Art subsystem to stabilize after boot.
             # supported() returns True quickly (WebSocket reachable) but

--- a/custom_components/samsungtv_smart/switch.py
+++ b/custom_components/samsungtv_smart/switch.py
@@ -220,6 +220,12 @@ class FrameArtModeSwitch(SwitchEntity):
         self._media_player_entity_id: str | None = None
         self._ip_control: SamsungIPControl | None = None
         self._ip_control_token: str | None = None
+        # Set when an Art Mode ON was requested but the TV was off and never
+        # became reachable (off the network). We don't hammer it; instead we
+        # re-apply once the media_player reports the TV back online. Cleared by
+        # a successful turn-on, or by an explicit turn-off (art no longer
+        # wanted).
+        self._pending_art_on = False
 
     def _get_ip_control(self) -> SamsungIPControl | None:
         """Return an IP Control client if paired AND enabled, else None.
@@ -393,6 +399,8 @@ class FrameArtModeSwitch(SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn Art Mode on."""
         self._log.debug("Turning Art Mode ON for %s", self._device_name)
+        # A fresh explicit attempt supersedes any earlier deferred one.
+        self._pending_art_on = False
 
         # Short-circuit: if already in Art Mode, nothing to do.
         # Avoids useless set_artmode(True) calls that the TV may silently
@@ -435,9 +443,13 @@ class FrameArtModeSwitch(SwitchEntity):
             if not await self._wait_for_tv_ready(max_wait=20):
                 self._log.warning(
                     "Art Mode ON aborted for %s: TV did not become reachable "
-                    "after power-on (likely off the network) — not retrying",
+                    "after power-on (likely off the network) — will re-apply "
+                    "when the TV comes back online",
                     self._device_name,
                 )
+                # Defer instead of hammering: re-apply once the media_player
+                # reports the TV reachable again (handled in the state listener).
+                self._pending_art_on = True
                 self._set_optimistic(False)
                 self._available = True
                 self.async_write_ha_state()
@@ -541,6 +553,8 @@ class FrameArtModeSwitch(SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn Art Mode off (switch to normal TV mode)."""
         self._log.debug("Turning Art Mode OFF for %s", self._device_name)
+        # Art no longer wanted — drop any deferred re-apply.
+        self._pending_art_on = False
 
         # Check if TV is on
         tv_is_on = await self._is_tv_on()
@@ -727,6 +741,25 @@ class FrameArtModeSwitch(SwitchEntity):
         if new_state is None:
             return
         art_status = new_state.attributes.get("art_mode_status")
+
+        # Deferred re-apply: a previous Art Mode ON was aborted because the TV
+        # was off the network. Re-apply now that it is reachable again — but
+        # only on a real edge to avoid loops. If art is already on, the request
+        # is already satisfied.
+        if self._pending_art_on:
+            if art_status == "on":
+                self._pending_art_on = False
+            elif new_state.state not in (STATE_OFF, "unavailable", "unknown"):
+                self._pending_art_on = False
+                self._log.info(
+                    "TV %s back online — re-applying deferred Art Mode ON",
+                    self._device_name,
+                )
+                self._hass.async_create_background_task(
+                    self.async_turn_on(),
+                    f"art_mode_deferred_on_{self._entry.entry_id}",
+                )
+                return
         if art_status in ("on", "off"):
             # Mirror the media_player's authoritative art_mode_status directly,
             # including when the TV is ON but no longer in Art Mode (e.g. an app


### PR DESCRIPTION
Follow-up to #147 (merged at `8.4.0b3`). `8.4.0b6`. Base `v8.4-dev`.

## 1. Multilingual metadata (5 languages)
LLM returns title + descriptions in `en/fr/es/it/pt-BR` in one call. Language-independent fields top-level; per-language prose in a `translations` dict with English fallback. `sensor.<tv>_art_metadata` exposes the instance-language copy + the full `translations` attribute → a frontend card renders each viewer's own browser/UI language (FR & EN users on one dashboard). Cache renamed `_v2`. Per-viewer `custom:button-card` in the release notes.

## 2. Art-mode off-network bail-fast + deferred re-apply
Aborts the 8s wait + 5× retry loop when powering on an off/unreachable TV (~60s of hammering — the "vrille"). The abort is **not definitive**: the request is remembered and **re-applied automatically when the media_player reports the TV back online** (real state edge only; cleared by turn-off or a new explicit turn-on; cold-boot preserved).

## 3. Token-budget fix (b6)
The 5-language JSON overran the old 700-token reply budget → truncated output → `Expecting ',' delimiter` JSONDecodeError (reported in testing). Output cap raised to **`_LLM_MAX_TOKENS = 3000`** across all three providers so the full multilingual reply fits.

## Testing
- `flake8` / `isort` / `black` clean; offline unit checks for the multilingual normalization pass.
- Live testing surfaced (and this PR fixes) the truncation; re-test with b6 expected to parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2