### PR TITLE
fix(art): use ordinary JPEG encoding for uploads, not maximal (8.5.1b10)

### DIFF
--- a/custom_components/samsungtv_smart/http_upload.py
+++ b/custom_components/samsungtv_smart/http_upload.py
@@ -111,18 +111,19 @@ class SamsungArtUploadView(HomeAssistantView):
 def _prepare_image(data: bytes) -> tuple[bytes, str]:
     """Re-encode any image into a plain JPEG the Frame is happy to decode.
 
-    Every upload is normalised, not just the exotic ones. The TV is far
-    pickier than a browser: progressive scans, CMYK, 16-bit or paletted
-    samples and oversized EXIF blobs are all things it may store and then
-    fail to decode — the artwork ends up as a grey rectangle and the TV never
-    emits ``image_added``. Re-encoding once, here, removes that whole class of
+    Every upload is normalised, not just the exotic ones. The TV is far pickier
+    than a browser: progressive scans, CMYK, 16-bit or paletted samples and
+    oversized EXIF blobs are all things it may store and then fail to decode —
+    the artwork ends up as a grey rectangle and the TV never emits
+    ``image_added``. Re-encoding once, here, removes that whole class of
     surprises (and is what the SmartThings app does before sending).
 
-    Quality is deliberately maximal: ``quality=100`` with **4:4:4** chroma (no
-    subsampling) and the original resolution untouched, so normalising costs
-    fidelity only through a single re-quantisation, not through downscaling or
-    chroma decimation. EXIF orientation is applied before the metadata is
-    dropped, so portrait photos are not sent sideways.
+    Encoding stays deliberately ordinary — ``quality=92`` with standard 4:2:0
+    chroma — because that is what cameras, phones and the SmartThings app emit,
+    and it is what the TV reliably accepts; maximal settings (quality=100,
+    4:4:4) were refused by the Frame. Resolution is left untouched, so the only
+    fidelity cost is a single re-quantisation. EXIF orientation is applied
+    before the metadata is dropped, so portrait photos are not sent sideways.
 
     Pillow (and the optional ``pillow-heif`` opener for iPhone HEIC) are
     imported lazily so a missing codec never breaks importing this module.
@@ -144,8 +145,8 @@ def _prepare_image(data: bytes) -> tuple[bytes, str]:
         rgb.save(
             out,
             format="JPEG",
-            quality=100,
-            subsampling=0,  # 4:4:4 — keep full chroma resolution
+            quality=92,
+            subsampling="4:2:0",  # what every camera/phone emits; TV-safe
             progressive=False,  # baseline only: TVs choke on progressive
             optimize=False,
         )

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.5.1b9"
+  "version": "8.5.1b10"
 }


### PR DESCRIPTION
Follow-up to #174: the maximal encoding it introduced is refused by the Frame.

`quality=100` with **4:4:4** chroma produced files the TV would not take. Drop back to **`quality=92` / 4:2:0** — what cameras, phones and the SmartThings app emit, and what the TV reliably accepts.

Resolution is still left untouched, so the only fidelity cost remains a single re-quantisation. Size comes back to normal too: a 4259×2160 photo lands around **4 MB** instead of 12.5 MB.

Everything else from #174 is unchanged — systematic normalisation, baseline (never progressive), EXIF orientation applied then metadata stripped.

`manifest` → `8.5.1b10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_