### PR TITLE
fix(art): suspend the timeout circuit breaker during an upload (8.5.1b8)

### DIFF
--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -210,6 +210,9 @@ class SamsungTVAsyncArt:
         # Circuit breaker: consecutive request timeouts on a live socket
         # (zombie art app detection — see _note_request_timeout).
         self._timeout_streak = 0
+        # Suspends that breaker while an upload waits for image_added, so
+        # unrelated thumbnail timeouts can't tear the socket down mid-upload.
+        self._upload_in_progress = False
 
         # Connection lock to prevent concurrent connection attempts (v6.3.5)
         self._connection_lock = asyncio.Lock()
@@ -872,7 +875,17 @@ class SamsungTVAsyncArt:
         Occasional single timeouts (e.g. the capability probes on TVs that
         don't implement a request) don't trip it: interleaved successful
         requests keep resetting the streak.
+
+        An upload in flight suspends the breaker entirely. On TVs whose
+        get_thumbnail never answers (2024 Frames), the thumbnail coordinator
+        piles up timeouts *while* an upload waits for ``image_added``; tripping
+        here would force-close the socket, cancel that pending wait and report
+        a bogus "no content_id returned" for an upload the TV was still
+        processing. The channel is demonstrably alive during an upload anyway —
+        the TV just answered send_image and accepted the d2d transfer.
         """
+        if self._upload_in_progress:
+            return
         self._timeout_streak += 1
         if self._timeout_streak < ART_WS_TIMEOUT_TRIP:
             return
@@ -1966,6 +1979,32 @@ class SamsungTVAsyncArt:
         self._log.debug(
             "Art API: Sending send_image request, request_id=%s", request_id
         )
+
+        # Hold the timeout circuit breaker off for the whole transfer: on TVs
+        # whose get_thumbnail never answers, the coordinator's timeouts would
+        # otherwise trip it and force-close the socket while we wait for
+        # image_added, killing a perfectly good upload.
+        self._upload_in_progress = True
+        try:
+            return await self._upload_locked(
+                file, matte, portrait_matte, file_type, date, timeout, request_id
+            )
+        finally:
+            self._upload_in_progress = False
+            self._timeout_streak = 0
+
+    async def _upload_locked(  # noqa: PLR0913 - mirrors upload()'s parameters
+        self,
+        file: bytes,
+        matte: str,
+        portrait_matte: str,
+        file_type: str,
+        date: str,
+        timeout: int,
+        request_id: str,
+    ) -> str | None:
+        """Do the send_image handshake and d2d transfer (breaker suspended)."""
+        file_size = len(file)
 
         data = await self._send_art_request(
             {

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.5.1b7"
+  "version": "8.5.1b8"
 }


### PR DESCRIPTION
**Root cause of the 55" upload failures — our own code, not the TV.** This also explains why the failure was intermittent and why every previous theory (truncation, session id, image format) fell apart on retest.

## The evidence

The failing uploads never reached the 30 s `image_added` timeout — they aborted after **4–13 s**. The logs say exactly why:

```
22:13:18.621  Waiting for image_added event (timeout=30s)
22:13:23.065  3 consecutive request timeouts on a live socket —
              art channel looks wedged, forcing reconnect
22:13:23.067  No image_added event received
22:13:24.069  reconnected after 1 attempt(s)
```

`get_thumbnail` never answers on this TV (a long-standing quirk of this panel — every thumbnail fetch logs `Empty thumbnail data … got 0 bytes`). Those timeouts accumulate **while the upload is waiting**. At three in a row, the zombie-channel circuit breaker added in 8.3.4 force-closes the socket, and the receive loop's cleanup **cancels every pending future** (`art.py:726-729`) — including the upload's `image_added` wait. A transfer the TV was still processing gets reported as `no content_id returned`.

This accounts for everything observed:
- **flaky**: succeeds whenever thumbnails happen to be cached, so no streak builds;
- **card and service fail identically**: they share this code path;
- **the 2023 32" is immune**: its thumbnails answer, so the streak never reaches 3.

## Fix

Suspend the breaker for the duration of an upload. The channel is demonstrably alive there — the TV has just answered `send_image` and accepted the d2d transfer — so a wedged-channel heuristic has nothing to detect. Unrelated thumbnail timeouts can no longer tear the socket down mid-upload. The streak resets when the upload finishes, so genuine zombie detection is unaffected everywhere else.

`manifest` → `8.5.1b8`.

## Test

Upload the Goya to the 55" salon repeatedly (the previous builds succeeded roughly one time in three). It should now succeed consistently, including while the art gallery is refreshing thumbnails.

Note this does not fix the thumbnails themselves on that TV — `get_thumbnail` still returns nothing there, so those artworks keep showing placeholders. That's a separate issue worth its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_