### PR TITLE
fix(art): stable session id in send_image/get_thumbnail — 2024 Frame upload & thumbnails (8.5.1b4)

### DIFF
--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -98,7 +98,9 @@ _MAX_BACKOFF = 60.0  # hard cap on the per-attempt reconnect delay (seconds)
 
 # Upload d2d socket: write the image in chunks of this size, draining after
 # each, so data really hits the wire before the socket is closed (see upload()).
-_UPLOAD_CHUNK_SIZE = 64 * 1024
+# The drain-per-chunk is what matters, not the chunk size; 512K keeps the
+# flush guarantee with far fewer syscalls than the reference's 64K.
+_UPLOAD_CHUNK_SIZE = 512 * 1024
 
 # Circuit breaker: consecutive request timeouts on a live socket before the
 # channel is declared wedged (TV art APP dead while its network stack keeps


### PR DESCRIPTION
Second (and likely decisive) fix for the QE55LS03D (Frame 2024) upload failure, after the chunked-writes fix in #168 proved necessary but not sufficient — the retest on 8.5.1b2 (64K chunks) still failed: data reached the wire (2.75 MB in ~184 ms), yet the TV aborted ~2 s later (`ms.channel.clientDisconnect`), no `image_added`, and this time **no content entry was created at all**.

## Root cause

Comparing with the reference implementation (samsung-tv-ws-api, which supports 2024 models): it sends `"id"` = a **stable per-session art uuid** (generated once) plus a fresh `request_id` per request. Our `_get_uuid()` **regenerated `_art_uuid` on every call** and sent the throwaway request_id as both `id` and `conn_info.id`.

2024 Frames use that id to associate the d2d data socket with a known client. With a throwaway id, the TV aborts the transfer right after the bytes arrive — and the same check explains why **all 30 thumbnail downloads fail** on this TV (`No thumbnail data received`) while the 2023 32" works: older firmware just doesn't enforce it.

## Changes

- `_get_uuid()` returns a fresh uuid **without clobbering** `self._art_uuid` (stable, set in `__init__`).
- `send_image` and all three `get_thumbnail`/`get_thumbnail_list` requests now send the stable `art_uuid` as `id`/`conn_info.id`, keeping a fresh `request_id` (still the pending-map key — `_send_art_request` now respects a caller-provided `request_id`).
- Keeps the chunked d2d writes from #168 (both bugs were real) and bumps chunks to 512K.
- `manifest` → `8.5.1b3`.

## Test on the QE55LS03D

1. Upload `Goya_Maja_naga2.jpg` via the card → expect a `content_id` and a real preview (no grey rectangle).
2. Check the art sensor/gallery: thumbnails should now download too (previously 30/30 failed on this TV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2