### PR TITLE
fix(art): stable session id in send_image/get_thumbnail — 2024 Frame upload & thumbnails (8.5.1b4)

### DIFF
--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -269,9 +269,16 @@ class SamsungTVAsyncArt:
         self._supports_thumbnail_list: bool | None = None
 
     def _get_uuid(self) -> str:
-        """Generate a new UUID for art requests."""
-        self._art_uuid = str(uuid.uuid4())
-        return self._art_uuid
+        """Generate a new per-request UUID.
+
+        Does NOT touch self._art_uuid: that one is the stable client identity
+        for the whole art session (generated once in __init__). The reference
+        implementation sends "id": art_uuid (stable) with a fresh "request_id"
+        per request; 2024 Frames (LS03D) use the stable id to associate the
+        d2d upload with a known client — a throwaway id there makes the TV
+        abort the transfer (clientDisconnect, no image_added).
+        """
+        return str(uuid.uuid4())
 
     def register_capability_callback(self, func) -> None:
         """Register a callback fired when a get-capability is first learned.
@@ -922,12 +929,13 @@ class SamsungTVAsyncArt:
             self._log.debug("Art API: WebSocket still not connected after open()")
             return None
 
-        # Set up request IDs (both old and new API style)
+        # Set up request IDs (both old and new API style). Callers may pass a
+        # distinct request_id (fresh) and id (stable art_uuid) — see upload().
         if not request_data.get("id"):
             request_data["id"] = self._get_uuid()
-        request_data["request_id"] = request_data["id"]
+        request_data.setdefault("request_id", request_data["id"])
 
-        request_key = wait_for_event or request_data["id"]
+        request_key = wait_for_event or request_data["request_id"]
 
         # Create future before sending
         self._pending_requests[request_key] = asyncio.get_event_loop().create_future()
@@ -1053,7 +1061,8 @@ class SamsungTVAsyncArt:
                 "conn_info": {
                     "d2d_mode": "socket",
                     "connection_id": random.randrange(4 * 1024 * 1024 * 1024),
-                    "id": self._get_uuid(),
+                    # Stable session id — same 2024-Frame requirement as upload().
+                    "id": self._art_uuid,
                 },
             },
             timeout=15,
@@ -1233,7 +1242,8 @@ class SamsungTVAsyncArt:
                 "conn_info": {
                     "d2d_mode": "socket",
                     "connection_id": random.randrange(4 * 1024 * 1024 * 1024),
-                    "id": self._get_uuid(),
+                    # Stable session id — same 2024-Frame requirement as upload().
+                    "id": self._art_uuid,
                 },
             },
             timeout=10,
@@ -1322,7 +1332,8 @@ class SamsungTVAsyncArt:
                 "conn_info": {
                     "d2d_mode": "socket",
                     "connection_id": random.randrange(4 * 1024 * 1024 * 1024),
-                    "id": self._get_uuid(),
+                    # Stable session id — same 2024-Frame requirement as upload().
+                    "id": self._art_uuid,
                 },
             },
             timeout=15,
@@ -1972,11 +1983,14 @@ class SamsungTVAsyncArt:
                 "request": "send_image",
                 "file_type": file_type,
                 "request_id": request_id,
-                "id": request_id,
+                # Stable session identity, NOT the throwaway request_id: 2024
+                # Frames tie the d2d transfer to this client id and abort the
+                # upload (clientDisconnect, no image_added) when it's unknown.
+                "id": self._art_uuid,
                 "conn_info": {
                     "d2d_mode": "socket",
                     "connection_id": random.randrange(4 * 1024 * 1024 * 1024),
-                    "id": request_id,
+                    "id": self._art_uuid,
                 },
                 "image_date": date,
                 "matte_id": matte or "none",

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.5.1b3"
+  "version": "8.5.1b4"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.5.1b2"
+  "version": "8.5.1b3"
 }


### PR DESCRIPTION
⚠️ **Re-opens the actual fix.** #169 was merged but only carried the 512K-chunk tweak — the decisive change (stable session id) was pushed just after that merge and never landed on master. This PR brings it in, off fresh master.

Second (and likely decisive) fix for the QE55LS03D (Frame 2024) upload failure, after the chunked-writes fix in #168 proved necessary but not sufficient — the retest on 8.5.1b2 (64K chunks) still failed: data reached the wire (2.75 MB in ~184 ms), yet the TV aborted ~2 s later (`ms.channel.clientDisconnect`), no `image_added`, and **no content entry was created at all**.

## Root cause

Comparing with the reference implementation (samsung-tv-ws-api, which supports 2024 models): it sends `"id"` = a **stable per-session art uuid** (generated once) plus a fresh `request_id` per request. Our `_get_uuid()` **regenerated `_art_uuid` on every call** and sent the throwaway request_id as both `id` and `conn_info.id`.

2024 Frames use that id to associate the d2d data socket with a known client. With a throwaway id, the TV aborts the transfer right after the bytes arrive — and the same check explains why **all 30 thumbnail downloads fail** on this TV (`No thumbnail data received`) while the 2023 32" works: older firmware just doesn't enforce it.

## Changes

- `_get_uuid()` returns a fresh uuid **without clobbering** `self._art_uuid` (stable, set in `__init__`).
- `send_image` and all three `get_thumbnail`/`get_thumbnail_list` requests now send the stable `art_uuid` as `id`/`conn_info.id`, keeping a fresh `request_id` (still the pending-map key — `_send_art_request` now respects a caller-provided `request_id`).
- `manifest` → `8.5.1b4`.

(The chunked 512K d2d writes from #168/#169 are already on master.)

## Test on the QE55LS03D

1. Upload `Goya_Maja_naga2.jpg` via the card → expect a `content_id` and a real preview (no grey rectangle).
2. Check the art gallery: thumbnails should now download too (previously 30/30 failed on this TV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_