### PR TITLE
One-click Frame artwork upload card + HTTP endpoint (8.5.0b1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode su
 - Channel and app list management
 - Logo fetching for apps and sources
 - `folder-gallery-card` Lovelace card bundled — no manual installation required
+- `samsung-art-upload-card` Lovelace card bundled — pick an image on any device (phone, laptop) and push it straight to the Frame in one tap
 
 ---
 
@@ -331,6 +332,17 @@ Each configured TV creates the following entities:
 | `select.<tv_name>_picture_mode` | Select | Change picture mode (Standard, Movie, etc.) |
 
 > **Note:** The `folder-gallery-card` Lovelace card is bundled with this integration and registered automatically. No manual installation or resource configuration required.
+
+> **One-click Frame upload:** The `samsung-art-upload-card` Lovelace card is also bundled and auto-registered. Add it to any dashboard to pick an image on your phone or laptop and push it straight to The Frame — no pre-placed file, no folder sensor, no coding:
+>
+> ```yaml
+> type: custom:samsung-art-upload-card
+> entity: media_player.samsung_frame   # optional; a picker is shown if omitted
+> matte: shadowbox_polar               # optional default matte
+> title: Upload to The Frame           # optional
+> ```
+>
+> The card POSTs the selected image to the integration's authenticated endpoint (`/api/samsungtv_smart/art_upload`), which reuses the `art_upload` service to display and refresh it on the TV.
 
 ### Media Player Attributes
 

--- a/RELEASE_NOTES_8.5.0.md
+++ b/RELEASE_NOTES_8.5.0.md
@@ -1,0 +1,93 @@
+# Release notes — 8.5.0
+
+If this project is useful to you, you can support its development:
+
+# <a href="https://buymeacoffee.com/thefab21" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-black.png" alt="Buy Me A Coffee" height="41" width="174"></a>
+
+> **Status: stable release.** Builds on 8.4.0 — no breaking changes. The only
+> new moving part is an optional bundled Lovelace card; everything else is
+> unchanged.
+
+## Highlights
+
+- **One-click artwork upload — no coding, from any device.** A new bundled
+  Lovelace card lets you pick an image on your phone or laptop and push it
+  straight to The Frame in a single tap. No pre-placed file, no folder sensor,
+  no service call to hand-write.
+- **iPhone HEIC photos just work.** Uploads are transcoded to JPEG
+  server-side, so the HEIC files iPhones produce (often disguised behind a
+  `.jpeg` name) are accepted instead of being silently rejected by the TV.
+
+---
+
+## One-click artwork upload (new)
+
+Until now, getting a *new* picture onto The Frame with this integration took a
+bit of setup — dropping a file where Home Assistant could see it, then calling
+the `art_upload` service. The SmartThings app is easier for that, but it only
+works when you're in front of the TV.
+
+**8.5.0 adds a proper GUI for it.** The integration now bundles a Lovelace card,
+`samsung-art-upload-card`, that is registered automatically — nothing to install
+or configure as a resource. Add it to any dashboard:
+
+```yaml
+type: custom:samsung-art-upload-card
+# entity: media_player.the_frame   # optional — a picker appears if omitted and you have several Frames
+# matte: shadowbox_polar           # optional default matte
+# title: Upload to The Frame       # optional
+```
+
+Then, from your phone or laptop, pick an image and tap **Upload to Frame**.
+That's it — the picture is pushed to the TV and displayed.
+
+### How it works
+
+The card POSTs the selected file to a small **authenticated** endpoint the
+integration now exposes (`/api/samsungtv_smart/art_upload`). That endpoint
+reuses the existing `art_upload` flow — ensure Art Mode, upload, refresh, and
+retry the TV-side thumbnail — and reports back the new content id. Because it
+rides on the same service, everything the service already does (matte, art-mode
+handling, thumbnail retry) applies unchanged.
+
+### Choosing the target Frame
+
+- Pin a TV with `entity:` in the card config and it always uploads there.
+- Omit `entity:` and, if you have **more than one** Frame, the card shows a
+  selector so you can choose per upload. With a single Frame there's no
+  selector — it just uploads to it.
+
+### iPhone HEIC handling
+
+iPhones hand browsers **HEIC/HEIF** images — frequently with a misleading
+`.jpeg` name and `image/jpeg` content type — which The Frame does not accept
+(the upload used to fail with *"no content_id returned"*). The upload endpoint
+now inspects the real bytes: genuine JPEG/PNG pass through untouched, and
+anything else is decoded and re-encoded to JPEG before being sent to the TV.
+This adds `pillow-heif` to the requirements (installed automatically); if the
+HEIC codec is ever unavailable it degrades gracefully without affecting the rest
+of the integration.
+
+---
+
+## Upgrade notes
+
+- No configuration changes required. Existing services, entities and the
+  `folder-gallery-card` are unchanged.
+- After updating, **restart Home Assistant** (so `pillow-heif` is installed and
+  the new card resource is registered), then hard-refresh your browser
+  (Ctrl-Shift-R) before adding the card.
+- The card is optional — if you don't add it, nothing about your setup changes.
+
+---
+
+## Changelog
+
+- **New:** bundled `samsung-art-upload-card` Lovelace card (auto-registered).
+- **New:** authenticated `/api/samsungtv_smart/art_upload` HTTP endpoint.
+- **New:** server-side HEIC/HEIF → JPEG transcoding for uploads (`pillow-heif`).
+- **Change:** the `art_upload` service now returns the upload result
+  (`content_id`) so callers can read it back.
+- **Fix:** bundled card resources register immediately when the integration is
+  reloaded after Home Assistant has already started (previously only on the next
+  full restart).

--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -814,7 +814,7 @@ async def _register_bundled_card(hass: HomeAssistant, filename: str) -> None:
     )
     _LOGGER.debug("SamsungTV Smart: %s registered at %s", filename, url)
 
-    async def _register_resource(event: Event) -> None:
+    async def _register_resource(event: Event | None = None) -> None:
         try:
             lovelace_data = hass.data.get("lovelace")
             resources = getattr(lovelace_data, "resources", None)
@@ -833,7 +833,12 @@ async def _register_bundled_card(hass: HomeAssistant, filename: str) -> None:
                 err,
             )
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _register_resource)
+    # Register right away if HA is already running (e.g. the integration was
+    # reloaded or set up after startup); otherwise wait for the started event.
+    if hass.is_running:
+        await _register_resource()
+    else:
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _register_resource)
 
 
 async def get_device_info(hostname: str, session: ClientSession) -> dict:

--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -795,6 +795,47 @@ async def _register_gallery_card(hass: HomeAssistant) -> None:
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _register_lovelace_resource)
 
 
+async def _register_bundled_card(hass: HomeAssistant, filename: str) -> None:
+    """Serve a bundled Lovelace card JS and auto-add it as a resource.
+
+    Generic version of the gallery-card registration: registers the static
+    path immediately, then adds the Lovelace resource once HA has started.
+    """
+    js_file = Path(__file__).parent / "www" / filename
+    if not js_file.exists():
+        _LOGGER.warning(
+            "SamsungTV Smart: %s not found at %s, skipping", filename, js_file
+        )
+        return
+
+    url = f"/api/{DOMAIN}/{filename}"
+    await hass.http.async_register_static_paths(
+        [StaticPathConfig(url, str(js_file), cache_headers=False)]
+    )
+    _LOGGER.debug("SamsungTV Smart: %s registered at %s", filename, url)
+
+    async def _register_resource(event: Event) -> None:
+        try:
+            lovelace_data = hass.data.get("lovelace")
+            resources = getattr(lovelace_data, "resources", None)
+            if resources is None:
+                return
+            await resources.async_get_info()
+            if url not in [r["url"] for r in resources.async_items()]:
+                await resources.async_create_item({"res_type": "module", "url": url})
+                _LOGGER.info(
+                    "SamsungTV Smart: %s registered as Lovelace resource", filename
+                )
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.warning(
+                "SamsungTV Smart: could not register %s as Lovelace resource: %s",
+                filename,
+                err,
+            )
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _register_resource)
+
+
 async def get_device_info(hostname: str, session: ClientSession) -> dict:
     """Try retrieve device information"""
     try:
@@ -1067,6 +1108,18 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass.http.register_view(SamsungTVThumbnailView(hass))
     except Exception as exc:  # pylint: disable=broad-except
         _LOGGER.warning("Could not register thumbnail view: %s", exc)
+
+    # One-click upload endpoint used by the art-upload card (pick a file on any
+    # device → straight to the Frame, no folder sensor needed).
+    try:
+        from .http_upload import SamsungArtUploadView
+
+        hass.http.register_view(SamsungArtUploadView(hass))
+    except Exception as exc:  # pylint: disable=broad-except
+        _LOGGER.warning("Could not register art upload view: %s", exc)
+
+    # Register the art-upload Lovelace card (served + auto-added as a resource).
+    await _register_bundled_card(hass, "samsung-art-upload-card.js")
 
     return True
 

--- a/custom_components/samsungtv_smart/http_upload.py
+++ b/custom_components/samsungtv_smart/http_upload.py
@@ -1,0 +1,116 @@
+"""Authenticated HTTP endpoint for one-click artwork upload from a card.
+
+A custom Lovelace card (``samsung-art-upload-card``) POSTs a picked image file
+straight to this view, which pushes it to the Frame TV — no pre-placed file, no
+folder sensor, no coding. The heavy lifting reuses the existing
+``samsungtv_smart.art_upload`` service (ensure Art Mode, refresh, retry the
+TV-side thumbnail), so this view is just: receive the multipart file → write a
+temp file → call the service → return the content_id.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+
+from aiohttp import web
+
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+# Guard against absurd uploads (Frame art is a few MB at most).
+_MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+_ALLOWED_SUFFIX = {"image/jpeg": ".jpg", "image/png": ".png"}
+
+
+class SamsungArtUploadView(HomeAssistantView):
+    """POST an image and push it to a Frame TV entity (auth required)."""
+
+    url = f"/api/{DOMAIN}/art_upload"
+    name = f"api:{DOMAIN}:art_upload"
+    # requires_auth defaults to True — the card sends the user's access token.
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Store hass for service calls."""
+        self._hass = hass
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Handle a multipart upload: fields ``entity_id``, ``file``, ``matte_id``."""
+        try:
+            reader = await request.multipart()
+        except Exception:  # noqa: BLE001 - malformed request
+            return self.json_message("Expected multipart/form-data", 400)
+
+        entity_id: str | None = None
+        matte_id = "shadowbox_polar"
+        file_bytes: bytes | None = None
+        content_type = "image/jpeg"
+
+        async for part in reader:
+            if part.name == "entity_id":
+                entity_id = (await part.text()).strip()
+            elif part.name == "matte_id":
+                matte_id = (await part.text()).strip() or matte_id
+            elif part.name == "file":
+                content_type = (part.headers.get("Content-Type") or "").lower()
+                chunks = bytearray()
+                while chunk := await part.read_chunk():
+                    chunks.extend(chunk)
+                    if len(chunks) > _MAX_UPLOAD_BYTES:
+                        return self.json_message("File too large", 413)
+                file_bytes = bytes(chunks)
+
+        if not entity_id:
+            return self.json_message("Missing 'entity_id'", 400)
+        if not file_bytes:
+            return self.json_message("Missing 'file'", 400)
+
+        # Validate the target is one of our media_player entities.
+        state = self._hass.states.get(entity_id)
+        if state is None or not entity_id.startswith("media_player."):
+            return self.json_message(f"Unknown entity {entity_id}", 400)
+
+        suffix = _ALLOWED_SUFFIX.get(content_type, ".jpg")
+        tmp_path = await self._hass.async_add_executor_job(
+            _write_temp_file, file_bytes, suffix
+        )
+        try:
+            result = await self._hass.services.async_call(
+                DOMAIN,
+                "art_upload",
+                {"entity_id": entity_id, "file_path": tmp_path, "matte_id": matte_id},
+                blocking=True,
+                return_response=True,
+            )
+        except Exception as ex:  # noqa: BLE001 - surface a clean error to the card
+            _LOGGER.exception("Art upload via HTTP failed")
+            return self.json_message(f"Upload failed: {ex}", 500)
+        finally:
+            await self._hass.async_add_executor_job(_remove_file, tmp_path)
+
+        # The service returns per-entity results; take the one for our entity.
+        payload = result.get(entity_id) if isinstance(result, dict) else result
+        if isinstance(payload, dict) and payload.get("error"):
+            return self.json_message(payload["error"], 502)
+        return self.json(payload or {"success": True})
+
+
+def _write_temp_file(data: bytes, suffix: str) -> str:
+    """Write bytes to a temp file and return its path (executor)."""
+    fd, path = tempfile.mkstemp(prefix="samsungtv_art_", suffix=suffix)
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(data)
+    return path
+
+
+def _remove_file(path: str) -> None:
+    """Best-effort temp file cleanup (executor)."""
+    try:
+        os.remove(path)
+    except OSError:
+        pass

--- a/custom_components/samsungtv_smart/http_upload.py
+++ b/custom_components/samsungtv_smart/http_upload.py
@@ -10,6 +10,7 @@ temp file → call the service → return the content_id.
 
 from __future__ import annotations
 
+import io
 import logging
 import os
 import tempfile
@@ -25,7 +26,6 @@ _LOGGER = logging.getLogger(__name__)
 
 # Guard against absurd uploads (Frame art is a few MB at most).
 _MAX_UPLOAD_BYTES = 50 * 1024 * 1024
-_ALLOWED_SUFFIX = {"image/jpeg": ".jpg", "image/png": ".png"}
 
 
 class SamsungArtUploadView(HomeAssistantView):
@@ -49,7 +49,6 @@ class SamsungArtUploadView(HomeAssistantView):
         entity_id: str | None = None
         matte_id = "shadowbox_polar"
         file_bytes: bytes | None = None
-        content_type = "image/jpeg"
 
         async for part in reader:
             if part.name == "entity_id":
@@ -57,7 +56,6 @@ class SamsungArtUploadView(HomeAssistantView):
             elif part.name == "matte_id":
                 matte_id = (await part.text()).strip() or matte_id
             elif part.name == "file":
-                content_type = (part.headers.get("Content-Type") or "").lower()
                 chunks = bytearray()
                 while chunk := await part.read_chunk():
                     chunks.extend(chunk)
@@ -75,9 +73,19 @@ class SamsungArtUploadView(HomeAssistantView):
         if state is None or not entity_id.startswith("media_player."):
             return self.json_message(f"Unknown entity {entity_id}", 400)
 
-        suffix = _ALLOWED_SUFFIX.get(content_type, ".jpg")
+        # iPhones hand us HEIC/HEIF (often with a .jpeg name and image/jpeg
+        # type) which The Frame rejects. Transcode anything that is not already
+        # JPEG/PNG to JPEG before handing it to the upload service.
+        try:
+            data, suffix = await self._hass.async_add_executor_job(
+                _prepare_image, file_bytes
+            )
+        except Exception as ex:  # noqa: BLE001 - surface a clean error to the card
+            _LOGGER.exception("Art upload: could not decode image")
+            return self.json_message(f"Unsupported or corrupt image: {ex}", 415)
+
         tmp_path = await self._hass.async_add_executor_job(
-            _write_temp_file, file_bytes, suffix
+            _write_temp_file, data, suffix
         )
         try:
             result = await self._hass.services.async_call(
@@ -98,6 +106,36 @@ class SamsungArtUploadView(HomeAssistantView):
         if isinstance(payload, dict) and payload.get("error"):
             return self.json_message(payload["error"], 502)
         return self.json(payload or {"success": True})
+
+
+def _prepare_image(data: bytes) -> tuple[bytes, str]:
+    """Return (bytes, suffix) the Frame will accept, transcoding if needed.
+
+    JPEG/PNG bytes pass through untouched (matched by magic bytes so a HEIC
+    file misnamed ``.jpeg`` is not trusted). Anything else — notably iPhone
+    HEIC/HEIF — is decoded and re-encoded to JPEG. Pillow (and the optional
+    ``pillow-heif`` opener for HEIC) are imported lazily so a missing codec
+    never breaks importing this module. Runs in an executor (blocking PIL).
+    """
+    if data[:3] == b"\xff\xd8\xff":  # JPEG SOI
+        return data, ".jpg"
+    if data[:8] == b"\x89PNG\r\n\x1a\n":  # PNG signature
+        return data, ".png"
+
+    from PIL import Image  # noqa: PLC0415 - lazy: keep PIL out of import path
+
+    try:
+        import pillow_heif  # noqa: PLC0415 - optional HEIC codec
+
+        pillow_heif.register_heif_opener()
+    except Exception:  # noqa: BLE001 - HEIC just stays unsupported without it
+        pass
+
+    with Image.open(io.BytesIO(data)) as img:
+        rgb = img.convert("RGB")
+        out = io.BytesIO()
+        rgb.save(out, format="JPEG", quality=92)
+    return out.getvalue(), ".jpg"
 
 
 def _write_temp_file(data: bytes, suffix: str) -> str:

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -25,5 +25,5 @@
     "casttube>=0.2.1",
     "Pillow>=10.0.0"
   ],
-  "version": "8.4.0"
+  "version": "8.5.0b1"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.5.0b3"
+  "version": "8.5.0"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -23,7 +23,8 @@
     "wakeonlan>=2.0.0",
     "aiofiles>=0.8.0",
     "casttube>=0.2.1",
-    "Pillow>=10.0.0"
+    "Pillow>=10.0.0",
+    "pillow-heif>=0.13.0"
   ],
-  "version": "8.5.0b2"
+  "version": "8.5.0b3"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -25,5 +25,5 @@
     "casttube>=0.2.1",
     "Pillow>=10.0.0"
   ],
-  "version": "8.5.0b1"
+  "version": "8.5.0b2"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -356,6 +356,7 @@ async def async_setup_entry(
             vol.Optional(ATTR_FILE_TYPE, default="jpg"): cv.string,
         },
         "async_art_upload",
+        supports_response=SupportsResponse.OPTIONAL,
     )
     platform.async_register_entity_service(
         SERVICE_ART_UPLOAD_BATCH,

--- a/custom_components/samsungtv_smart/www/samsung-art-upload-card.js
+++ b/custom_components/samsungtv_smart/www/samsung-art-upload-card.js
@@ -125,7 +125,7 @@ class SamsungArtUploadCard extends HTMLElement {
       <ha-card header="${cfg.title || "Upload to The Frame"}">
         <div style="padding:16px;display:flex;flex-direction:column;gap:12px">
           ${picker}
-          <input id="stv-file" type="file" accept="image/jpeg,image/png" />
+          <input id="stv-file" type="file" accept="image/*,.heic,.heif" />
           <button id="stv-btn" disabled
             style="padding:10px;border:none;border-radius:10px;cursor:pointer;
                    background:var(--primary-color);color:var(--text-primary-color);

--- a/custom_components/samsungtv_smart/www/samsung-art-upload-card.js
+++ b/custom_components/samsungtv_smart/www/samsung-art-upload-card.js
@@ -108,7 +108,7 @@ class SamsungArtUploadCard extends HTMLElement {
     const cfg = this._config || {};
     const entities = this._frameEntities();
     const picker =
-      !cfg.entity && entities.length
+      !cfg.entity && entities.length > 1
         ? `<select id="stv-entity" style="width:100%;padding:8px;margin-bottom:8px">
              ${entities
                .map(

--- a/custom_components/samsungtv_smart/www/samsung-art-upload-card.js
+++ b/custom_components/samsungtv_smart/www/samsung-art-upload-card.js
@@ -1,0 +1,154 @@
+/**
+ * samsung-art-upload-card
+ *
+ * One-click artwork upload to a Samsung Frame TV: pick an image on any device
+ * (phone, laptop) and it is pushed straight to the Frame — no folder sensor,
+ * no pre-placed file. The file is POSTed to the integration's authenticated
+ * endpoint (/api/samsungtv_smart/art_upload), which reuses the art_upload
+ * service to display/refresh it.
+ *
+ * Config:
+ *   type: custom:samsung-art-upload-card
+ *   entity: media_player.samsung_frame   # optional; if omitted a picker is shown
+ *   matte: shadowbox_polar               # optional default matte
+ *   title: Upload to The Frame           # optional
+ */
+
+class SamsungArtUploadCard extends HTMLElement {
+  setConfig(config) {
+    this._config = config || {};
+    this._file = null;
+    this._busy = false;
+    this._msg = "";
+    this._render();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    if (!this._built) this._render();
+  }
+
+  getCardSize() {
+    return 3;
+  }
+
+  _frameEntities() {
+    if (!this._hass) return [];
+    // Frame TVs are the media_players that expose the art_mode_status attribute.
+    return Object.keys(this._hass.states).filter(
+      (e) =>
+        e.startsWith("media_player.") &&
+        "art_mode_status" in (this._hass.states[e].attributes || {})
+    );
+  }
+
+  _selectedEntity() {
+    if (this._config.entity) return this._config.entity;
+    const sel = this.querySelector("#stv-entity");
+    return sel ? sel.value : this._frameEntities()[0];
+  }
+
+  async _upload() {
+    if (this._busy) return;
+    const entity = this._selectedEntity();
+    if (!entity) return this._setMsg("No Frame TV entity selected.", true);
+    if (!this._file) return this._setMsg("Pick an image first.", true);
+
+    this._busy = true;
+    this._setMsg("Uploading…");
+    this._sync();
+
+    const form = new FormData();
+    form.append("entity_id", entity);
+    form.append("matte_id", this._config.matte || "shadowbox_polar");
+    form.append("file", this._file, this._file.name);
+
+    try {
+      const token = this._hass.auth?.data?.access_token;
+      const resp = await fetch("/api/samsungtv_smart/art_upload", {
+        method: "POST",
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        body: form,
+      });
+      const data = await resp.json().catch(() => ({}));
+      if (!resp.ok) throw new Error(data.message || `HTTP ${resp.status}`);
+      this._setMsg(`Uploaded ✓ (${data.content_id || "done"})`);
+      this._file = null;
+      const input = this.querySelector("#stv-file");
+      if (input) input.value = "";
+    } catch (err) {
+      this._setMsg(`Failed: ${err.message}`, true);
+    } finally {
+      this._busy = false;
+      this._sync();
+    }
+  }
+
+  _setMsg(msg, error = false) {
+    this._msg = msg;
+    this._error = error;
+  }
+
+  _sync() {
+    const btn = this.querySelector("#stv-btn");
+    if (btn) {
+      btn.disabled = this._busy || !this._file;
+      btn.textContent = this._busy ? "Uploading…" : "Upload to Frame";
+    }
+    const msg = this.querySelector("#stv-msg");
+    if (msg) {
+      msg.textContent = this._msg;
+      msg.style.color = this._error ? "var(--error-color)" : "var(--secondary-text-color)";
+    }
+  }
+
+  _render() {
+    if (!this._hass) return;
+    this._built = true;
+    const cfg = this._config || {};
+    const entities = this._frameEntities();
+    const picker =
+      !cfg.entity && entities.length
+        ? `<select id="stv-entity" style="width:100%;padding:8px;margin-bottom:8px">
+             ${entities
+               .map(
+                 (e) =>
+                   `<option value="${e}">${
+                     this._hass.states[e].attributes.friendly_name || e
+                   }</option>`
+               )
+               .join("")}
+           </select>`
+        : "";
+
+    this.innerHTML = `
+      <ha-card header="${cfg.title || "Upload to The Frame"}">
+        <div style="padding:16px;display:flex;flex-direction:column;gap:12px">
+          ${picker}
+          <input id="stv-file" type="file" accept="image/jpeg,image/png" />
+          <button id="stv-btn" disabled
+            style="padding:10px;border:none;border-radius:10px;cursor:pointer;
+                   background:var(--primary-color);color:var(--text-primary-color);
+                   font-size:14px">Upload to Frame</button>
+          <div id="stv-msg" style="font-size:13px;min-height:1em"></div>
+        </div>
+      </ha-card>`;
+
+    this.querySelector("#stv-file").addEventListener("change", (ev) => {
+      this._file = ev.target.files && ev.target.files[0];
+      this._setMsg(this._file ? this._file.name : "");
+      this._sync();
+    });
+    this.querySelector("#stv-btn").addEventListener("click", () => this._upload());
+    this._sync();
+  }
+}
+
+customElements.define("samsung-art-upload-card", SamsungArtUploadCard);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: "samsung-art-upload-card",
+  name: "Samsung Frame Art Upload",
+  description: "Pick an image and push it straight to a Samsung Frame TV.",
+});


### PR DESCRIPTION
Closes #161.

Adds an **"atomic" GUI upload** facility for Frame TV artwork: pick an image on any device (phone, laptop) and push it straight to the Frame in one tap — no folder sensor, no pre-placed file, no coding.

## What's included

- **`www/samsung-art-upload-card.js`** — bundled Lovelace card with a real `<input type="file">` and an optional entity picker. The picker is shown only when more than one Frame is detected; with a single Frame (or an `entity:` pinned in config) it uploads directly. Frames are detected as `media_player.*` exposing `art_mode_status`.
- **`http_upload.py`** — `SamsungArtUploadView`, an auth-required `HomeAssistantView` at `/api/samsungtv_smart/art_upload`. It receives the multipart file, validates the target entity, writes a temp file and reuses the existing `art_upload` service (ensure Art Mode, refresh, thumbnail retry), then returns the `content_id`. Temp file is cleaned up in `finally`; uploads are capped at 50 MB and limited to JPEG/PNG.
- **`__init__.py`** — registers the view and auto-registers the card via a new generic `_register_bundled_card` helper (static path + Lovelace resource on startup).
- **`media_player.py`** — the `art_upload` service now declares `supports_response=OPTIONAL` so the view can retrieve the `content_id`.
- **manifest** bumped to `8.5.0b1`; **README** documents the card + endpoint.

## Usage

```yaml
type: custom:samsung-art-upload-card
entity: media_player.samsung_frame   # optional; a picker is shown if omitted and >1 Frame
matte: shadowbox_polar               # optional default matte
title: Upload to The Frame           # optional
```

## Status

Beta (`8.5.0b1`) — **not yet tested end-to-end** (needs a running HA). In particular the card's auth-token approach (`hass.auth.data.access_token`) should be validated live before promoting to a stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_