### PR TITLE
feat(art): normalise every upload path, not just the card (8.5.2b1)

### DIFF
--- a/custom_components/samsungtv_smart/api/_image_prep.py
+++ b/custom_components/samsungtv_smart/api/_image_prep.py
@@ -1,0 +1,90 @@
+"""Normalise images into something a Frame TV will actually decode.
+
+The Frame is far pickier than a browser. Progressive JPEGs, unusual chroma
+subsampling, CMYK, 16-bit or paletted samples, oversized EXIF blobs — and above
+all **images larger than the panel** — are happily *stored* by the TV and then
+fail to render: the artwork shows up as a grey rectangle with no thumbnail, and
+the TV never emits ``image_added``, so the upload also looks like it failed.
+
+The SmartThings app never hits this because it re-encodes before sending, so we
+do the same, once, for every upload path (the card, ``art_upload`` and
+``art_upload_batch``).
+
+Pillow — and the optional ``pillow-heif`` opener for iPhone HEIC — are imported
+lazily so a missing codec degrades this to a clean error instead of breaking the
+import of the whole integration. Everything here is blocking: call it from an
+executor.
+"""
+
+from __future__ import annotations
+
+import io
+
+# Panel size assumed when the TV has not reported its resolution yet.
+DEFAULT_PANEL = (3840, 2160)
+
+
+def panel_size(resolution: str | None) -> tuple[int, int]:
+    """Parse a TV-reported resolution ("3840x2160") into a (w, h) tuple.
+
+    Falls back to 4K on anything unparseable, so a TV that has not answered the
+    REST device-info call yet still gets a sane cap.
+    """
+    try:
+        width, height = (int(part) for part in str(resolution).lower().split("x", 1))
+    except (AttributeError, TypeError, ValueError):
+        return DEFAULT_PANEL
+    return (width, height) if width > 0 and height > 0 else DEFAULT_PANEL
+
+
+def fit_box(image_size: tuple[int, int], panel: tuple[int, int]) -> tuple[int, int]:
+    """Bounding box for an image, matched to the panel's orientation.
+
+    The panel's long and short edges are mapped onto the image's own long and
+    short edges. A landscape photo on a 3840x2160 Frame is capped at 3840x2160;
+    a portrait one at 2160x3840 — which is what a portrait-mounted Frame (the
+    art app has portrait mattes, and IP Control a display rotator) displays.
+    Capping a portrait image at 2160 tall instead would throw away half its
+    detail.
+    """
+    long_edge, short_edge = max(panel), min(panel)
+    width, height = image_size
+    return (short_edge, long_edge) if height > width else (long_edge, short_edge)
+
+
+def normalise_for_frame(
+    data: bytes, panel: tuple[int, int] = DEFAULT_PANEL
+) -> tuple[bytes, str]:
+    """Return (jpeg_bytes, ".jpg") the TV can decode. Blocking — use executor.
+
+    Encoding stays deliberately ordinary — quality 92 with standard 4:2:0
+    chroma — because that is what cameras, phones and the SmartThings app emit,
+    and what the TV reliably accepts; maximal settings (quality 100, 4:4:4)
+    were refused by the Frame. EXIF orientation is applied before the metadata
+    is dropped, so portrait photos are not sent sideways.
+    """
+    from PIL import Image, ImageOps  # noqa: PLC0415 - lazy: keep PIL out of import
+
+    try:
+        import pillow_heif  # noqa: PLC0415 - optional HEIC codec
+
+        pillow_heif.register_heif_opener()
+    except Exception:  # noqa: BLE001 - HEIC just stays unsupported without it
+        pass
+
+    with Image.open(io.BytesIO(data)) as img:
+        img = ImageOps.exif_transpose(img)  # honour rotation, then drop EXIF
+        rgb = img.convert("RGB")
+        box = fit_box(rgb.size, panel)
+        if rgb.width > box[0] or rgb.height > box[1]:
+            rgb.thumbnail(box, Image.LANCZOS)
+        out = io.BytesIO()
+        rgb.save(
+            out,
+            format="JPEG",
+            quality=92,
+            subsampling="4:2:0",
+            progressive=False,  # baseline only: TVs choke on progressive
+            optimize=False,
+        )
+    return out.getvalue(), ".jpg"

--- a/custom_components/samsungtv_smart/api/art.py
+++ b/custom_components/samsungtv_smart/api/art.py
@@ -30,6 +30,8 @@ import uuid
 
 import aiohttp
 
+from . import _image_prep
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -1935,8 +1937,15 @@ class SamsungTVAsyncArt:
         date: str | None = None,
         timeout: int = 30,
         hass=None,
+        panel: tuple[int, int] | None = None,
     ) -> str | None:
-        """Upload a new image to the TV."""
+        """Upload a new image to the TV.
+
+        The image is normalised (baseline JPEG, EXIF stripped, fitted to
+        ``panel``) before it is sent — see ``_image_prep``. Every upload path
+        funnels through here, so the card, ``art_upload`` and
+        ``art_upload_batch`` all get the same treatment.
+        """
         self._log.debug("Art API: Starting upload, file type: %s", type(file))
 
         if isinstance(file, str):
@@ -1961,6 +1970,26 @@ class SamsungTVAsyncArt:
             except Exception as ex:
                 self._log.error("Art API: Failed to read file: %s", ex)
                 return None
+
+        # Normalise to something the TV can actually decode. Done here rather
+        # than per-caller so the service and batch paths get it too; the batch
+        # fingerprints (mtime / perceptual hash) are computed on the SOURCE
+        # file before this, so skip-unchanged and dedup are unaffected.
+        try:
+            if hass is not None:
+                file, _suffix = await hass.async_add_executor_job(
+                    _image_prep.normalise_for_frame,
+                    file,
+                    panel or _image_prep.DEFAULT_PANEL,
+                )
+            else:
+                file, _suffix = _image_prep.normalise_for_frame(
+                    file, panel or _image_prep.DEFAULT_PANEL
+                )
+            file_type = "jpg"
+        except Exception as ex:  # noqa: BLE001 - unsupported/corrupt image
+            self._log.error("Art API: Could not prepare image for upload: %s", ex)
+            return None
 
         file_size = len(file)
         file_type = _detect_wire_type(file, hint=file_type)
@@ -2137,6 +2166,7 @@ class SamsungTVAsyncArt:
         throttle: float = 2.0,
         sidecar_path: str | None = None,
         dedup_dir: str | None = None,
+        panel: tuple[int, int] | None = None,
     ) -> dict:
         """Upload a list of image files, cheaply and idempotently.
 
@@ -2204,7 +2234,7 @@ class SamsungTVAsyncArt:
                 await asyncio.sleep(throttle)
             did_upload = True
 
-            content_id = await self.upload(path, matte=matte, hass=hass)
+            content_id = await self.upload(path, matte=matte, hass=hass, panel=panel)
             if content_id:
                 uploaded.append(content_id)
                 sidecar[name] = {"content_id": content_id, "modified": mtime}

--- a/custom_components/samsungtv_smart/http_upload.py
+++ b/custom_components/samsungtv_smart/http_upload.py
@@ -10,7 +10,6 @@ temp file → call the service → return the content_id.
 
 from __future__ import annotations
 
-import io
 import logging
 import os
 import tempfile
@@ -26,12 +25,6 @@ _LOGGER = logging.getLogger(__name__)
 
 # Guard against absurd uploads (Frame art is a few MB at most).
 _MAX_UPLOAD_BYTES = 50 * 1024 * 1024
-
-# Fallback panel size when the TV has not reported its resolution yet. Uploads
-# are fitted to the panel: more pixels than it can show buy nothing on screen
-# and are themselves a decode failure (the TV stores the entry, then displays a
-# grey rectangle). Aspect ratio is preserved and smaller images are left alone.
-_DEFAULT_PANEL = (3840, 2160)
 
 
 class SamsungArtUploadView(HomeAssistantView):
@@ -79,19 +72,11 @@ class SamsungArtUploadView(HomeAssistantView):
         if state is None or not entity_id.startswith("media_player."):
             return self.json_message(f"Unknown entity {entity_id}", 400)
 
-        # iPhones hand us HEIC/HEIF (often with a .jpeg name and image/jpeg
-        # type) which The Frame rejects. Transcode anything that is not already
-        # JPEG/PNG to JPEG before handing it to the upload service.
-        try:
-            data, suffix = await self._hass.async_add_executor_job(
-                _prepare_image, file_bytes, _panel_size(state)
-            )
-        except Exception as ex:  # noqa: BLE001 - surface a clean error to the card
-            _LOGGER.exception("Art upload: could not decode image")
-            return self.json_message(f"Unsupported or corrupt image: {ex}", 415)
-
+        # Hand the raw bytes to the upload service: it normalises every
+        # image (HEIC included) to a TV-safe baseline JPEG fitted to the
+        # panel, so the card, the service and the batch behave the same.
         tmp_path = await self._hass.async_add_executor_job(
-            _write_temp_file, data, suffix
+            _write_temp_file, file_bytes, ".img"
         )
         try:
             result = await self._hass.services.async_call(
@@ -112,85 +97,6 @@ class SamsungArtUploadView(HomeAssistantView):
         if isinstance(payload, dict) and payload.get("error"):
             return self.json_message(payload["error"], 502)
         return self.json(payload or {"success": True})
-
-
-def _panel_size(state) -> tuple[int, int]:
-    """Panel resolution from the entity's ``screen_resolution`` attribute.
-
-    Reported by the TV itself ("3840x2160", "7680x4320" on 8K sets), so the
-    upload cap follows the hardware instead of assuming 4K forever.
-    """
-    raw = (state.attributes or {}).get("screen_resolution") if state else None
-    try:
-        width, height = (int(part) for part in str(raw).lower().split("x", 1))
-    except (AttributeError, TypeError, ValueError):
-        return _DEFAULT_PANEL
-    return (width, height) if width > 0 and height > 0 else _DEFAULT_PANEL
-
-
-def _fit_box(image_size: tuple[int, int], panel: tuple[int, int]) -> tuple[int, int]:
-    """Bounding box for an image, matched to the panel's orientation.
-
-    The panel's long and short edges are mapped onto the image's own long and
-    short edges. A landscape photo on a 3840x2160 Frame is capped at 3840x2160;
-    a portrait one is capped at 2160x3840, which is what a portrait-mounted
-    Frame (the art app has portrait mattes, and IP Control a display rotator)
-    actually displays — capping it at 2160 tall instead would throw away half
-    the detail of a portrait artwork.
-    """
-    long_edge, short_edge = max(panel), min(panel)
-    width, height = image_size
-    return (short_edge, long_edge) if height > width else (long_edge, short_edge)
-
-
-def _prepare_image(data: bytes, panel: tuple[int, int]) -> tuple[bytes, str]:
-    """Re-encode any image into a plain JPEG the Frame is happy to decode.
-
-    Every upload is normalised, not just the exotic ones. The TV is far pickier
-    than a browser: progressive scans, CMYK, 16-bit or paletted samples and
-    oversized EXIF blobs are all things it may store and then fail to decode —
-    the artwork ends up as a grey rectangle and the TV never emits
-    ``image_added``. Re-encoding once, here, removes that whole class of
-    surprises (and is what the SmartThings app does before sending).
-
-    Encoding stays deliberately ordinary — ``quality=92`` with standard 4:2:0
-    chroma — because that is what cameras, phones and the SmartThings app emit,
-    and it is what the TV reliably accepts; maximal settings (quality=100,
-    4:4:4) were refused by the Frame. Images larger than the panel are fitted
-    to it (aspect preserved, see :func:`_fit_box`) — beyond that the extra
-    pixels buy nothing on screen and are themselves a decode failure. EXIF
-    orientation is applied before the metadata is dropped, so portrait photos
-    are not sent sideways.
-
-    Pillow (and the optional ``pillow-heif`` opener for iPhone HEIC) are
-    imported lazily so a missing codec never breaks importing this module.
-    Runs in an executor (blocking PIL).
-    """
-    from PIL import Image, ImageOps  # noqa: PLC0415 - lazy: keep PIL out of import
-
-    try:
-        import pillow_heif  # noqa: PLC0415 - optional HEIC codec
-
-        pillow_heif.register_heif_opener()
-    except Exception:  # noqa: BLE001 - HEIC just stays unsupported without it
-        pass
-
-    with Image.open(io.BytesIO(data)) as img:
-        img = ImageOps.exif_transpose(img)  # honour rotation, then drop EXIF
-        rgb = img.convert("RGB")
-        box = _fit_box(rgb.size, panel)
-        if rgb.width > box[0] or rgb.height > box[1]:
-            rgb.thumbnail(box, Image.LANCZOS)
-        out = io.BytesIO()
-        rgb.save(
-            out,
-            format="JPEG",
-            quality=92,
-            subsampling="4:2:0",  # what every camera/phone emits; TV-safe
-            progressive=False,  # baseline only: TVs choke on progressive
-            optimize=False,
-        )
-    return out.getvalue(), ".jpg"
 
 
 def _write_temp_file(data: bytes, suffix: str) -> str:

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.5.1"
+  "version": "8.5.2b1"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -3455,6 +3455,15 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             self.hass, entry, content_id, cache=cache, force=force
         )
 
+    def _art_panel_size(self) -> tuple[int, int]:
+        """Panel resolution for upload fitting, as the TV reports it."""
+        from .api._image_prep import panel_size  # noqa: PLC0415 - lazy
+
+        resolution = None
+        if (info := self._device_info) and (device := info.get("device")):
+            resolution = device.get("resolution")
+        return panel_size(resolution)
+
     async def _ensure_tv_awake_for_art(self) -> bool:
         """Ensure the TV is powered, WITHOUT forcing it into Art Mode.
 
@@ -3723,6 +3732,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 matte=matte_id,
                 file_type=file_type,
                 hass=self.hass,
+                panel=self._art_panel_size(),
             )
             if content_id:
                 self._log.info(
@@ -3805,6 +3815,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             throttle=throttle,
             sidecar_path=sidecar_path,
             dedup_dir=dedup_dir,
+            panel=self._art_panel_size(),
         )
 
         # Reflect the new art and fetch the (delayed) TV-side thumbnails.


### PR DESCRIPTION
Closes the asymmetry left by 8.5.1: the re-encode only covered the upload **card**. `art_upload` and `art_upload_batch` still sent raw bytes, so a progressive JPEG, a CMYK scan or an image wider than the panel still landed as a **grey rectangle** when uploaded through a service call or a folder batch — exactly the failure 8.5.1 was meant to end.

## Change

Normalisation moves to a shared `api/_image_prep.py` and is applied inside `SamsungTVAsyncArt.upload()`, which **every** path funnels through — card, service and batch now behave identically:

- decode any input (iPhone HEIC included),
- apply EXIF orientation, then drop all metadata,
- fit to the panel, orientation-aware,
- re-encode as baseline JPEG (quality 92, 4:2:0).

The panel size comes from the resolution the TV reports (`screen_resolution`), passed down from the entity, so 8K sets aren't capped at 4K and portrait artwork keeps its height. Falls back to 4K when the TV hasn't answered yet.

`http_upload.py` loses its private copy of the logic and just hands the raw bytes to the service.

## Batch semantics are unaffected

Worth stating explicitly, since re-encoding could plausibly break idempotency: **skip-unchanged (mtime) and perceptual dedup are computed on the SOURCE file** in `upload_batch`, before `upload()` is called. They keep seeing stable fingerprints, not the re-encoded bytes — so re-running a folder still uploads 0 files.

## Verified

Helper exercised directly (not just linted):

| panel | input | output |
|---|---|---|
| 3840×2160 | 4259×2160 progressive | 3840×1947, baseline |
| 7680×4320 | 4259×2160 | unchanged (fits) |
| 3840×2160 | 2160×4259 portrait | 1947×3840 |
| any | garbage bytes | raises cleanly → logged, upload returns `None` |

`manifest` → `8.5.2b1`.

## Test

Upload the same picture three ways to the 55" — via the card, via `samsungtv_smart.art_upload` with a `file_path`, and via `art_upload_batch` on a folder. All three should now produce a real preview. Re-running the batch should still report everything skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_