### PR TITLE
Release 8.4.0: release notes + README + version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode su
   - [Frame Art Services](#frame-art-services)
 - [Frame Art Mode](#frame-art-mode)
   - [Thumbnail Downloads](#thumbnail-downloads)
+  - [Artwork Identification](#artwork-identification)
 - [Automations & Tips](#automations--tips)
 - [Troubleshooting](#troubleshooting)
   - [Integration not appearing in Add Integration](#integration-not-appearing-in-add-integration)
@@ -47,6 +48,8 @@ This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode su
 - SmartThings integration for enhanced status polling (channel info, picture mode, sound mode…)
 - **Three SmartThings authentication methods**: OAuth2, Personal Access Token, or existing ST integration
 - **Samsung Frame TV Art Mode** — full artwork management via a dedicated async API
+- **Self-healing Art WebSocket** — auto-reconnect + a zombie-channel circuit breaker fix the long-standing "Art Mode turns off randomly, needs a reload" problem
+- **Artwork identification (opt-in)** — reverse image search (Google Vision) confirmed by an LLM (Claude / OpenAI / Gemini) shows the title, artist, date and bio of the art on your Frame, in 5 languages
 - New dedicated entities: Art Mode switch and Frame Art sensor
 - **Picture mode control** — `select` entity with dual-strategy (SmartThings API + WS fallback for HDMI inputs)
 - **Improved source detection** — REST fallback for Frame 2024 TVs where `supportedInputSources` returns empty; supports custom source names
@@ -62,7 +65,8 @@ This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode su
 ## Requirements
 
 - Home Assistant **≥ 2025.6.0**
-- Python packages (installed automatically): `websocket-client`, `wakeonlan`, `aiofiles`, `casttube`, `pysmartthings>=6.0`
+- Python packages (installed automatically): `websocket-client`, `wakeonlan`, `aiofiles`, `casttube`, `Pillow`, `pysmartthings>=6.0`
+- For Artwork Identification (optional): a Google Cloud Vision API key and an LLM API key (Anthropic, OpenAI or Gemini)
 - A Samsung Smart TV running **Tizen OS** (2016+), reachable on the local network
 - For SmartThings features: a Samsung account and a SmartThings-registered TV
 
@@ -392,6 +396,8 @@ These services require a Samsung **Frame TV** with Art Mode. They are called on 
 | `samsungtv_smart.art_get_current` | Get info about the currently displayed artwork |
 | `samsungtv_smart.art_select_image` | Display a specific artwork by content ID |
 | `samsungtv_smart.art_upload` | Upload a local image to the TV |
+| `samsungtv_smart.art_upload_batch` | Upload every image in a folder — idempotent re-runs (skips unchanged files) + throttle for large batches + optional perceptual duplicate check |
+| `samsungtv_smart.art_identify` | Identify the current artwork (reverse image search + LLM) and return its metadata. Requires the Art Identification option to be configured |
 | `samsungtv_smart.art_delete` | Delete a user-uploaded artwork (MY-* IDs only) |
 | `samsungtv_smart.art_get_thumbnail` | Download a single artwork thumbnail |
 | `samsungtv_smart.art_get_thumbnails_batch` | Batch-download thumbnails for multiple artworks |
@@ -440,6 +446,19 @@ data:
   category_id: MY-C0002
   favorites_only: false
   force_download: false
+```
+
+**Batch upload a folder (idempotent):**
+
+```yaml
+action: samsungtv_smart.art_upload_batch
+target:
+  entity_id: media_player.samsung_frame
+data:
+  folder: /config/www/frame_upload
+  # skip_unchanged: true   # (default) re-running uploads only new/changed files
+  # throttle: 2.0          # (default) seconds between uploads
+  # dedup: true            # also skip photos already on the TV (needs thumbnails downloaded)
 ```
 
 **Configure slideshow:**
@@ -522,6 +541,33 @@ override.
 fails (a transient TV/WebSocket hiccup), the integration reuses a previously
 downloaded copy of that artwork as `current.jpg` instead of showing an error
 placeholder. (Contributed by @prestonmcafee.)
+
+### Artwork Identification
+
+*Opt-in.* Identify the artwork currently on the Frame and show its **title,
+artist, date and a short bio** — in the viewer's language — via a two-stage,
+cache-first pipeline: a **reverse image search** (Google Cloud Vision) proposes
+candidates from the real web, then an **LLM** (Anthropic / OpenAI / Gemini)
+confirms only a genuine match against the image (so it doesn't hallucinate on
+obscure works, and identifies photographs too).
+
+**Enable it** under **Settings → Devices & Services → your TV → Configure →
+Art Identification**: turn it on, paste a Google Vision API key, pick the LLM
+provider and paste its key (an optional model field defaults sensibly). Keys are
+stored in the config entry, never in YAML.
+
+Once enabled, **`sensor.<tv>_art_metadata`** identifies each artwork
+automatically as it changes (debounced) and exposes the metadata as attributes,
+including a `translations` map with **5 languages** (`en`, `fr`, `es`, `it`,
+`pt-BR`) so each viewer can read it in their own UI language. A ready-to-use
+Lovelace card (plain and per-viewer-language variants) is in
+`RELEASE_NOTES_8.4.0.md`. There is also a manual `samsungtv_smart.art_identify`
+service (returns the metadata; `force: true` bypasses the cache).
+
+Results are cached per artwork (by the stable `SAM-*` Art-Store id, or by image
+content for personal uploads), so identification runs once and is then instant
+and free. Google Vision is free under ~1000 requests/month; the LLM is rarely
+called thanks to the cache. Personal-photo identification is off by default.
 
 ## See Also
 

--- a/RELEASE_NOTES_8.4.0.md
+++ b/RELEASE_NOTES_8.4.0.md
@@ -4,18 +4,42 @@ If this project is useful to you, you can support its development:
 
 # <a href="https://buymeacoffee.com/thefab21" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-black.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
-## Artwork identification (opt-in) — engine + manual service (8.4.0b1)
+> **Status: stable release.** 8.4.0 also folds in the entire **8.3.4** line
+> (Art Mode reliability + 2024/2025 firmware-compat), which was only ever
+> published as betas — see *"Also included: the 8.3.4 Art Mode reliability
+> line"* at the bottom, and `RELEASE_NOTES_8.3.4.md` for the detail.
 
-New optional feature: identify the artwork currently shown on a Frame TV, so
-Home Assistant can display its title, artist, date and a short artist bio.
+## Highlights
 
-**How it works** — two stages, cache-first:
+- **Artwork identification (opt-in, new)** — show the title, artist, date and a
+  short bio of the art on your Frame, in your language.
+- **Art Mode stops turning off "randomly"** — the art WebSocket now heals
+  itself (auto-reconnect + zombie-channel circuit breaker), no more reload.
+- **2024/2025 Frame firmware compatibility** (art-mode detection, matte list,
+  upload type).
+- **Batch folder upload** with idempotent re-runs and optional duplicate
+  detection.
+- **Ambient light sensor stays live while the TV is off.**
+- **Art Mode switch no longer thrashes an off-network TV**, and re-applies once
+  it's back.
+
+---
+
+## Artwork identification (opt-in, new)
+
+Identify the artwork currently shown on a Frame TV so Home Assistant can
+display its **title, artist, date and a short artist bio** — and even a couple
+of description paragraphs — with each viewer reading it in their own language.
+
+### How it works — two stages, cache-first
+
 1. **Reverse image search** (Google Cloud Vision *Web Detection*) turns the
-   thumbnail into concrete candidate titles/artists from the real web.
-2. **LLM confirmation** (Anthropic, OpenAI *or* Gemini) is handed those candidates and
-   the image, and confirms only if one genuinely matches what it sees —
-   otherwise it returns "not identified". Reverse-search-first is what stops
-   the hallucinations a bare vision model produces on obscure works.
+   thumbnail into concrete candidate titles/artists pulled from the real web.
+2. **LLM confirmation** (Anthropic, OpenAI *or* Gemini) is handed those
+   candidates and the image, and confirms only if one genuinely matches what it
+   sees — otherwise it returns "not identified". Reverse-search-first is what
+   stops the hallucinations a bare vision model produces on obscure works — it
+   even identifies photographs, not just famous paintings.
 
 Results are **cached** so each artwork is identified only once — keyed by the
 Samsung Art-Store id (`SAM-*`, stable across TV resets) or, for personal
@@ -23,51 +47,47 @@ uploads, by the image content itself (so a recycled local id can never surface
 another image's metadata). Successful identifications are kept indefinitely;
 "not identified" is retried after two weeks; transport errors are never cached.
 
-**This build (b1) ships the engine + configuration + a manual service** so it
-can be tested end-to-end before the automatic per-artwork trigger and the
-metadata sensor land:
-
-- Configure under **Settings → Devices → the TV → Configure → Art
-  Identification**: enable the feature, paste your Google Vision API key, pick
-  the LLM provider (Anthropic/OpenAI/Gemini), paste its key, optionally set a
-  model (blank = `claude-haiku-4-5` / `gpt-4o` / `gemini-2.5-flash`), and
-  choose whether to also identify
-  personal photos (off by default — they're rarely in the art index). Keys are
-  stored in the config entry (never in your YAML/Git).
-- Call **`samsungtv_smart.art_identify`** on the TV entity (a `Response
-  variable` returns the metadata; `force: true` bypasses the cache).
-
-Costs are tiny: Google Vision is free under ~1000 requests/month, and — since
+**Cost is tiny**: Google Vision is free under ~1000 requests/month, and — since
 the same few dozen artworks rotate — the cache serves almost everything after a
 short warm-up, so the LLM is rarely called.
 
-## Multilingual metadata + off-network art-mode guard (8.4.0b4)
+### Setup
 
-- **The metadata is now produced in 5 languages** (`en`, `fr`, `es`, `it`,
-  `pt-BR`) in a single LLM call. The `sensor.<tv>_art_metadata` exposes the
-  descriptive fields (`title`, `artwork_description`, `artist_biography`,
-  `visual_description`) in the Home Assistant instance language for a plain
-  card, **plus a full `translations` attribute** `{lang: {…}}` so a frontend
-  card can show each viewer the description **in their own browser/UI
-  language** — a FR user and an EN user looking at the same dashboard each read
-  it in their language. `artist`/`date`/`confidence` stay language-independent.
-  (The cache is rebuilt once — old English-only entries re-identify into all
-  languages.)
-- **Art-mode switch: stop thrashing an off-network TV, re-apply when it's
-  back.** When `switch.…_art_mode` is turned on while the TV is off and it never
-  becomes reachable after the power-on (deep standby / dropped Wi-Fi), the
-  switch now **aborts instead of running the 8s stabilise wait + 5× retry
-  loop** (~60s of futile hammering). The request is **not lost**: it is
-  remembered and **re-applied automatically the moment the media_player reports
-  the TV back online** (no reliance on an automation re-firing). The deferred
-  request is dropped if Art Mode is turned off in the meantime, or superseded
-  by a new explicit turn-on. This tames the "art mode went haywire" episodes an
-  automation commanding art-on on an off Salon TV used to trigger.
+Under **Settings → Devices & Services → the TV → Configure → Art
+Identification**: enable the feature, paste your Google Vision API key, pick the
+LLM provider (Anthropic/OpenAI/Gemini), paste its key, optionally set a model
+(blank = `claude-haiku-4-5` / `gpt-4o` / `gemini-2.5-flash`), and choose whether
+to also identify personal photos (off by default — they're rarely in the art
+index). Keys are stored in the config entry (never in your YAML/Git).
 
-### Per-viewer language Lovelace card
+### The metadata sensor (automatic)
 
-`custom:button-card` reads the viewer's language from `hass` and picks the
-matching translation (replace `samsung_hacs`):
+When enabled, a **`sensor.<tv>_art_metadata`** is created. It watches the
+artwork on screen and, on every change (debounced ~8 s so a fast slideshow
+doesn't fire per frame), runs the pipeline automatically and publishes:
+
+- **state** = the artwork title (in the HA instance language), or `Unidentified`;
+- **attributes** = `artist`, `date`, `confidence`, `artist_biography`,
+  `artwork_description`, `visual_description`, `matched_candidate`,
+  `suggested_search_query`, `source` (`cache`/`fresh`), `content_id`, and a full
+  **`translations`** map (see below).
+
+Enabling/disabling the feature adds/removes this sensor (a reload); editing an
+API key does not reload. There is also a manual **`samsungtv_smart.art_identify`**
+service (returns the metadata via a response variable; `force: true` bypasses
+the cache) for testing or on-demand use.
+
+### Multilingual (5 languages)
+
+Metadata is produced in **`en`, `fr`, `es`, `it`, `pt-BR`** in a single LLM
+call. The sensor exposes the descriptive fields in the HA instance language for
+a plain card, **plus a full `translations` attribute** `{lang: {…}}` so a
+frontend card can show each viewer the description **in their own browser/UI
+language** — a FR user and an EN user on the same dashboard each read it in
+their language. `artist` / `date` / `confidence` stay language-independent.
+
+**Per-viewer language card** (`custom:button-card` reads the viewer's language;
+replace `samsung_hacs`):
 
 ```yaml
 type: custom:button-card
@@ -89,26 +109,7 @@ styles:
   name: [{ white-space: pre-line }, { font-size: 13px }]
 ```
 
-## Automatic identification + metadata sensor (8.4.0b2)
-
-When the feature is enabled, a new **`sensor.<tv>_art_metadata`** is created. It
-watches the artwork on screen and, on every change (debounced ~8 s so a fast
-slideshow doesn't fire per frame), runs the pipeline automatically and
-publishes:
-
-- **state** = the artwork title (or `Unidentified`);
-- **attributes** = `artist`, `date`, `artist_biography`, `artwork_description`,
-  `visual_description`, `confidence`, `matched_candidate`,
-  `suggested_search_query`, `source` (`cache`/`fresh`), `content_id`.
-
-The sensor and the manual `art_identify` service share one cache, so a title
-seen once is instant (and free) forever after. Enabling/disabling the feature
-adds/removes this sensor (a reload); editing an API key does not reload.
-
-### Ready-made Lovelace card
-
-A Markdown card that shows the current artwork thumbnail with its title, artist
-and bio underneath (replace `samsung_hacs` with your entity):
+**Simple card** (instance language, plain Markdown, no custom card needed):
 
 ```yaml
 type: markdown
@@ -130,13 +131,11 @@ content: >
   {% endif %}
 ```
 
-A richer `custom:button-card` / picture-glance version can be built if wanted.
+### Troubleshooting
 
-### Troubleshooting (8.4.0b3)
-
-Debug logging now traces the whole pipeline — the gating decision, the
-thumbnail read, the **Vision candidates**, the **raw LLM reply**, cache
-hit/miss, timing, and each sensor trigger. Enable it with:
+Debug logging traces the whole pipeline — the gating decision, the thumbnail
+read, the **Vision candidates**, the **raw LLM reply**, cache hit/miss, timing,
+and each sensor trigger:
 
 ```yaml
 logger:
@@ -147,3 +146,42 @@ logger:
 
 Typical lines: `Vision candidates best_guess=[…]`, `LLM (anthropic/…) raw
 reply: {…}`, `identified=True title=… in 6.3s`, `cache HIT (…)`.
+
+## Ambient light sensor stays live while the TV is off
+
+The Frame's ambient light sensor runs independently of TV power (it drives the
+panel's art auto-dimming and is useful for room-light automations), and
+SmartThings keeps publishing it in standby. The `Light Level` / brightness
+sensors now keep updating at a slow keepalive cadence while the TV is off,
+instead of freezing at their last value.
+
+## Art Mode switch — no thrashing on an off-network TV
+
+When the Art Mode switch is turned on while the TV is off and it never becomes
+reachable after the power-on (deep standby / dropped Wi-Fi), the switch now
+**aborts instead of the 8 s stabilise wait + 5× retry loop** (~60 s of futile
+hammering). The request is **not lost**: it is remembered and **re-applied
+automatically the moment the media_player reports the TV back online** — no
+reliance on an automation re-firing. The deferred request is dropped if Art
+Mode is turned off in the meantime, or superseded by a new explicit turn-on.
+
+---
+
+## Also included: the 8.3.4 Art Mode reliability line
+
+8.4.0 carries everything from the 8.3.4 betas (full detail in
+`RELEASE_NOTES_8.3.4.md`):
+
+- **Art WebSocket self-healing** — auto-reconnect with bounded backoff, plus a
+  zombie-channel circuit breaker (force-reconnect after consecutive request
+  timeouts on a live socket). Together they close the long-standing "why did Art
+  Mode turn off randomly?" bug that previously needed an integration reload.
+- **2024/2025 Frame firmware-compat** — art-mode status field (`status`/`value`),
+  matte list field (`matte_list`/`matte_type_list`), WS-over-REST art-mode
+  detection, and real image-format upload-type detection.
+- **`art_upload_batch` service** — upload a whole folder, idempotently (a
+  per-folder sidecar skips unchanged files so re-runs upload 0 duplicates) and
+  throttled (large batches complete instead of failing partway), with an opt-in
+  perceptual duplicate check against the art already on the TV.
+- **Robustness** — a missing/broken Pillow no longer takes the whole
+  integration down (lazy import).

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -25,5 +25,5 @@
     "casttube>=0.2.1",
     "Pillow>=10.0.0"
   ],
-  "version": "8.4.0b11"
+  "version": "8.4.0"
 }


### PR DESCRIPTION
Docs + version bump to prepare the **8.4.0** stable release. Base `v8.4-dev`.

## Release notes
`RELEASE_NOTES_8.4.0.md` rewritten as a stable release (was per-beta):
- **Highlights** summary.
- Full **Artwork Identification** section — how it works, setup, the metadata sensor, multilingual + ready-made cards, cost, troubleshooting.
- **Ambient light sensor live while the TV is off** + **art-mode off-network guard / deferred re-apply**.
- **"Also included: the 8.3.4 Art Mode reliability line"** — auto-reconnect, zombie-channel circuit breaker, 2024/2025 firmware-compat, `art_upload_batch`, lazy-PIL (8.3.4 was only ever betas, so 8.4.0 folds it in).

## README
- **Features**: self-healing Art WebSocket + Artwork Identification.
- **Requirements**: Pillow + optional Vision/LLM keys.
- **Frame Art Services**: `art_upload_batch` and `art_identify` rows + a batch-upload example.
- New **Artwork Identification** section + Table-of-Contents entry.

## Version
`manifest.json → 8.4.0`.

After merging, promote `v8.4-dev → master` and publish the `8.4.0` release (body from `RELEASE_NOTES_8.4.0.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_