### PR TITLE
Art WS circuit breaker: force reconnect after consecutive request timeouts (#153)

### DIFF
--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -28,8 +28,8 @@ import time
 from typing import Any
 import uuid
 
-import aiohttp
 from PIL import Image
+import aiohttp
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,6 +87,12 @@ ART_WS_HEARTBEAT = 20
 # unreachable TV never turns into a hot reconnect loop.
 _KEEPALIVE_INTERVAL = 60.0  # idle ping cadence: keep a quiet-but-live WS open
 _MAX_BACKOFF = 60.0  # hard cap on the per-attempt reconnect delay (seconds)
+
+# Circuit breaker: consecutive request timeouts on a live socket before the
+# channel is declared wedged (TV art APP dead while its network stack keeps
+# the WS open and answering PINGs — heartbeat can't catch that) and the socket
+# is force-closed to hand recovery to the auto-reconnect path (issue #153).
+ART_WS_TIMEOUT_TRIP = 3
 
 # Art-app error codes returned in {"event": "error", "error_code": N} replies,
 # per the decompiled firmware (notes/QN55LS03FAFXZA/ART_MODE_DECOMPILED.md).
@@ -187,6 +193,9 @@ class SamsungTVAsyncArt:
         self._max_connection_failures = 3  # Start backoff after 3 failures
         self._backoff_until: float | None = None
         self._last_connection_attempt: float = 0
+        # Circuit breaker: consecutive request timeouts on a live socket
+        # (zombie art app detection — see _note_request_timeout).
+        self._timeout_streak = 0
 
         # Connection lock to prevent concurrent connection attempts (v6.3.5)
         self._connection_lock = asyncio.Lock()
@@ -609,13 +618,9 @@ class SamsungTVAsyncArt:
         for attempt in range(max_attempts):
             await asyncio.sleep(self._backoff_delay(attempt))
             if await self.open():
-                self._log.debug(
-                    "Art API: reconnected after %d attempt(s)", attempt + 1
-                )
+                self._log.debug("Art API: reconnected after %d attempt(s)", attempt + 1)
                 return True
-        self._log.warning(
-            "Art API: reconnect gave up after %d attempts", max_attempts
-        )
+        self._log.warning("Art API: reconnect gave up after %d attempts", max_attempts)
         return False
 
     async def _keepalive(self) -> None:
@@ -824,14 +829,63 @@ class SamsungTVAsyncArt:
                 self._pending_requests[request_key],
                 timeout=timeout,
             )
+            # A real answer proves the art app is alive — reset the breaker.
+            self._timeout_streak = 0
             return result
         except asyncio.TimeoutError:
             self._log.debug("Art API: Timeout waiting for '%s'", request_key)
+            self._note_request_timeout()
             return None
         except asyncio.CancelledError:
+            # Channel teardown cancelled the future — the receive loop is
+            # already handling recovery; not a zombie-app signal.
             return None
         finally:
             self._pending_requests.pop(request_key, None)
+
+    def _note_request_timeout(self) -> None:
+        """Circuit breaker for a zombie art channel (app dead, socket alive).
+
+        The TV's art APP can crash while its network stack keeps the WebSocket
+        open and answering PINGs: the aiohttp heartbeat sees a healthy socket,
+        the receive loop never exits, and every request just times out forever
+        — the integration stays wedged until a reload (issue #153). Detect it
+        by counting CONSECUTIVE request timeouts (any real answer resets the
+        count); at the threshold, force-close the socket so the receive loop
+        exits through its normal unintentional-drop path, which cleans up and
+        starts the bounded-backoff auto-reconnect.
+
+        Occasional single timeouts (e.g. the capability probes on TVs that
+        don't implement a request) don't trip it: interleaved successful
+        requests keep resetting the streak.
+        """
+        self._timeout_streak += 1
+        if self._timeout_streak < ART_WS_TIMEOUT_TRIP:
+            return
+        if not self._connected or not self._ws or self._ws.closed:
+            # Already disconnected — lazy open()/auto-reconnect owns recovery.
+            self._timeout_streak = 0
+            return
+        self._log.warning(
+            "Art API: %d consecutive request timeouts on a live socket — "
+            "art channel looks wedged, forcing reconnect",
+            self._timeout_streak,
+        )
+        self._timeout_streak = 0
+        # Close from a task: _ws.close() makes the receive loop's `async for`
+        # terminate (CLOSED), and its cleanup/auto-reconnect machinery takes
+        # over — one recovery path for every kind of dead channel.
+        asyncio.create_task(self._force_close_ws())
+
+    async def _force_close_ws(self) -> None:
+        """Close the current WS to trigger the receive-loop recovery path."""
+        ws = self._ws
+        if ws is None or ws.closed:
+            return
+        try:
+            await ws.close()
+        except Exception as ex:  # noqa: BLE001 - best effort; loop will notice
+            self._log.debug("Art API: force-close failed: %s", ex)
 
     async def _send_art_request(
         self,

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -25,5 +25,5 @@
     "casttube>=0.2.1",
     "Pillow>=10.0.0"
   ],
-  "version": "8.3.4b1"
+  "version": "8.3.4b2"
 }

--- a/tests/api/test_art_circuit_breaker.py
+++ b/tests/api/test_art_circuit_breaker.py
@@ -1,0 +1,81 @@
+"""Circuit breaker: consecutive request timeouts must force a reconnect.
+
+Covers the zombie-channel case from issue #153: the TV's art APP dies while
+its network stack keeps the WebSocket open and answering PINGs, so the
+heartbeat never fires, the receive loop never exits, and every request just
+times out until the integration is reloaded.
+"""
+import asyncio
+
+
+class _FakeWS:
+    """Minimal live-looking WebSocket that records close() calls."""
+
+    def __init__(self):
+        self.closed = False
+        self.close_calls = 0
+
+    async def close(self):
+        self.closed = True
+        self.close_calls += 1
+
+
+async def _timeout_once(art_client):
+    """Run one request that times out immediately (nobody resolves the future)."""
+    await art_client._wait_for_response("k", timeout=0)
+
+
+async def test_breaker_trips_after_consecutive_timeouts(art_client):
+    import art
+
+    ws = _FakeWS()
+    art_client._ws = ws
+    art_client._connected = True
+
+    for _ in range(art.ART_WS_TIMEOUT_TRIP):
+        await _timeout_once(art_client)
+    # The force-close runs in a task — let it execute.
+    await asyncio.sleep(0)
+
+    assert ws.close_calls == 1
+    assert art_client._timeout_streak == 0  # reset after tripping
+
+
+async def test_success_resets_streak(art_client):
+    import art
+
+    ws = _FakeWS()
+    art_client._ws = ws
+    art_client._connected = True
+
+    # Two timeouts (one below the trip threshold)...
+    for _ in range(art.ART_WS_TIMEOUT_TRIP - 1):
+        await _timeout_once(art_client)
+    assert art_client._timeout_streak == art.ART_WS_TIMEOUT_TRIP - 1
+
+    # ...then a real answer arrives: the streak must reset.
+    fut = asyncio.get_event_loop().create_future()
+    art_client._pending_requests["ok"] = fut
+    fut.set_result({"event": "ok"})
+    assert await art_client._wait_for_response("ok", timeout=1) == {"event": "ok"}
+    assert art_client._timeout_streak == 0
+
+    # A later single timeout starts again from 1 — no trip, no close.
+    await _timeout_once(art_client)
+    await asyncio.sleep(0)
+    assert ws.close_calls == 0
+
+
+async def test_no_trip_when_already_disconnected(art_client):
+    import art
+
+    art_client._ws = None
+    art_client._connected = False
+
+    for _ in range(art.ART_WS_TIMEOUT_TRIP + 1):
+        await _timeout_once(art_client)
+    await asyncio.sleep(0)
+
+    # Nothing to close, no crash; the streak reset at the threshold (the
+    # timeout right after it legitimately starts a fresh count at 1).
+    assert art_client._timeout_streak < art.ART_WS_TIMEOUT_TRIP


### PR DESCRIPTION
Closes the residual gap behind #153, on top of the merged #152 auto-reconnect. `8.3.4b2`, base `master`.

## The gap
#152 recovers every case where the receive loop **exits** (socket drop, missed heartbeat PONG). But the TV's art **APP can crash while its network stack keeps the WebSocket open and answering PINGs**: heartbeat sees a healthy socket, the receive loop never exits, and every request just times out forever — exactly @PrestonMcAfee's "wedged until reload" state (art toggle ignored, gallery selections dead, `motion_timer`/`brightness_sensor` selects blocking >10 s, `current_content_id` gone → `None.jpg` camera 404s).

## The fix
`_wait_for_response` counts **consecutive** timeouts:
- any real answer resets the streak → single timeouts from capability probes (e.g. `get_brightness` on TVs that don't implement it) can never trip it;
- at **3** consecutive timeouts on a live socket, log a WARNING and **force-close the WS** — the receive loop's `async for` terminates and its existing unintentional-drop cleanup + bounded-backoff auto-reconnect (#152) take over. One recovery path for every kind of dead channel, no new state machine;
- when already disconnected, the lazy `open()` / reconnect task owns recovery and the breaker just resets.

## Testing
- `tests/api/test_art_circuit_breaker.py` (same harness as #150/#152): trip after 3 consecutive timeouts → exactly one `close()`; success resets the streak (no premature trip); disconnected → no-op.
- Logic also validated standalone (3/3 scenarios).
- `flake8` / `isort` / `black` clean.

With this + #152, the full recovery story for #153 is: socket dies → heartbeat detects → auto-reconnect; app dies (socket alive) → circuit breaker force-closes → same auto-reconnect. No more manual reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_