### PR TITLE
fix(art): chunked upload writes — 2024 Frames stored truncated images (8.5.1b2)

### DIFF
--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -96,6 +96,10 @@ ART_WS_HEARTBEAT = 20
 _KEEPALIVE_INTERVAL = 60.0  # idle ping cadence: keep a quiet-but-live WS open
 _MAX_BACKOFF = 60.0  # hard cap on the per-attempt reconnect delay (seconds)
 
+# Upload d2d socket: write the image in chunks of this size, draining after
+# each, so data really hits the wire before the socket is closed (see upload()).
+_UPLOAD_CHUNK_SIZE = 64 * 1024
+
 # Circuit breaker: consecutive request timeouts on a live socket before the
 # channel is declared wedged (TV art APP dead while its network stack keeps
 # the WS open and answering PINGs — heartbeat can't catch that) and the socket
@@ -2047,8 +2051,16 @@ class SamsungTVAsyncArt:
                 writer.write(header.encode("ascii"))
 
                 self._log.debug("Art API: Sending file data (%d bytes)", file_size)
-                writer.write(file)
-                await writer.drain()
+                # Send in chunks, draining after each one, so the bytes are
+                # actually flushed to the wire as we go. Writing the whole file
+                # in one call only fills the asyncio buffer ("sent" in ms), and
+                # the immediate TLS close below then races with the buffered
+                # data — 2024 Frames (LS03D) end up with a truncated image:
+                # entry created, grey thumbnail, and no image_added event.
+                # Matches the reference implementation (samsung-tv-ws-api).
+                for pos in range(0, file_size, _UPLOAD_CHUNK_SIZE):
+                    writer.write(file[pos : pos + _UPLOAD_CHUNK_SIZE])
+                    await writer.drain()
                 self._log.debug("Art API: Data sent successfully")
             finally:
                 writer.close()

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.5.1b1"
+  "version": "8.5.1b2"
 }


### PR DESCRIPTION
Fixes the upload failure on the living-room QE55LS03D (Frame 2024): image appeared on the TV but with a **grey thumbnail**, and the service reported `no content_id returned` — while the same file uploaded fine on the 2023 32" and via the SmartThings app (which also uploads locally).

## Root cause — our send, not the TV

The d2d upload wrote the entire file in a single `writer.write(file)` and closed the TLS socket right after `drain()`. That write only fills the asyncio transport buffer — the logs prove it: **5.8 MB "sent" in 13 ms**, physically impossible on the wire. The immediate `close()` then races with the buffered data. On 2024 Frames the stream gets truncated: the TV creates the content entry from the header, can't decode the incomplete JPEG (grey thumbnail), never emits `image_added` → 30 s timeout → false error. The observed `ms.channel.clientDisconnect` +3.7 s after "Data sent" is the TV's art app aborting the broken transfer.

## Fix

Write the image in **64 KB chunks with `await writer.drain()` after each**, so bytes actually reach the wire before the socket closes — matching the reference implementation ([NickWaterton/samsung-tv-ws-api](https://github.com/NickWaterton/samsung-tv-ws-api), which officially supports 2024 models):

```python
for pos in range(0, file_size, _UPLOAD_CHUNK_SIZE):
    writer.write(file[pos : pos + _UPLOAD_CHUNK_SIZE])
    await writer.drain()
```

Applies to single upload and, via it, `art_upload_batch` and the upload card. `manifest` → `8.5.1b2`.

## Status

Beta — needs a live test on the QE55LS03D (upload Goya_Maja_naga2.jpg again and check the preview renders and the card reports the content_id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_