### PR TITLE
fix(art): upload to a Frame that is actually reachable, and fail fast when none is

### DIFF
--- a/RELEASE_NOTES_8.6.0.md
+++ b/RELEASE_NOTES_8.6.0.md
@@ -110,6 +110,24 @@ than trusting the prompt:
 > it with a `400`; that case is detected and retried once without it, falling
 > back to the prompt-driven contract instead of failing.
 
+## Uploading to a Frame that is not there
+
+Two problems compounded when one TV of several was unreachable.
+
+**The gallery card sent uploads to the wrong Frame.** It discovers Frames by
+looking for the `art_mode_status` attribute, which an unreachable TV does not
+expose — so with two configured and one down, discovery returned a single
+Frame. That failed the "more than one, ask the user" test, so no chooser
+appeared and the card fell back to the entity named in the card's YAML: the
+very TV discovery had just excluded for being unreachable. Now a single
+discovered Frame is used directly; two or more still open the chooser.
+
+**And the upload then hung silently.** `art_upload` tried to wake the TV,
+waited on a power-on that could never complete, and reported nothing. The
+integration now tells a TV in standby (which still answers its REST endpoint)
+apart from one that is unplugged or faulty (which does not), and fails straight
+away with *"<host> is unreachable — cannot upload"* instead of stalling.
+
 ## Clearer failures
 
 Two error paths that used to mislead:
@@ -156,3 +174,7 @@ Two error paths that used to mislead:
   instead of a misleading JSON delimiter error.
 - **Fix:** an unavailable model raises a dedicated error listing usable models
   rather than failing silently on every artwork.
+- **Fix:** the gallery card uploads to a Frame that is actually reachable
+  instead of falling back to the configured entity when only one is found.
+- **Fix:** an upload to an unreachable TV fails immediately with a clear
+  message instead of hanging on a power-on that cannot happen.

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -3513,6 +3513,18 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             except Exception:  # noqa: BLE001 - best effort probe
                 pass
 
+        # Off, or gone. Tell the two apart before spending 10s trying to wake
+        # something that will never answer: a Frame in standby still serves its
+        # REST endpoint, an unplugged or faulty one does not. Without this an
+        # upload to a dead TV simply hung with nothing in the UI to explain it.
+        if await self._async_load_device_info(force=True) is None:
+            self._log.warning(
+                "Frame Art: %s is unreachable — cannot upload. Check the TV is "
+                "powered at the mains and on the network.",
+                self._host,
+            )
+            return False
+
         # Genuinely off: power it on, then leave the mode alone.
         ip_client = self._get_ip_control_client()
         if ip_client is not None:
@@ -3717,7 +3729,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
         # Only needs the art app reachable — do not force Art Mode on.
         if not await self._ensure_tv_awake_for_art():
-            return {"error": "Failed to turn on TV"}
+            return {"error": "TV unreachable or could not be turned on"}
 
         try:
             # Check if file exists
@@ -3798,7 +3810,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             return {"error": "Frame TV not supported"}
         # Writing to the art library does not require the panel to show art.
         if not await self._ensure_tv_awake_for_art():
-            return {"error": "Failed to turn on TV"}
+            return {"error": "TV unreachable or could not be turned on"}
 
         from .api._upload_sidecar import list_images
 

--- a/custom_components/samsungtv_smart/www/folder-gallery-card.js
+++ b/custom_components/samsungtv_smart/www/folder-gallery-card.js
@@ -1237,15 +1237,23 @@ class FolderGalleryCard extends HTMLElement {
     if (!action.service && !action.perform_action) return;
 
     // Multi-frame upload routing.
-    // When the action is an upload, the gallery points at a local photo
+    // When the action is an upload and the gallery points at a local photo
     // source (folder not store/personal AND image not a SAM-/MY_ content id),
-    // and more than one Frame TV is present, ask the user which Frame to
-    // upload to instead of using the configured entity. Every other case
-    // keeps the original behaviour untouched.
+    // route to a Frame that is actually there rather than to whatever entity
+    // the YAML happens to name. Every other case keeps the original behaviour.
     if (this._isUploadAction(action) && this._isLocalPhotoSource(imageData)) {
       const frames = this._discoverFrames();
       if (frames.length > 1) {
         this._openFrameChooser(imageData, action, frames);
+        return;
+      }
+      if (frames.length === 1) {
+        // Exactly one Frame: use it. Discovery only lists TVs currently
+        // exposing art_mode_status, so a configured-but-unreachable TV drops
+        // out of the list -- and silently falling back to the configured
+        // entity sent uploads to a TV that was powered off or removed, with no
+        // chooser shown to reveal the mismatch.
+        this._dispatchAction(imageData, action, frames[0].entity_id);
         return;
       }
     }


### PR DESCRIPTION
Two upload bugs that compounded when one TV of several is unreachable. Found from logs where three gallery-card uploads silently went to a TV that was off and awaiting repair, with no chooser shown and no error.

## 1. The gallery card sent uploads to the wrong Frame

`_discoverFrames()` lists media_players exposing `art_mode_status` — an attribute an unreachable TV does not have (the integration can't confirm Frame support, and logs `Frame TV art mode is not supported on this device`).

So with two TVs configured and one down, discovery returned **one** Frame. That failed the `frames.length > 1` chooser test, the card fell through, and dispatched to the entity named in the card's YAML — **the very TV discovery had just excluded for being unreachable**.

A single discovered Frame is now used directly:

| situation | before | after |
|---|---|---|
| 2 Frames reachable | chooser | chooser *(unchanged)* |
| **1 reachable, config names the dead one** | **sent to the dead one** | **sent to the reachable one** |
| 1 reachable, config already correct | ok | ok |
| none discovered | configured entity | configured entity *(unchanged)* |

Verified by executing the card's own `executeAction` / `_discoverFrames` against all four cases.

## 2. The upload then hung silently

`_ensure_tv_awake_for_art` fell through to `_ensure_art_mode_ready`, which issues `turn_on` and sleeps 10 s waiting for a TV that will never answer — no error, no log, nothing in the UI. The user retried three times blind.

It now tells **off** from **gone**: a Frame in standby still serves its REST endpoint, an unplugged or faulty one does not. The probe runs before any wake attempt and returns early:

```
Frame Art: 192.168.1.161 is unreachable — cannot upload.
Check the TV is powered at the mains and on the network.
```

The service error also changes from the misleading `Failed to turn on TV` to `TV unreachable or could not be turned on`.

Verified across five states — Art Mode, normal viewing, standby, IP-Control wake all stay ready; only the unreachable case fails, and immediately.

Release notes updated with a section covering how the two interacted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_