### PR TITLE
feat(art-identify): discover models from the provider; fix Gemini 3.x (8.6.0b1)

### DIFF
--- a/RELEASE_NOTES_8.6.0.md
+++ b/RELEASE_NOTES_8.6.0.md
@@ -1,0 +1,118 @@
+# Release notes — 8.6.0
+
+If this project is useful to you, you can support its development:
+
+# <a href="https://buymeacoffee.com/thefab21" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-black.png" alt="Buy Me A Coffee" height="41" width="174"></a>
+
+> **Status: stable release.** Focused on Artwork Identification: it stops
+> breaking when a provider retires a model, and it works with the current
+> generation of reasoning models. No breaking changes; existing configurations
+> keep working.
+
+## Highlights
+
+- **The model list is now read from your provider**, instead of being
+  hardcoded — so a retired model no longer silently breaks identification.
+- **Gemini 3.x models work.** Identification failed with a cryptic JSON error
+  on the newer models; the cause was the reply being cut off, not malformed.
+- **A model that becomes unavailable now tells you so**, and lists the models
+  your key can actually use.
+
+---
+
+## Model discovery: pick from what your key can actually use
+
+Until now the model was a free-text field with a hardcoded default per
+provider. That gives every default an expiry date: when Google retired
+`gemini-2.5-flash` for new users, identification stopped working for everyone
+who had never touched the setting, with only a `404` in the log
+([#188](https://github.com/TheFab21/ha-samsungtv-smart/issues/188)).
+
+The integration now asks the provider what it offers, the same way Home
+Assistant's own Google Generative AI integration does:
+
+| provider | endpoint | filtering |
+|---|---|---|
+| Gemini | `GET /v1beta/models` | keeps only models supporting `generateContent` |
+| OpenAI | `GET /v1/models` | drops embeddings, audio, image and moderation models |
+| Anthropic | `GET /v1/models` | newest first, as returned by the API |
+
+**In the config flow** (*Configure → Art Identification*), once a provider and
+an API key are saved, the **Model** field becomes a dropdown listing the models
+that key can use. It stays free-text-capable, so a brand-new model missing from
+the list — or a fine-tune — can still be typed in. If the API can't be reached,
+the field simply falls back to plain text: a network problem never leaves you
+with an un-fillable form.
+
+**Leaving the model blank** no longer pins a constant. The best available model
+is chosen from the live list, preferring the cheap fast tiers (`flash-lite` /
+`flash`, `mini`, `haiku`) that suit this task — a constrained extraction, not a
+reasoning problem. Hardcoded values remain only as a last resort for when the
+list can't be read at all.
+
+## Gemini 3.x: replies were being cut off, not malformed
+
+Setting a newer Gemini model reached the API but failed with:
+
+```text
+Expecting ',' delimiter: line 20 column 6 (char 2439)
+```
+
+That looks like a broken model. It wasn't. On Gemini 2.5+/3.x, **"thinking"
+tokens are drawn from the same budget as the answer**, and these models reason
+by default. Our output cap was spent before the JSON was finished, so the reply
+arrived truncated mid-structure — hence a parse error at a seemingly random
+offset, differing between attempts. It also explains why `gemini-3.1-flash-lite`
+worked immediately: lite models think far less.
+
+Three changes:
+
+- **Thinking is disabled for this call** (`thinkingConfig.thinkingBudget = 0`).
+  Identification is a constrained extraction against a candidate list supplied
+  by the reverse image search — there is nothing to reason about.
+- **The output budget is raised** from 3 000 to 8 000 tokens, which the
+  five-language reply needs comfortably.
+- **JSON mode uses the documented REST spelling** (`responseMimeType`).
+
+## Clearer failures
+
+Two error paths that used to mislead:
+
+- **A truncated reply** now says so — *"LLM reply was cut off mid-JSON — the
+  model ran out of output tokens"* — instead of `Expecting ',' delimiter`,
+  which pointed at the wrong problem entirely.
+- **A retired or mistyped model** (HTTP 404) now raises a distinct error naming
+  the models your key *can* use, and pointing at *Configure → Art
+  Identification*. Previously it retried forever against a model that no longer
+  exists.
+
+---
+
+## Upgrade notes
+
+- No configuration changes. Update via HACS and restart Home Assistant.
+- **If Artwork Identification stopped working**, open *Configure → Art
+  Identification*, clear the **Model** field and save: the best available model
+  for your key is selected automatically. Re-opening the page then shows the
+  full dropdown.
+- Nothing else in the integration is affected — this release touches only the
+  identification pipeline and its configuration step.
+
+---
+
+## Changelog
+
+- **New:** the model list is fetched from the provider (Gemini, OpenAI,
+  Anthropic) and offered as a dropdown in the config flow, with free text kept
+  as an escape hatch.
+- **New:** a blank model resolves to the best model the key can use, chosen
+  from the live list instead of a hardcoded constant.
+- **Fix:** Gemini 2.5+/3.x replies were truncated because thinking tokens share
+  the output budget — thinking is now disabled for this call and the budget
+  raised ([#188](https://github.com/TheFab21/ha-samsungtv-smart/issues/188)).
+- **Fix:** Gemini JSON mode uses the documented REST field name
+  (`responseMimeType`).
+- **Fix:** a truncated LLM reply is reported as such, instead of a misleading
+  JSON delimiter error.
+- **Fix:** an unavailable model raises a dedicated error listing usable models
+  rather than failing silently on every artwork.

--- a/RELEASE_NOTES_8.6.0.md
+++ b/RELEASE_NOTES_8.6.0.md
@@ -74,6 +74,30 @@ Three changes:
   five-language reply needs comfortably.
 - **JSON mode uses the documented REST spelling** (`responseMimeType`).
 
+## The same hardening for OpenAI and Anthropic
+
+Truncation is not a Gemini quirk — OpenAI's reasoning models (o-series, gpt-5)
+also spend reasoning tokens from `max_completion_tokens`, and any model can be
+cut short by a budget that is too tight. So instead of inferring truncation
+from a parse error after the fact, the integration now reads **the provider's
+own stop signal**:
+
+| provider | field | truncated when |
+|---|---|---|
+| Anthropic | `stop_reason` | `max_tokens` |
+| OpenAI | `choices[].finish_reason` | `length` |
+| Gemini | `candidates[].finishReason` | `MAX_TOKENS` |
+
+The raised output budget (8 000 tokens) and the model-discovery dropdown apply
+to all three providers as well — only the thinking switch is Gemini-specific,
+because it is the only one of the three that reasons by default on this call.
+
+> **A note on Anthropic:** prefilling the assistant turn with `{` is the classic
+> trick for forcing JSON, but it is no longer supported on Claude 4.6 / Sonnet
+> 4.5 and later — adopting it would have re-created exactly the kind of
+> obsolescence this release fixes. Claude keeps the prompt-driven JSON contract,
+> now backed by explicit truncation detection.
+
 ## Clearer failures
 
 Two error paths that used to mislead:
@@ -112,7 +136,8 @@ Two error paths that used to mislead:
   raised ([#188](https://github.com/TheFab21/ha-samsungtv-smart/issues/188)).
 - **Fix:** Gemini JSON mode uses the documented REST field name
   (`responseMimeType`).
-- **Fix:** a truncated LLM reply is reported as such, instead of a misleading
-  JSON delimiter error.
+- **Fix:** truncation is detected from each provider's own stop signal
+  (`stop_reason` / `finish_reason` / `finishReason`) and reported as such,
+  instead of a misleading JSON delimiter error.
 - **Fix:** an unavailable model raises a dedicated error listing usable models
   rather than failing silently on every artwork.

--- a/RELEASE_NOTES_8.6.0.md
+++ b/RELEASE_NOTES_8.6.0.md
@@ -92,11 +92,23 @@ The raised output budget (8 000 tokens) and the model-discovery dropdown apply
 to all three providers as well — only the thinking switch is Gemini-specific,
 because it is the only one of the three that reasons by default on this call.
 
+All three providers now also constrain the reply format at the API level rather
+than trusting the prompt:
+
+| provider | mechanism |
+|---|---|
+| Anthropic | `output_config.format` with a JSON Schema |
+| OpenAI | `response_format: {"type": "json_object"}` |
+| Gemini | `responseMimeType: "application/json"` |
+
 > **A note on Anthropic:** prefilling the assistant turn with `{` is the classic
 > trick for forcing JSON, but it is no longer supported on Claude 4.6 / Sonnet
 > 4.5 and later — adopting it would have re-created exactly the kind of
-> obsolescence this release fixes. Claude keeps the prompt-driven JSON contract,
-> now backed by explicit truncation detection.
+> obsolescence this release fixes. Structured outputs are the supported
+> replacement, and the schema is generated from the same constants the parser
+> uses, so the two cannot drift apart. Models released before the feature reject
+> it with a `400`; that case is detected and retried once without it, falling
+> back to the prompt-driven contract instead of failing.
 
 ## Clearer failures
 
@@ -136,6 +148,9 @@ Two error paths that used to mislead:
   raised ([#188](https://github.com/TheFab21/ha-samsungtv-smart/issues/188)).
 - **Fix:** Gemini JSON mode uses the documented REST field name
   (`responseMimeType`).
+- **New:** Anthropic replies are constrained by a JSON Schema
+  (`output_config.format`), with an automatic fallback for models that predate
+  structured outputs.
 - **Fix:** truncation is detected from each provider's own stop signal
   (`stop_reason` / `finish_reason` / `finishReason`) and reported as such,
   instead of a misleading JSON delimiter error.

--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -72,6 +72,14 @@ class LLMError(Exception):
     """LLM confirmation call failed or returned unparseable output."""
 
 
+class ModelUnavailableError(LLMError):
+    """The configured model was rejected by the provider (retired/typo).
+
+    A subclass so existing handlers keep catching it, while callers that care
+    can tell a configuration problem apart from a transport failure.
+    """
+
+
 _VISION_URL = "https://vision.googleapis.com/v1/images:annotate"
 _ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
 _ANTHROPIC_VERSION = "2023-06-01"
@@ -87,7 +95,14 @@ _HTTP_TIMEOUT = 45  # seconds per external call
 # title + three prose fields in every LANGS language — or the reply is
 # truncated and fails to parse. 700 was fine single-language; 5 languages need
 # far more headroom.
-_LLM_MAX_TOKENS = 3000
+_LLM_MAX_TOKENS = 8000
+
+# Gemini 2.5+/3.x spend "thinking" tokens from the SAME budget as the answer,
+# and reason by default. With a modest cap the reply is cut off mid-JSON —
+# which surfaces as a cryptic "Expecting ',' delimiter" rather than a quota
+# error (issue #188). Disable thinking for this task: it is a constrained
+# extraction against a supplied candidate list, not a reasoning problem.
+_GEMINI_THINKING_BUDGET = 0
 
 # Languages the metadata is produced in, so each viewer can be shown the
 # artwork description in their own UI language (the Lovelace card picks by the
@@ -264,12 +279,40 @@ def _build_llm_prompt(candidates: dict[str, list[str]]) -> str:
 
 
 def _parse_llm_json(raw: str) -> dict[str, Any]:
-    """Extract the JSON object from an LLM reply, tolerating stray fences/prose."""
-    start = raw.find("{")
-    end = raw.rfind("}")
-    if start == -1 or end == -1 or end < start:
-        raise LLMError(f"no JSON object in LLM reply: {raw[:200]}")
-    return json.loads(raw[start : end + 1])
+    """Extract the JSON object from an LLM reply, tolerating stray fences/prose.
+
+    Raises a *diagnosable* error when the reply was cut short. A truncated
+    answer used to surface as ``Expecting ',' delimiter: line 20 column 6``,
+    which tells the user nothing about the actual cause (the model spent its
+    token budget before finishing the JSON — see ``_GEMINI_THINKING_BUDGET``).
+    """
+    text = raw.strip()
+    if not text:
+        raise LLMError("empty LLM reply (model returned no text)")
+
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1:
+        raise LLMError(f"no JSON object in LLM reply: {text[:200]}")
+
+    if end < start:
+        raise LLMError(
+            "LLM reply was cut off before the JSON closed — the model ran out "
+            f"of output tokens. Reply ended with: ...{text[-120:]!r}"
+        )
+
+    try:
+        return json.loads(text[start : end + 1])
+    except json.JSONDecodeError as ex:
+        # An unbalanced brace count is the signature of a truncated reply,
+        # as opposed to a genuinely malformed one.
+        candidate = text[start : end + 1]
+        if candidate.count("{") != candidate.count("}"):
+            raise LLMError(
+                "LLM reply was cut off mid-JSON — the model ran out of output "
+                f"tokens ({ex}). Try a lighter model or a larger budget."
+            ) from ex
+        raise LLMError(f"could not parse LLM JSON ({ex}): {candidate[:200]}") from ex
 
 
 async def async_llm_confirm(
@@ -360,7 +403,10 @@ async def async_llm_confirm(
             "generationConfig": {
                 "temperature": 0.1,
                 "maxOutputTokens": _LLM_MAX_TOKENS,
-                "response_mime_type": "application/json",
+                # camelCase is the documented REST spelling (the snake_case
+                # form is the Python SDK's).
+                "responseMimeType": "application/json",
+                "thinkingConfig": {"thinkingBudget": _GEMINI_THINKING_BUDGET},
             },
         }
         # Gemini takes the key as a query param, not a header.
@@ -373,6 +419,22 @@ async def async_llm_confirm(
     ) as resp:
         if resp.status != 200:
             text = await resp.text()
+            # A retired or mistyped model is a configuration problem, not a
+            # transient failure: retrying it forever just burns quota and
+            # leaves a cryptic 404 in the log. Name the alternatives instead.
+            if resp.status == 404:
+                available = await async_list_models(session, provider, api_key)
+                suggestion = (
+                    f" Available models for this key include: "
+                    f"{', '.join(available[:8])}."
+                    if available
+                    else ""
+                )
+                raise ModelUnavailableError(
+                    f"{provider} model {model!r} is not available to this API "
+                    f"key.{suggestion} Update it under Configure → Art "
+                    f"Identification."
+                )
             raise LLMError(f"{provider} API {resp.status}: {text[:200]}")
         data = await resp.json()
 
@@ -582,3 +644,124 @@ async def async_identify_for_entry(
     )
     result["content_id"] = content_id
     return result
+
+
+# --- Model discovery -------------------------------------------------------
+#
+# Hardcoding a model id gives it an expiry date: providers retire models and
+# the integration then fails with a 404 for everyone who never touched the
+# setting (issue #188, where the pinned gemini-2.5-flash became unavailable to
+# new users). Ask the provider what it actually offers instead, the way Home
+# Assistant's own Google Generative AI integration does.
+
+_MODELS_URL = {
+    "anthropic": "https://api.anthropic.com/v1/models",
+    "openai": "https://api.openai.com/v1/models",
+    "gemini": "https://generativelanguage.googleapis.com/v1beta/models",
+}
+
+# Preference order used to pick a default from the live list: cheap, fast,
+# vision-capable models first. Matched as substrings, best match wins.
+_MODEL_PREFERENCE = {
+    "anthropic": ("haiku", "sonnet"),
+    "openai": ("mini", "gpt-4o", "gpt-4"),
+    "gemini": ("flash-lite", "flash"),
+}
+
+# Substrings marking models that cannot do the job (no vision, or a different
+# modality entirely), so they never reach the picker.
+_MODEL_EXCLUDE = (
+    "embed",
+    "tts",
+    "whisper",
+    "audio",
+    "moderation",
+    "image-",
+    "dall-e",
+    "realtime",
+    "transcribe",
+    "search",
+    "veo",
+    "imagen",
+)
+
+
+async def async_list_models(
+    session: ClientSession, provider: str, api_key: str
+) -> list[str]:
+    """Return the model ids this key can actually use, best candidates first.
+
+    Raises :class:`LLMError` when the key is rejected or the provider is
+    unreachable, so the config flow can report a precise reason instead of
+    silently offering an empty list.
+    """
+    url = _MODELS_URL.get(provider)
+    if url is None:
+        raise LLMError(f"unknown LLM provider: {provider!r}")
+
+    headers: dict[str, str] = {}
+    params: dict[str, str] = {}
+    if provider == "anthropic":
+        headers = {"x-api-key": api_key, "anthropic-version": _ANTHROPIC_VERSION}
+        params = {"limit": "1000"}
+    elif provider == "openai":
+        headers = {"Authorization": f"Bearer {api_key}"}
+    else:  # gemini takes the key as a query param
+        params = {"key": api_key, "pageSize": "1000"}
+
+    async with session.get(
+        url, headers=headers, params=params, timeout=_HTTP_TIMEOUT
+    ) as resp:
+        if resp.status != 200:
+            text = await resp.text()
+            raise LLMError(f"{provider} model list {resp.status}: {text[:200]}")
+        data = await resp.json()
+
+    names: list[str] = []
+    if provider == "gemini":
+        for item in data.get("models") or []:
+            # Only models that can answer a generateContent call are usable.
+            if "generateContent" not in (item.get("supportedGenerationMethods") or []):
+                continue
+            # The API returns "models/gemini-x"; the request path wants the bare id.
+            names.append(str(item.get("name", "")).removeprefix("models/"))
+    else:  # anthropic and openai share the {"data": [{"id": ...}]} shape
+        names = [str(item.get("id", "")) for item in data.get("data") or []]
+
+    usable = [
+        name
+        for name in names
+        if name and not any(bad in name.lower() for bad in _MODEL_EXCLUDE)
+    ]
+    return sort_models_by_preference(provider, usable)
+
+
+def sort_models_by_preference(provider: str, models: list[str]) -> list[str]:
+    """Order models so the cheapest sensible default comes first.
+
+    Within a preference tier the provider's own order is kept (Anthropic
+    returns newest first, and for the others alphabetical is stable enough),
+    so a newly released haiku outranks last year's.
+    """
+    preference = _MODEL_PREFERENCE.get(provider, ())
+
+    def rank(name: str) -> tuple[int, str]:
+        lowered = name.lower()
+        for index, token in enumerate(preference):
+            if token in lowered:
+                return (index, "")
+        return (len(preference), lowered)
+
+    return sorted(models, key=rank)
+
+
+async def async_pick_default_model(
+    session: ClientSession, provider: str, api_key: str
+) -> str | None:
+    """Best available model for a provider, or None if the list can't be read."""
+    try:
+        models = await async_list_models(session, provider, api_key)
+    except (LLMError, ClientError, TimeoutError) as ex:
+        _LOGGER.debug("Could not list %s models: %s", provider, ex)
+        return None
+    return models[0] if models else None

--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -438,6 +438,8 @@ async def async_llm_confirm(
             raise LLMError(f"{provider} API {resp.status}: {text[:200]}")
         data = await resp.json()
 
+    _raise_if_truncated(provider, model, data)
+
     if provider == "anthropic":
         blocks = data.get("content") or []
         raw = next((b.get("text", "") for b in blocks if b.get("type") == "text"), "")
@@ -451,6 +453,34 @@ async def async_llm_confirm(
     _LOGGER.debug("LLM (%s/%s) raw reply: %s", provider, model, raw[:600])
     parsed = _parse_llm_json(raw)
     return _normalize_result(parsed)
+
+
+def _raise_if_truncated(provider: str, model: str, data: dict[str, Any]) -> None:
+    """Fail loudly when the provider says it stopped at the token limit.
+
+    Every provider reports this in its own field, and all three can hit it the
+    same way: reasoning/thinking tokens are drawn from the reply budget, so a
+    model that reasons a lot returns a JSON object cut mid-structure. Reading
+    the provider's own signal is far more reliable than inferring it from a
+    parse error after the fact (issue #188).
+    """
+    if provider == "anthropic":
+        reason = data.get("stop_reason")
+        truncated = reason == "max_tokens"
+    elif provider == "gemini":
+        reason = (data.get("candidates") or [{}])[0].get("finishReason")
+        truncated = reason == "MAX_TOKENS"
+    else:  # openai
+        reason = (data.get("choices") or [{}])[0].get("finish_reason")
+        truncated = reason == "length"
+
+    if truncated:
+        raise LLMError(
+            f"{provider} model {model!r} hit its output limit "
+            f"({_LLM_MAX_TOKENS} tokens) before finishing the JSON "
+            f"(stop reason {reason!r}). Pick a lighter model — reasoning "
+            f"models spend this budget thinking before they answer."
+        )
 
 
 def _normalize_result(parsed: dict[str, Any]) -> dict[str, Any]:

--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -278,6 +278,44 @@ def _build_llm_prompt(candidates: dict[str, list[str]]) -> str:
     )
 
 
+def _anthropic_output_schema() -> dict[str, Any]:
+    """JSON Schema for the identification reply, in Anthropic's strict dialect.
+
+    Built from the key tuples above so it can never drift from what
+    ``_normalize_result`` expects. Three constraints the API enforces:
+    ``additionalProperties: false`` on every object, no recursion, and no
+    numeric/length keywords (``minimum``, ``minLength``, ...) — so the shape is
+    expressed with types and ``required`` alone.
+    """
+    translated = {
+        "type": "object",
+        "properties": {
+            field: {"type": ["string", "null"]} for field in TRANSLATED_FIELDS
+        },
+        "required": list(TRANSLATED_FIELDS),
+        "additionalProperties": False,
+    }
+    return {
+        "type": "object",
+        "properties": {
+            "identified": {"type": "boolean"},
+            "confidence": {"type": ["number", "null"]},
+            "matched_candidate": {"type": ["string", "null"]},
+            "artist": {"type": ["string", "null"]},
+            "date": {"type": ["string", "null"]},
+            "suggested_search_query": {"type": ["string", "null"]},
+            "translations": {
+                "type": "object",
+                "properties": {lang: translated for lang in LANGS},
+                "required": list(LANGS),
+                "additionalProperties": False,
+            },
+        },
+        "required": [*TOP_LEVEL_KEYS, "translations"],
+        "additionalProperties": False,
+    }
+
+
 def _parse_llm_json(raw: str) -> dict[str, Any]:
     """Extract the JSON object from an LLM reply, tolerating stray fences/prose.
 
@@ -354,6 +392,16 @@ async def async_llm_confirm(
                     ],
                 }
             ],
+            # Structured outputs (GA, no beta header): the API constrains the
+            # reply to this schema instead of us hoping the prompt was obeyed.
+            # Dropped and retried without it on models that predate the feature
+            # — see the 400 handling below.
+            "output_config": {
+                "format": {
+                    "type": "json_schema",
+                    "schema": _anthropic_output_schema(),
+                }
+            },
         }
         url = _ANTHROPIC_URL
     elif provider == "openai":
@@ -414,11 +462,35 @@ async def async_llm_confirm(
     else:
         raise LLMError(f"unknown LLM provider: {provider!r}")
 
-    async with session.post(
-        url, json=body, headers=headers, timeout=_HTTP_TIMEOUT
-    ) as resp:
-        if resp.status != 200:
+    # Two attempts at most: the retry exists only to drop `output_config` for a
+    # model that predates structured outputs. Everything else fails on the
+    # first pass.
+    for attempt in (1, 2):
+        async with session.post(
+            url, json=body, headers=headers, timeout=_HTTP_TIMEOUT
+        ) as resp:
+            if resp.status == 200:
+                data = await resp.json()
+                break
+
             text = await resp.text()
+            # An older Claude rejects output_config with a 400. Drop it and
+            # retry — the prompt still asks for the same JSON, so we degrade to
+            # the previous contract instead of failing outright.
+            if (
+                attempt == 1
+                and resp.status == 400
+                and "output_config" in body
+                and "output_config" in text
+            ):
+                _LOGGER.debug(
+                    "Art identify: %s rejected structured outputs, retrying "
+                    "with the prompt-only JSON contract",
+                    model,
+                )
+                body.pop("output_config", None)
+                continue
+
             # A retired or mistyped model is a configuration problem, not a
             # transient failure: retrying it forever just burns quota and
             # leaves a cryptic 404 in the log. Name the alternatives instead.
@@ -436,7 +508,6 @@ async def async_llm_confirm(
                     f"Identification."
                 )
             raise LLMError(f"{provider} API {resp.status}: {text[:200]}")
-        data = await resp.json()
 
     _raise_if_truncated(provider, model, data)
 

--- a/custom_components/samsungtv_smart/config_flow.py
+++ b/custom_components/samsungtv_smart/config_flow.py
@@ -1317,6 +1317,57 @@ class OptionsFlowHandler(OptionsFlow):
             ],
         )
 
+    async def _async_llm_model_selector(self, data):
+        """Model field: a live dropdown when the provider can be queried.
+
+        Falls back to free text when no key is stored yet or the provider is
+        unreachable — the field must never become un-fillable just because the
+        network is down. ``custom_value`` stays on so a model missing from the
+        list (brand new, or a fine-tune) can still be typed in.
+        """
+        from .art_identify import async_list_models  # noqa: PLC0415 - lazy
+
+        provider = data.get(CONF_ART_LLM_PROVIDER)
+        api_key = data.get(CONF_ART_LLM_API_KEY)
+        if not provider or not api_key:
+            return str
+
+        try:
+            models = await async_list_models(
+                async_get_clientsession(self.hass), provider, api_key
+            )
+        except Exception as ex:  # noqa: BLE001 - never block the form
+            _LOGGER.debug("Could not list %s models for the form: %s", provider, ex)
+            return str
+
+        if not models:
+            return str
+
+        current = data.get(CONF_ART_LLM_MODEL)
+        if current and current not in models:
+            # Keep a retired/pinned model selectable so the form shows the
+            # truth instead of silently swapping it for something else.
+            models = [current, *models]
+        return SelectSelector(
+            SelectSelectorConfig(
+                options=[SelectOptionDict(value=m, label=m) for m in models],
+                mode=SelectSelectorMode.DROPDOWN,
+                custom_value=True,
+            )
+        )
+
+    async def _async_pick_llm_model(self, data) -> str | None:
+        """Best model for the configured provider/key, or None if unknown."""
+        from .art_identify import async_pick_default_model  # noqa: PLC0415 - lazy
+
+        provider = data.get(CONF_ART_LLM_PROVIDER)
+        api_key = data.get(CONF_ART_LLM_API_KEY)
+        if not provider or not api_key:
+            return None
+        return await async_pick_default_model(
+            async_get_clientsession(self.hass), provider, api_key
+        )
+
     async def async_step_art_identify(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -1349,7 +1400,14 @@ class OptionsFlowHandler(OptionsFlow):
                 if value:
                     new_data[key] = value
                 elif key == CONF_ART_LLM_MODEL:
-                    new_data.pop(key, None)  # blank model -> fall back to default
+                    # Blank model: resolve the best model this key can
+                    # actually use, rather than pinning a constant that the
+                    # provider will eventually retire (issue #188).
+                    picked = await self._async_pick_llm_model(new_data)
+                    if picked:
+                        new_data[key] = picked
+                    else:
+                        new_data.pop(key, None)
             self.hass.config_entries.async_update_entry(entry, data=new_data)
             return await self.async_step_menu()
 
@@ -1374,7 +1432,7 @@ class OptionsFlowHandler(OptionsFlow):
             vol.Optional(
                 CONF_ART_LLM_MODEL,
                 default=data.get(CONF_ART_LLM_MODEL, ""),
-            ): str,
+            ): await self._async_llm_model_selector(data),
             vol.Required(
                 CONF_ART_IDENTIFY_PERSONAL,
                 default=data.get(CONF_ART_IDENTIFY_PERSONAL, False),

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -97,11 +97,15 @@ CONF_ART_IDENTIFY_PERSONAL = "art_identify_personal"
 
 ART_LLM_PROVIDERS = ("anthropic", "openai", "gemini")
 DEFAULT_ART_LLM_PROVIDER = "anthropic"
-# Sensible current defaults; user-overridable in the options.
+# Last-resort defaults, used ONLY when the provider's model list cannot be
+# read (no key yet, or the API is unreachable). The real default is picked
+# from the live list — see art_identify.async_pick_default_model — because a
+# pinned id eventually gets retired and breaks identification for everyone who
+# never touched the setting (issue #188).
 DEFAULT_ART_LLM_MODEL = {
     "anthropic": "claude-haiku-4-5",
-    "openai": "gpt-4o",
-    "gemini": "gemini-2.5-flash",
+    "openai": "gpt-4o-mini",
+    "gemini": "gemini-flash-latest",
 }
 
 # Cache TTLs (seconds). A successful identification never changes, so it is kept

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.5.3"
+  "version": "8.6.0b1"
 }


### PR DESCRIPTION
Closes #188. Both parts of the issue, plus the release notes for 8.6.

## 1. Gemini 3.x — the reply was truncated, not malformed

Setting a newer Gemini model reached the API but failed with `Expecting ',' delimiter: line 20 column 6`. That reads like a broken model; it isn't.

On **Gemini 2.5+/3.x, thinking tokens are drawn from the same budget as the answer**, and those models reason by default. Our 3 000-token cap was spent before the JSON closed, so the reply arrived cut mid-structure — hence a parse error at a different offset on each attempt (char 2439, then 1552). It also explains why `gemini-3.1-flash-lite` worked immediately: lite models think far less. Same root cause as [ha-llmvision#609](https://github.com/valentinfrlch/ha-llmvision/issues/609).

- `thinkingConfig.thinkingBudget = 0` — this is a constrained extraction against candidates supplied by the reverse image search, not a reasoning task.
- Output budget 3 000 → 8 000, which the five-language reply needs.
- JSON mode now uses the documented REST spelling `responseMimeType` (the snake_case form is the Python SDK's; Google accepts both, so this is alignment rather than a fix).

## 2. Model discovery — stop hardcoding an expiry date

A pinned model id breaks for everyone who never touched the setting the day the provider retires it. The integration now asks what the key can actually use, the way HA's own `google_generative_ai_conversation` config flow does:

| provider | endpoint | filtering |
|---|---|---|
| Gemini | `GET /v1beta/models` | only models supporting `generateContent` |
| OpenAI | `GET /v1/models` | drops embeddings / audio / image / moderation |
| Anthropic | `GET /v1/models` | newest first, as returned |

The **Model** field becomes a dropdown once a provider and key are stored, with `custom_value=True` so a brand-new model or a fine-tune can still be typed. If the API is unreachable it falls back to plain text — a network problem must never leave an un-fillable form. A **blank model** now resolves from the live list, preferring the cheap fast tiers (`flash-lite`/`flash`, `mini`, `haiku`). Hardcoded values remain only as a last resort.

## 3. Failures that diagnose themselves

- A truncated reply now says *"LLM reply was cut off mid-JSON — the model ran out of output tokens"* instead of a delimiter error pointing at the wrong problem.
- A 404 raises a dedicated `ModelUnavailableError` **naming the models the key can use** and pointing at *Configure → Art Identification*, instead of retrying a dead model on every artwork.

## Verified

Exercised the real code paths, not just linted:

- **Parser** against the issue's exact inputs — clean JSON, markdown fences, prose-wrapped, truncated (both shapes), empty, no-JSON — each produces the right outcome, truncation now correctly identified.
- **Discovery** with mocked provider responses: each payload shape parsed, noise filtered (`text-embedding-3-large`, `whisper-1`, `dall-e-3`, `imagen-4.0`, `veo-3` all dropped), correct auth per provider (`x-api-key` / `Bearer` / query param), and the key passed as a parameter rather than concatenated into the URL so it can't leak into logs.
- **Ranking**: Gemini returns `gemini-3.1-flash-lite` first — the very model that worked for the reporter.
- **Failure modes**: unknown provider, rejected key, and API down all degrade cleanly (the last returns `None`, falling back to the constant).

`manifest` → `8.6.0b1`, plus `RELEASE_NOTES_8.6.0.md`.

## Test

With a Gemini key: clear the **Model** field and save — it should auto-select a working model; re-open the page and the dropdown should list your available models. Then trigger an identification and confirm it succeeds where `gemini-3.6-flash` previously failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_