### PR TITLE
Make the PIL import lazy in api/art.py (fixes integration dying without Pillow)

### DIFF
--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -28,7 +28,6 @@ import time
 from typing import Any
 import uuid
 
-from PIL import Image
 import aiohttp
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,8 +46,17 @@ def _map_format_to_wire(pil_format: str | None) -> str | None:
 
 
 def _detect_wire_type(data: bytes, hint: str | None = None) -> str:
-    """Detect the real image format from bytes; fall back to the caller hint."""
+    """Detect the real image format from bytes; fall back to the caller hint.
+
+    Pillow is imported lazily here (not at module scope) so a missing or
+    broken Pillow only degrades this best-effort upload-type detection — it
+    must never break importing this module, which would take the whole
+    integration (media_player, remote, buttons, ...) down with it. Every other
+    PIL use in this repo is lazy for the same reason.
+    """
     try:
+        from PIL import Image  # noqa: PLC0415 - lazy: keep PIL out of import path
+
         with Image.open(io.BytesIO(data)) as img:
             wire = _map_format_to_wire(img.format)
             if wire:

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -25,5 +25,5 @@
     "casttube>=0.2.1",
     "Pillow>=10.0.0"
   ],
-  "version": "8.3.4b2"
+  "version": "8.3.4b3"
 }


### PR DESCRIPTION
Fixes the regression @PrestonMcAfee hit jumping 8.3.3 → 8.4.0b8 ("most or all of the regular buttons — home, source, netflix — killed", rolled back to restore basic functionality). `8.3.4b3`, base `master`.

## Root cause
PR #150 added `from PIL import Image` **at module scope** in `api/art.py`. `__init__.py` imports that module, so a missing/broken Pillow raises `ImportError` during setup and takes the **whole integration** down — media_player, remote and the KEY/app buttons all disappear. The manifest declares `Pillow>=10.0.0`, but that doesn't cover installs where the wheel isn't available yet, an offline/arch case, or where platform setup runs before the requirement resolves. Every other PIL use in this repo (`http_thumbnail.py`, `sensor.py`) is deliberately lazy for exactly this reason — #150 broke that convention.

## Fix
Move the import into `_detect_wire_type()` (lazy, `from PIL import Image` inside the `try`). A missing Pillow now only degrades best-effort upload-type detection (falls back to the caller hint) instead of breaking module import. Pillow stays in the manifest so detection works wherever it's present.

## Testing
- `flake8` clean; module parses.
- `_detect_wire_type` behaviour unchanged when Pillow is present; returns the hint-based type when it's absent.

Recommend a fresh `8.3.4b3` pre-release so Preston can retry without the rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_