### PR TITLE
Fix Q-Symphony speaker selection fallback

### DIFF
--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -72,6 +72,25 @@ LIST_RESULT_KEY = "_list_result"
 CMD_TIMEOUT = 5  # seconds for normal commands
 PAIR_TIMEOUT = 30  # seconds: pairing waits for the on-screen acceptance
 
+
+def resolve_speaker_select_option(
+    value: str, external_devices: dict[str, str]
+) -> str:
+    """Return the public option name for a speaker output value.
+
+    Some Q-Symphony firmware reports the external speaker's device ID in
+    ``getTVStates.speakerSelect`` instead of a public target name. Resolve that
+    ID to the device name published by ``externalSpeakerControl`` and normalize
+    the standard target names reported with inconsistent capitalization.
+    """
+    for name, device_id in external_devices.items():
+        if value == device_id:
+            return name
+
+    public_options = {option.casefold(): option for option in SPEAKER_SELECT_OPTIONS}
+    return public_options.get(value.casefold(), value)
+
+
 # JSON-RPC error code returned when the access token is missing/expired.
 ERROR_UNAUTHORIZED = -32010
 # JSON-RPC "Parse error". Our requests are always well-formed JSON, and the 32"
@@ -370,11 +389,21 @@ class SamsungIPControl:
         ``speakerSelectControl`` called with no params echoes the current
         output, capitalized ("Internal"/"External") — unlike the mirror field
         in ``getTVStates`` which reports it lowercase.
+
+        Some Q-Symphony firmware returns ``null`` from this dedicated getter
+        while ``getTVStates.speakerSelect`` still contains the active external
+        device ID. Fall back to that snapshot so callers can resolve the ID
+        against ``externalSpeakerControl``.
         """
         result = await self._async_request("speakerSelectControl")
         value = result.get("speakerSelect")
         if not isinstance(value, str) or not value:
-            raise SamsungIPControlError(f"no speakerSelect in response: {result!r}")
+            states = await self.async_get_tv_states()
+            value = states.get("speakerSelect")
+        if not isinstance(value, str) or not value:
+            raise SamsungIPControlError(
+                "no speakerSelect in speakerSelectControl or getTVStates response"
+            )
         return value
 
     async def async_set_speaker_select(self, value: str) -> None:

--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -73,9 +73,7 @@ CMD_TIMEOUT = 5  # seconds for normal commands
 PAIR_TIMEOUT = 30  # seconds: pairing waits for the on-screen acceptance
 
 
-def resolve_speaker_select_option(
-    value: str, external_devices: dict[str, str]
-) -> str:
+def resolve_speaker_select_option(value: str, external_devices: dict[str, str]) -> str:
     """Return the public option name for a speaker output value.
 
     Some Q-Symphony firmware reports the external speaker's device ID in

--- a/custom_components/samsungtv_smart/select.py
+++ b/custom_components/samsungtv_smart/select.py
@@ -33,6 +33,7 @@ from .api.ipcontrol import (
     SamsungIPControlAuthError,
     SamsungIPControlError,
     SamsungIPControlModeLockedError,
+    resolve_speaker_select_option,
 )
 from .const import (
     AUTH_METHOD_OAUTH,
@@ -780,6 +781,7 @@ class SamsungTVIPControlSpeakerSelect(SelectEntity):
                 dev["deviceName"]: dev["deviceId"]
                 for dev in await client.async_get_external_speakers()
             }
+            current = resolve_speaker_select_option(current, self._external_devices)
         except SamsungIPControlAuthError as ex:
             _LOGGER.warning(
                 "IP Control speaker read for %s: token rejected (%s) — "

--- a/tests/api/test_ipcontrol_speaker_select.py
+++ b/tests/api/test_ipcontrol_speaker_select.py
@@ -1,0 +1,108 @@
+"""Tests for Samsung IP Control speaker output compatibility."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+def _load_ipcontrol_module():
+    """Load ipcontrol.py with a minimal Home Assistant type stub."""
+    homeassistant = types.ModuleType("homeassistant")
+    homeassistant_core = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:
+        """Type stub used only while importing the module."""
+
+    homeassistant_core.HomeAssistant = HomeAssistant
+    sys.modules.setdefault("homeassistant", homeassistant)
+    sys.modules.setdefault("homeassistant.core", homeassistant_core)
+
+    module_path = (
+        Path(__file__).parents[2]
+        / "custom_components"
+        / "samsungtv_smart"
+        / "api"
+        / "ipcontrol.py"
+    )
+    spec = importlib.util.spec_from_file_location("ipcontrol_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ipcontrol = _load_ipcontrol_module()
+
+
+class SpeakerSelectFallbackTest(unittest.IsolatedAsyncioTestCase):
+    """Verify the Q-Symphony fallback without network access."""
+
+    async def test_dedicated_getter_value_is_used(self):
+        """The normal dedicated getter remains the primary source."""
+        client = object.__new__(ipcontrol.SamsungIPControl)
+
+        async def fake_request(method, params=None):
+            self.assertEqual(method, "speakerSelectControl")
+            return {"speakerSelect": "Internal"}
+
+        client._async_request = fake_request
+
+        self.assertEqual(await client.async_get_speaker_select(), "Internal")
+
+    async def test_null_dedicated_getter_falls_back_to_tv_states(self):
+        """Q-Symphony's device ID is recovered from getTVStates."""
+        client = object.__new__(ipcontrol.SamsungIPControl)
+
+        async def fake_request(method, params=None):
+            if method == "speakerSelectControl":
+                return {"speakerSelect": None}
+            if method == "getTVStates":
+                return {"speakerSelect": "QSYM-RECEIVER"}
+            self.fail(f"unexpected method: {method}")
+
+        client._async_request = fake_request
+
+        self.assertEqual(
+            await client.async_get_speaker_select(),
+            "QSYM-RECEIVER",
+        )
+
+    async def test_missing_value_in_both_responses_is_an_error(self):
+        """A real missing capability still leaves the entity unavailable."""
+        client = object.__new__(ipcontrol.SamsungIPControl)
+
+        async def fake_request(method, params=None):
+            return {}
+
+        client._async_request = fake_request
+
+        with self.assertRaises(ipcontrol.SamsungIPControlError):
+            await client.async_get_speaker_select()
+
+
+class SpeakerSelectOptionResolutionTest(unittest.TestCase):
+    """Verify external IDs and standard values become valid select options."""
+
+    def test_q_symphony_device_id_resolves_to_name(self):
+        """The Q-Symphony ID maps to the option shown in Home Assistant."""
+        devices = {
+            "Q-Symphony": "QSYM-RECEIVER",
+            "Q6C Series Soundbar(HDMI)": "RCV-1",
+        }
+
+        self.assertEqual(
+            ipcontrol.resolve_speaker_select_option("QSYM-RECEIVER", devices),
+            "Q-Symphony",
+        )
+
+    def test_standard_value_is_normalized(self):
+        """The lowercase mirror value maps to the public option spelling."""
+        self.assertEqual(
+            ipcontrol.resolve_speaker_select_option("internal", {}),
+            "Internal",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- fall back to `getTVStates.speakerSelect` when `speakerSelectControl` returns `null`
- resolve external speaker device IDs such as `QSYM-RECEIVER` to the public option name from `externalSpeakerControl`
- normalize standard speaker option capitalization
- add focused regression tests

## Root cause

Some Q-Symphony firmware returns `null` from the dedicated speaker getter while still exposing the current output as an external device ID in `getTVStates`. The select entity rejected the null response and never mapped that device ID to a valid Home Assistant option, leaving the entity unavailable.

## Validation

- 5 regression tests passed
- Python compilation passed
- `git diff --check` passed
- live Home Assistant verification changed the entity from `unavailable` to `Q-Symphony`

Fixes #186
