### PR TITLE
Fix OAuth token rotation across shared TV entries

### DIFF
--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
 from pathlib import Path
 import socket
 import time
+from weakref import WeakValueDictionary
 
 from aiohttp import ClientConnectionError, ClientResponseError, ClientSession
 import async_timeout
@@ -182,9 +184,12 @@ CONFIG_SCHEMA = vol.Schema(
 
 _LOGGER = logging.getLogger(__name__)
 
-# Global lock dictionary to prevent concurrent OAuth refresh per entry
-# This is shared across all entities (media_player, switch, sensor)
-_OAUTH_REFRESH_LOCKS: dict[str, asyncio.Lock] = {}
+# Global lock dictionary to prevent concurrent OAuth refreshes for entries that
+# share a SmartThings refresh token. SmartThings rotates that token, so allowing
+# each TV entry to refresh it independently makes the first refresh invalidate
+# every sibling entry. Weak references avoid retaining one lock per daily token
+# rotation indefinitely.
+_OAUTH_REFRESH_LOCKS: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
 _OAUTH_REFRESH_IN_PROGRESS: dict[str, bool] = {}
 # Set once the SmartThings refresh token is rejected with invalid_grant: the
 # refresh token is dead and retrying only hammers the auth endpoint (observed
@@ -227,11 +232,74 @@ def start_oauth_reauth(hass: HomeAssistant, entry_id: str) -> None:
             _LOGGER.debug("Could not start reauth flow: %s", exc)
 
 
-def get_oauth_refresh_lock(entry_id: str) -> asyncio.Lock:
-    """Get or create a lock for OAuth refresh for a specific entry."""
-    if entry_id not in _OAUTH_REFRESH_LOCKS:
-        _OAUTH_REFRESH_LOCKS[entry_id] = asyncio.Lock()
-    return _OAUTH_REFRESH_LOCKS[entry_id]
+def _oauth_refresh_group_key(entry: ConfigEntry) -> str:
+    """Return a non-secret key for entries sharing an OAuth refresh token."""
+    oauth_token = entry.data.get(CONF_OAUTH_TOKEN)
+    refresh_token = (
+        oauth_token.get("refresh_token") if isinstance(oauth_token, dict) else None
+    )
+    if not isinstance(refresh_token, str) or not refresh_token:
+        return f"entry:{entry.entry_id}"
+
+    implementation = entry.data.get("auth_implementation", DOMAIN)
+    token_digest = hashlib.sha256(refresh_token.encode()).hexdigest()
+    return f"{implementation}:{token_digest}"
+
+
+def get_oauth_refresh_lock(entry: ConfigEntry) -> asyncio.Lock:
+    """Get or create a lock for entries sharing an OAuth refresh token."""
+    group_key = _oauth_refresh_group_key(entry)
+    lock = _OAUTH_REFRESH_LOCKS.get(group_key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _OAUTH_REFRESH_LOCKS[group_key] = lock
+    return lock
+
+
+@callback
+def update_shared_oauth_token(
+    hass: HomeAssistant,
+    source_entry: ConfigEntry,
+    previous_token: dict,
+    new_token: dict,
+    source_data_updates: dict | None = None,
+) -> int:
+    """Store a rotated OAuth token in all entries that shared its predecessor."""
+    previous_refresh_token = previous_token.get("refresh_token")
+    implementation = source_entry.data.get("auth_implementation", DOMAIN)
+    updated_count = 0
+
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        entry_token = entry.data.get(CONF_OAUTH_TOKEN)
+        is_source = entry.entry_id == source_entry.entry_id
+        if not is_source:
+            if not previous_refresh_token or not isinstance(entry_token, dict):
+                continue
+            if entry_token.get("refresh_token") != previous_refresh_token:
+                continue
+            if entry.data.get("auth_implementation", DOMAIN) != implementation:
+                continue
+
+        hass.config_entries.async_update_entry(
+            entry,
+            data={
+                **entry.data,
+                CONF_OAUTH_TOKEN: new_token,
+                CONF_API_KEY: new_token["access_token"],
+                "auth_implementation": implementation,
+                **(source_data_updates if is_source and source_data_updates else {}),
+            },
+        )
+        set_oauth_token_invalid(entry.entry_id, False)
+        ir.async_delete_issue(hass, DOMAIN, f"oauth_auth_failed_{entry.entry_id}")
+        updated_count += 1
+
+    _LOGGER.info(
+        "OAuth token updated for %d TV entr%s sharing the previous token",
+        updated_count,
+        "y" if updated_count == 1 else "ies",
+    )
+    return updated_count
 
 
 def is_oauth_refresh_in_progress(entry_id: str) -> bool:
@@ -562,7 +630,7 @@ async def async_get_samsungtv_api_key(  # noqa: C901
                     # (ST sensors, power switch) race the media_player refresh
                     # at startup, and a stale token here makes their setup
                     # fail with an auth error until the next reload.
-                    lock = get_oauth_refresh_lock(entry.entry_id)
+                    lock = get_oauth_refresh_lock(entry)
                     async with lock:
                         # Double-check after acquiring lock - token might have been refreshed
                         updated_entry = hass.config_entries.async_get_entry(
@@ -576,6 +644,8 @@ async def async_get_samsungtv_api_key(  # noqa: C901
                                     "Token was refreshed by another entity, using new token"
                                 )
                                 return updated_token.get("access_token")
+                            entry = updated_entry
+                            oauth_token = updated_token
 
                         set_oauth_refresh_in_progress(entry.entry_id, True)
                         try:
@@ -636,15 +706,11 @@ async def async_get_samsungtv_api_key(  # noqa: C901
                                 new_token = await implementation.async_refresh_token(
                                     oauth_token
                                 )
-                                # Update entry with new token
-                                hass.config_entries.async_update_entry(
+                                update_shared_oauth_token(
+                                    hass,
                                     entry,
-                                    data={
-                                        **entry.data,
-                                        CONF_OAUTH_TOKEN: new_token,
-                                        CONF_API_KEY: new_token["access_token"],
-                                        "auth_implementation": DOMAIN,
-                                    },
+                                    oauth_token,
+                                    new_token,
                                 )
                                 _LOGGER.info("OAuth token refreshed successfully")
                                 set_oauth_token_invalid(entry.entry_id, False)

--- a/custom_components/samsungtv_smart/config_flow.py
+++ b/custom_components/samsungtv_smart/config_flow.py
@@ -45,6 +45,7 @@ from . import (
     get_smartthings_api_key,
     get_smartthings_entries,
     is_valid_ha_version,
+    update_shared_oauth_token,
 )
 from .const import (
     ART_LLM_PROVIDERS,
@@ -896,16 +897,12 @@ class SamsungTVSmartOAuth2FlowHandler(
         if not self._reauth_entry:
             return self.async_abort(reason="reauth_failed")
 
-        self.hass.config_entries.async_update_entry(
+        update_shared_oauth_token(
+            self.hass,
             self._reauth_entry,
-            data={
-                **self._reauth_entry.data,
-                CONF_API_KEY: self._oauth_data["token"]["access_token"],
-                CONF_OAUTH_TOKEN: self._oauth_data["token"],
-                CONF_AUTH_METHOD: AUTH_METHOD_OAUTH,
-                # Store auth_implementation to enable token refresh
-                "auth_implementation": DOMAIN,
-            },
+            self._reauth_entry.data.get(CONF_OAUTH_TOKEN, {}),
+            self._oauth_data["token"],
+            {CONF_AUTH_METHOD: AUTH_METHOD_OAUTH},
         )
         # The data update above triggers the update listener, which schedules
         # the reload — reloading here too is deprecated in HA.

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -73,6 +73,7 @@ from . import (
     set_oauth_refresh_in_progress,
     set_oauth_token_invalid,
     start_oauth_reauth,
+    update_shared_oauth_token,
 )
 from .api.art import SamsungTVAsyncArt
 from .api.ipcontrol import (
@@ -821,12 +822,15 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         if self._auth_method != AUTH_METHOD_OAUTH:
             return True
 
-        # Acquire the global per-entry lock. If another task is already
-        # refreshing, this WAITS for it to finish instead of sleeping an
-        # arbitrary 0.5s (a real SmartThings refresh round-trip routinely
-        # takes longer, which left this update cycle on the stale token);
-        # the double-check below then adopts the freshly stored token.
-        lock = get_oauth_refresh_lock(self._entry_id)
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if not entry:
+            self._log.warning("Could not find config entry for OAuth refresh")
+            return False
+
+        # Entries that share a refresh token also share this lock. The first
+        # refresh propagates the rotated token before releasing it; waiters then
+        # adopt that stored token instead of submitting the invalid predecessor.
+        lock = get_oauth_refresh_lock(entry)
         async with lock:
             # Double-check after acquiring lock - another entity might have refreshed
             entry = self.hass.config_entries.async_get_entry(self._entry_id)
@@ -1060,15 +1064,11 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
             new_token = await implementation.async_refresh_token(oauth_token)
 
-            # Update config entry with new token and auth_implementation
-            self.hass.config_entries.async_update_entry(
+            update_shared_oauth_token(
+                self.hass,
                 entry,
-                data={
-                    **entry.data,
-                    CONF_OAUTH_TOKEN: new_token,
-                    CONF_API_KEY: new_token["access_token"],
-                    "auth_implementation": DOMAIN,
-                },
+                oauth_token,
+                new_token,
             )
 
             # Update local api key

--- a/tests/test_oauth_token_sharing.py
+++ b/tests/test_oauth_token_sharing.py
@@ -1,0 +1,206 @@
+"""Tests for OAuth token rotation across multiple TV entries."""
+
+import asyncio
+import sys
+from types import ModuleType
+from unittest.mock import patch
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+# The repository test requirements do not install pysmartthings. This test
+# exercises token coordination only, so provide the one symbol imported while
+# loading the integration package without pulling in the cloud client.
+if "pysmartthings" not in sys.modules:
+    pysmartthings = ModuleType("pysmartthings")
+    pysmartthings.SmartThings = object
+    sys.modules["pysmartthings"] = pysmartthings
+
+from custom_components.samsungtv_smart import (  # noqa: E402
+    async_get_samsungtv_api_key,
+    get_oauth_refresh_lock,
+    is_oauth_token_invalid,
+    set_oauth_token_invalid,
+    update_shared_oauth_token,
+)
+from custom_components.samsungtv_smart.config_flow import (  # noqa: E402
+    SamsungTVSmartOAuth2FlowHandler,
+)
+from custom_components.samsungtv_smart.const import (  # noqa: E402
+    AUTH_METHOD_OAUTH,
+    CONF_AUTH_METHOD,
+    CONF_OAUTH_TOKEN,
+    DOMAIN,
+)
+
+
+def _entry(title, token, implementation=DOMAIN):
+    """Create an OAuth TV config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=title,
+        unique_id=title,
+        data={
+            CONF_AUTH_METHOD: AUTH_METHOD_OAUTH,
+            CONF_OAUTH_TOKEN: token,
+            "auth_implementation": implementation,
+        },
+    )
+
+
+def test_refresh_lock_is_shared_only_by_matching_oauth_group():
+    """Entries sharing credentials and refresh token use the same lock."""
+    shared_token = {"access_token": "old-access", "refresh_token": "old-refresh"}
+    first = _entry("First", shared_token)
+    sibling = _entry("Sibling", shared_token)
+    other_token = _entry(
+        "Other token",
+        {"access_token": "other-access", "refresh_token": "other-refresh"},
+    )
+    other_implementation = _entry(
+        "Other implementation", shared_token, implementation="other-credentials"
+    )
+
+    first_lock = get_oauth_refresh_lock(first)
+    assert get_oauth_refresh_lock(sibling) is first_lock
+    assert get_oauth_refresh_lock(other_token) is not first_lock
+    assert get_oauth_refresh_lock(other_implementation) is not first_lock
+
+
+def test_rotated_token_updates_only_entries_sharing_predecessor(hass):
+    """A new token is copied only to entries that shared the previous one."""
+    previous_token = {
+        "access_token": "old-access",
+        "refresh_token": "old-refresh",
+        "expires_at": 1,
+    }
+    new_token = {
+        "access_token": "new-access",
+        "refresh_token": "new-refresh",
+        "expires_at": 4_000_000_000,
+    }
+    source = _entry("Source", previous_token)
+    sibling = _entry("Sibling", previous_token)
+    unrelated = _entry(
+        "Unrelated",
+        {
+            "access_token": "unrelated-access",
+            "refresh_token": "unrelated-refresh",
+            "expires_at": 1,
+        },
+    )
+    other_implementation = _entry(
+        "Other implementation", previous_token, implementation="other-credentials"
+    )
+    for entry in (source, sibling, unrelated, other_implementation):
+        entry.add_to_hass(hass)
+
+    set_oauth_token_invalid(source.entry_id, True)
+    set_oauth_token_invalid(sibling.entry_id, True)
+
+    with patch(
+        "custom_components.samsungtv_smart.ir.async_delete_issue"
+    ) as delete_issue:
+        updated = update_shared_oauth_token(hass, source, previous_token, new_token)
+
+    assert updated == 2
+    assert source.data[CONF_OAUTH_TOKEN] == new_token
+    assert sibling.data[CONF_OAUTH_TOKEN] == new_token
+    assert source.data["api_key"] == "new-access"
+    assert sibling.data["api_key"] == "new-access"
+    assert unrelated.data[CONF_OAUTH_TOKEN]["refresh_token"] == "unrelated-refresh"
+    assert other_implementation.data[CONF_OAUTH_TOKEN] == previous_token
+    assert not is_oauth_token_invalid(source.entry_id)
+    assert not is_oauth_token_invalid(sibling.entry_id)
+    assert delete_issue.call_count == 2
+
+
+async def test_manual_reauth_propagates_token_to_sibling_entries(hass):
+    """Completing reauth updates every entry that held the old token."""
+    previous_token = {
+        "access_token": "old-reauth-access",
+        "refresh_token": "old-reauth-refresh",
+        "expires_at": 1,
+    }
+    new_token = {
+        "access_token": "new-reauth-access",
+        "refresh_token": "new-reauth-refresh",
+        "expires_at": 4_000_000_000,
+    }
+    source = _entry("Reauth source", previous_token)
+    sibling = _entry("Reauth sibling", previous_token)
+    source.add_to_hass(hass)
+    sibling.add_to_hass(hass)
+
+    flow = SamsungTVSmartOAuth2FlowHandler()
+    flow.hass = hass
+    flow._reauth_entry = source
+    flow._oauth_data = {"token": new_token}
+
+    with (
+        patch("custom_components.samsungtv_smart.ir.async_delete_issue"),
+        patch.object(
+            flow,
+            "async_abort",
+            return_value={"type": "abort", "reason": "reauth_successful"},
+        ),
+    ):
+        result = await flow._async_finish_reauth()
+
+    assert result["reason"] == "reauth_successful"
+    assert source.data[CONF_OAUTH_TOKEN] == new_token
+    assert sibling.data[CONF_OAUTH_TOKEN] == new_token
+    assert source.data[CONF_AUTH_METHOD] == AUTH_METHOD_OAUTH
+
+
+async def test_concurrent_refresh_rotates_shared_token_once(hass):
+    """Concurrent TV refreshes submit the shared predecessor only once."""
+    previous_token = {
+        "access_token": "old-access",
+        "refresh_token": "old-refresh-concurrent",
+        "expires_at": 1,
+    }
+    new_token = {
+        "access_token": "new-access",
+        "refresh_token": "new-refresh-concurrent",
+        "expires_at": 4_000_000_000,
+    }
+    first = _entry("First concurrent", previous_token)
+    sibling = _entry("Sibling concurrent", previous_token)
+    first.add_to_hass(hass)
+    sibling.add_to_hass(hass)
+
+    refresh_started = asyncio.Event()
+    allow_refresh_to_finish = asyncio.Event()
+    refresh_calls = 0
+
+    class Implementation:
+        """Controllable OAuth implementation used by the test."""
+
+        async def async_refresh_token(self, token):
+            nonlocal refresh_calls
+            refresh_calls += 1
+            assert token == previous_token
+            refresh_started.set()
+            await allow_refresh_to_finish.wait()
+            return new_token
+
+    implementation = Implementation()
+    with (
+        patch(
+            "custom_components.samsungtv_smart.config_entry_oauth2_flow."
+            "async_get_config_entry_implementation",
+            return_value=implementation,
+        ),
+        patch("custom_components.samsungtv_smart.ir.async_delete_issue"),
+    ):
+        first_task = asyncio.create_task(async_get_samsungtv_api_key(hass, first))
+        await refresh_started.wait()
+        sibling_task = asyncio.create_task(async_get_samsungtv_api_key(hass, sibling))
+        await asyncio.sleep(0)
+        allow_refresh_to_finish.set()
+        results = await asyncio.gather(first_task, sibling_task)
+
+    assert results == ["new-access", "new-access"]
+    assert refresh_calls == 1
+    assert first.data[CONF_OAUTH_TOKEN] == new_token
+    assert sibling.data[CONF_OAUTH_TOKEN] == new_token


### PR DESCRIPTION
## Summary

- group OAuth refresh locking by the previous SmartThings refresh token instead of by config entry
- propagate a rotated token only to TV entries that shared that exact predecessor and OAuth implementation
- apply the same propagation after manual reauthentication
- clear stale invalid-token state and Repairs issues for every updated sibling entry
- add regression coverage for isolation, manual reauth, and concurrent refreshes

This keeps one OAuth application credential set for a multi-TV installation while preventing the first refresh from invalidating the remaining TV entries.

Closes #180

## Testing

- `python -m pytest -q` — 27 passed
- `flake8 custom_components`
- `isort --diff --check custom_components`
- `black --line-length 88 --diff --check custom_components`