### PR TITLE
fix(art): pass the panel size to _prepare_image (8.5.1b14)

### DIFF
--- a/custom_components/samsungtv_smart/http_upload.py
+++ b/custom_components/samsungtv_smart/http_upload.py
@@ -84,7 +84,7 @@ class SamsungArtUploadView(HomeAssistantView):
         # JPEG/PNG to JPEG before handing it to the upload service.
         try:
             data, suffix = await self._hass.async_add_executor_job(
-                _prepare_image, file_bytes
+                _prepare_image, file_bytes, _panel_size(state)
             )
         except Exception as ex:  # noqa: BLE001 - surface a clean error to the card
             _LOGGER.exception("Art upload: could not decode image")

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.5.1b13"
+  "version": "8.5.1b14"
 }


### PR DESCRIPTION
Hotfix for #177: card uploads fail immediately with

```
Failed: Unsupported or corrupt image: _prepare_image() missing 1 required positional argument: 'panel'
```

#177 added the `panel` parameter to `_prepare_image()` but the call-site edit silently missed the real indentation, so the caller was never updated. Lint passed; the function blew up at runtime.

Verified end-to-end this time, not just linted — the module is imported and the path exercised:

| panel | 4259×2160 → |
|---|---|
| 4K (3840×2160) | 3840×1947 |
| 8K (7680×4320) | unchanged |
| not reported | 3840×1947 (4K fallback) |

`manifest` → `8.5.1b14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_