### PR TITLE
Art identification: raise LLM token budget for the multilingual reply (v8.4)

### DIFF
--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -83,6 +83,11 @@ _GEMINI_URL_TMPL = (
 
 _CACHE_STORE_VERSION = 1
 _HTTP_TIMEOUT = 45  # seconds per external call
+# Output token budget for the confirmation reply. Must fit the whole JSON —
+# title + three prose fields in every LANGS language — or the reply is
+# truncated and fails to parse. 700 was fine single-language; 5 languages need
+# far more headroom.
+_LLM_MAX_TOKENS = 3000
 
 # Languages the metadata is produced in, so each viewer can be shown the
 # artwork description in their own UI language (the Lovelace card picks by the
@@ -289,7 +294,7 @@ async def async_llm_confirm(
         }
         body = {
             "model": model,
-            "max_tokens": 700,
+            "max_tokens": _LLM_MAX_TOKENS,
             "messages": [
                 {
                     "role": "user",
@@ -320,7 +325,7 @@ async def async_llm_confirm(
         # already constrain the answer, so determinism isn't needed here.
         body = {
             "model": model,
-            "max_completion_tokens": 700,
+            "max_completion_tokens": _LLM_MAX_TOKENS,
             "response_format": {"type": "json_object"},
             "messages": [
                 {
@@ -354,7 +359,7 @@ async def async_llm_confirm(
             ],
             "generationConfig": {
                 "temperature": 0.1,
-                "maxOutputTokens": 700,
+                "maxOutputTokens": _LLM_MAX_TOKENS,
                 "response_mime_type": "application/json",
             },
         }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -24,5 +24,5 @@
     "aiofiles>=0.8.0",
     "casttube>=0.2.1"
   ],
-  "version": "8.4.0b5"
+  "version": "8.4.0b6"
 }


### PR DESCRIPTION
Fix on top of the merged multilingual metadata (#148, `v8.4-dev` at `8.4.0b5`). `8.4.0b6`.

## Bug
The 5-language JSON (title + 3 prose fields × `en/fr/es/it/pt-BR`) overran the old **700-token** reply budget, so the LLM output was truncated mid-object → `Expecting ',' delimiter` `JSONDecodeError`. Non-fatal (caught, not cached, retried) but identification kept failing — reported on personal photos (`IMG-*`) after enabling the feature.

## Fix
Output cap raised to **`_LLM_MAX_TOKENS = 3000`** and applied across all three providers (`max_tokens` / `max_completion_tokens` / `maxOutputTokens`) so the full multilingual reply fits with headroom.

## Testing
- `flake8` / `isort` / `black` clean; parses.
- Re-test with b6: the 5-language JSON should parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_