### PR TITLE
fix(art-identify): stop reporting famous artworks as unidentified

### DIFF
--- a/RELEASE_NOTES_8.6.0.md
+++ b/RELEASE_NOTES_8.6.0.md
@@ -128,6 +128,39 @@ integration now tells a TV in standby (which still answers its REST endpoint)
 apart from one that is unplugged or faulty (which does not), and fails straight
 away with *"<host> is unreachable — cannot upload"* instead of stalling.
 
+## Famous artworks no longer come back "not identified"
+
+Well-known paintings were being reported as unidentified with a confidence
+around 0.1, even though the description of what the model *saw* was accurate.
+The pipeline was working; the rules it was given were not.
+
+**Reverse image search often fails on artwork, and fails noisily.** When Google
+Vision does not find the picture anywhere, it does not return nothing — it
+returns plausible-looking filler: entities like *Painting*, *Art*, *Artwork*,
+and page titles like *"How To Master Painting With Zero Experience"* or
+*"The Basics Of Digital Illustration - YouTube"*. Two consequences:
+
+- **The filler is now stripped.** Generic entities are pushed behind the
+  concrete ones, and tutorial/listicle pages are dropped outright — so an empty
+  page list honestly means *found nowhere*, instead of looking well-sourced.
+  On a real case from the logs, the useful leads *The Kimono* and
+  *Thyssen-Bornemisza National Museum* were sitting third and first in a list
+  otherwise made of *Painting / Art / Drawing / Artist / Artwork*, alongside
+  five painting tutorials. Genuine museum and Wikipedia pages are untouched.
+- **The model may now identify from its own knowledge** when no candidate is
+  usable. Previously it was told to confirm a candidate *or nothing* — a
+  deliberate guard against invented attributions, but one that made a Renoir
+  unidentifiable the moment the reverse search came back empty. It can now name
+  a work it genuinely recognises, with `matched_candidate` left `null` and
+  **confidence capped at 0.6** to mark that nothing external corroborates it.
+  The guard itself stays: recognising a style, a period or a school is
+  explicitly *not* recognising the work, and attribution by resemblance is
+  still forbidden.
+
+So a high confidence still means "corroborated by the web", and anything at
+0.6 or below means "the model recognised it unaided" — the two remain
+distinguishable in the sensor attributes.
+
 ## Clearer failures
 
 Two error paths that used to mislead:
@@ -176,5 +209,8 @@ Two error paths that used to mislead:
   rather than failing silently on every artwork.
 - **Fix:** the gallery card uploads to a Frame that is actually reachable
   instead of falling back to the configured entity when only one is found.
+- **Fix:** well-known artworks were reported unidentified when reverse image
+  search returned only generic filler — the filler is now stripped, and the
+  model may identify a work it recognises unaided (confidence capped at 0.6).
 - **Fix:** an upload to an unreachable TV fails immediately with a clear
   message instead of hanging on a power-on that cannot happen.

--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -36,6 +36,7 @@ import base64
 import hashlib
 import json
 import logging
+import re
 import time
 from typing import Any
 
@@ -243,6 +244,81 @@ async def async_vision_web_detection(
     }
 
 
+# Web entities Vision returns for practically every painting. They carry no
+# identifying power, but they pad the candidate list and make a genuinely
+# useful entity ("The Kimono", "Basket of Fruit") look like one item in a
+# wall of noise.
+_GENERIC_ENTITIES = frozenset(
+    {
+        "art",
+        "artist",
+        "artwork",
+        "acrylic paint",
+        "canvas",
+        "drawing",
+        "design",
+        "digital art",
+        "digital illustration",
+        "fine art",
+        "graphics",
+        "illustration",
+        "illustrator",
+        "image",
+        "landscape painting",
+        "modern art",
+        "oil painting",
+        "paint",
+        "painter",
+        "painting",
+        "photograph",
+        "photography",
+        "picture",
+        "portrait",
+        "poster",
+        "printmaking",
+        "still life",
+        "visual arts",
+        "watercolor painting",
+    }
+)
+
+# Page titles that match these are tutorials/listicles the image merely
+# resembles — Vision returns them when it has NOT found the picture anywhere.
+# Feeding them to the LLM as "the image appears on these pages" is actively
+# misleading.
+_NOISE_PAGE_RE = re.compile(
+    r"how to|tutorial|for beginners|beginners guide|tips|step by step|"
+    r"masterclass|guide to|the basics|basics of|painting technique|lesson|course|"
+    r"learn to|teaching you|level up|what is |youtube",
+    re.IGNORECASE,
+)
+
+
+def denoise_candidates(candidates: dict[str, list[str]]) -> dict[str, list[str]]:
+    """Drop the generic filler from Vision's reply and promote the specifics.
+
+    Vision answers a failed reverse image search with plausible-looking
+    filler: entities like "Painting"/"Art" and pages like "How To Master
+    Painting With Zero Experience". Passed through verbatim, that filler both
+    buries the occasional real lead and makes an unidentified image look
+    well-sourced. Entities that name something concrete are moved to the
+    front; noise pages are removed entirely so an empty ``pages`` list
+    honestly signals "found nowhere".
+    """
+    entities = candidates.get("entities") or []
+    specific = [e for e in entities if e.strip().lower() not in _GENERIC_ENTITIES]
+    generic = [e for e in entities if e.strip().lower() in _GENERIC_ENTITIES]
+    pages = [p for p in (candidates.get("pages") or []) if not _NOISE_PAGE_RE.search(p)]
+    best_guess = [
+        b for b in (candidates.get("best_guess") or []) if b.strip().lower() not in _GENERIC_ENTITIES
+    ]
+    return {
+        "best_guess": best_guess,
+        "entities": specific + generic,
+        "pages": pages,
+    }
+
+
 def _build_llm_prompt(candidates: dict[str, list[str]]) -> str:
     """Prompt that hands the reverse-search candidates to the LLM for checking.
 
@@ -258,11 +334,24 @@ def _build_llm_prompt(candidates: dict[str, list[str]]) -> str:
         f"- Best guess: {' / '.join(candidates.get('best_guess') or []) or '(none)'}\n"
         f"- Web entities: {', '.join(candidates.get('entities') or []) or '(none)'}\n"
         f"- Page titles: {' | '.join(candidates.get('pages') or []) or '(none)'}\n\n"
-        "Your task: confirm the identification ONLY if a candidate is consistent "
-        "with what you actually SEE in the image. If none matches, set "
-        '"identified": false and leave artist/date null and translations {}. '
+        "Your task, in this order:\n"
+        "1. If a candidate is consistent with what you actually SEE in the "
+        'image, confirm it: set "identified": true, name it in '
+        '"matched_candidate", and use your normal confidence.\n'
+        "2. The candidate list is often empty or generic, because reverse "
+        "image search regularly fails on artwork. In that case you MAY still "
+        "identify the work from your OWN knowledge, but only if you genuinely "
+        "recognise this specific piece — a famous painting you can name with "
+        "its artist. Then set \"identified\": true, leave "
+        '"matched_candidate": null, and cap "confidence" at 0.6 to mark that '
+        "no external source corroborates it.\n"
+        "3. If you do not recognise the work, set \"identified\": false and "
+        "leave artist/date null. A recognisable STYLE, period or school is NOT "
+        "recognising the work — do not guess a plausible title, and never "
+        "attribute it to an artist merely because it looks like their manner.\n"
         "Do NOT invent facts. Separate the visual description from the factual "
-        "identification. confidence is a number from 0 to 1.\n"
+        "identification. confidence is a number from 0 to 1. Always fill "
+        "visual_description, even when the work is not identified.\n"
         f"Provide title, artwork_description, artist_biography and "
         f"visual_description in ALL these languages: {langs}. artist, date and "
         "suggested_search_query stay in one language (English). Translate the "
@@ -622,7 +711,9 @@ async def async_identify(
     img_b64 = base64.b64encode(image_bytes).decode()
     started = time.monotonic()
     try:
-        candidates = await async_vision_web_detection(session, vision_key, img_b64)
+        candidates = denoise_candidates(
+            await async_vision_web_detection(session, vision_key, img_b64)
+        )
         _LOGGER.debug(
             "Artwork %s: Vision candidates best_guess=%s | entities=%s | pages=%s",
             key,

--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -310,7 +310,9 @@ def denoise_candidates(candidates: dict[str, list[str]]) -> dict[str, list[str]]
     generic = [e for e in entities if e.strip().lower() in _GENERIC_ENTITIES]
     pages = [p for p in (candidates.get("pages") or []) if not _NOISE_PAGE_RE.search(p)]
     best_guess = [
-        b for b in (candidates.get("best_guess") or []) if b.strip().lower() not in _GENERIC_ENTITIES
+        b
+        for b in (candidates.get("best_guess") or [])
+        if b.strip().lower() not in _GENERIC_ENTITIES
     ]
     return {
         "best_guess": best_guess,
@@ -342,10 +344,10 @@ def _build_llm_prompt(candidates: dict[str, list[str]]) -> str:
         "image search regularly fails on artwork. In that case you MAY still "
         "identify the work from your OWN knowledge, but only if you genuinely "
         "recognise this specific piece — a famous painting you can name with "
-        "its artist. Then set \"identified\": true, leave "
+        'its artist. Then set "identified": true, leave '
         '"matched_candidate": null, and cap "confidence" at 0.6 to mark that '
         "no external source corroborates it.\n"
-        "3. If you do not recognise the work, set \"identified\": false and "
+        '3. If you do not recognise the work, set "identified": false and '
         "leave artist/date null. A recognisable STYLE, period or school is NOT "
         "recognising the work — do not guess a plausible title, and never "
         "attribute it to an artist merely because it looks like their manner.\n"

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.0b2"
+  "version": "8.6.0b3"
 }


### PR DESCRIPTION
Three classic, well-known works came back `identified: false` with confidence ~0.14, while the `visual_description` the model produced was accurate. The pipeline was not broken — no truncation, no 404, no Vision outage. The rules it was given were wrong.

## What the logs actually showed

Vision **was** answering, but only with filler:

| artwork | entities | pages |
|---|---|---|
| `SAM-S2811` | `Thyssen-Bornemisza National Museum`, `The Kimono`, Painting, Art, Drawing, Artist, Artwork | 5× painting tutorials (*"How To Master Painting With Zero Experience"*, *"… - YouTube"*) |
| `SAM-S2813` | Painting, Art, `Basket of Fruit`, Modern art, Oil painting… | *"How to Start Painting for Beginners"*, … |
| `SAM-S1000068` | Illustration, Art, Design, Image… | *"The Basics Of Digital Illustration - YouTube"*, … |

And the raw LLM reply:

```json
{"identified":false,"confidence":0.14,"matched_candidate":null,
 "visual_description":"A dim, warm-toned interior scene shows a seated woman
  in a kimono-like garment, head bowed as if reading or sewing…"}
```

It saw the picture correctly. It refused because the prompt said: *confirm the identification ONLY if a candidate is consistent with what you see*. When reverse image search fails — which it does regularly on artwork — identification became structurally impossible, even for a Renoir. The anti-hallucination guard was doing the damage.

## 1. The model may now identify from its own knowledge

The prompt now has three ordered branches:

1. A candidate matches → confirm it, name it in `matched_candidate`, normal confidence.
2. No usable candidate → the model **may** name a work it genuinely recognises, with `matched_candidate: null` and **confidence capped at 0.6**, marking that nothing external corroborates it.
3. Not recognised → `identified: false`.

The guard is kept, and made explicit: a recognisable *style*, period or school is **not** recognising the work, and attributing by resemblance to an artist's manner is forbidden.

Because of the cap, the two kinds of answer stay distinguishable in the sensor attributes: above 0.6 means corroborated by the web, at or below means the model recognised it unaided.

## 2. Vision's filler is stripped before it reaches the LLM

`denoise_candidates()` promotes concrete entities ahead of generic ones (`Painting`, `Art`, `Artwork`, `Illustration`, …) and drops tutorial/listicle page titles outright — so an empty `pages` list honestly signals *found nowhere* instead of making an unidentified image look well-sourced.

Exercised against the exact candidate sets from the logs:

| input | result |
|---|---|
| `…, The Kimono, Painting, Art, Drawing, …` | `Thyssen-Bornemisza National Museum`, `The Kimono` first |
| `Painting, Art, Basket of Fruit, Modern art, …` | `Basket of Fruit`, `Expressionism` first |
| 5 painting tutorials | 4 dropped |
| `The Starry Night - Museum of Modern Art`, `Basket of Fruit (Caravaggio) - Wikipedia`, `Impressionist technique in Monet - Tate` | **all kept** |
| `{}` (Vision returned nothing) | empty lists, no crash |

The noise filter is deliberately narrow (`painting technique`, not `technique`) so a museum page discussing an artist's technique survives.

## Not changed

- **Thumbnail size.** The 8–80 KB thumbnails come from the thumbnail downloader; there is no larger source to send.
- **Model selection.** `gpt-5.4-mini` was auto-picked from the live list, but the raw replies show it read the image correctly — it was obeying the prompt, not underperforming.

Release notes for 8.6.0 updated; version bumped to `8.6.0b3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_