### PR TITLE
fix(art-identify): retry cached failures when the identification logic changes

### DIFF
--- a/RELEASE_NOTES_8.6.0.md
+++ b/RELEASE_NOTES_8.6.0.md
@@ -161,6 +161,14 @@ So a high confidence still means "corroborated by the web", and anything at
 0.6 or below means "the model recognised it unaided" — the two remain
 distinguishable in the sensor attributes.
 
+**Past failures are retried instead of being served from cache.** A failed
+identification was cached for 14 days, so the artworks an improvement is
+written for were precisely the ones that could not benefit from it — the old
+"not identified" kept being replayed. Cached failures now carry the pipeline
+revision that produced them and are ignored once that logic changes, so the
+work is re-identified on the next artwork change. Confirmed identifications are
+untouched: they stay valid and are not re-fetched.
+
 ## Clearer failures
 
 Two error paths that used to mislead:
@@ -209,6 +217,8 @@ Two error paths that used to mislead:
   rather than failing silently on every artwork.
 - **Fix:** the gallery card uploads to a Frame that is actually reachable
   instead of falling back to the configured entity when only one is found.
+- **Fix:** a cached "not identified" is retried when the identification logic
+  changes, instead of masking the improvement for up to 14 days.
 - **Fix:** well-known artworks were reported unidentified when reverse image
   search returned only generic filler — the filler is now stripped, and the
   model may identify a work it recognises unaided (confidence capped at 0.6).

--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -91,6 +91,14 @@ _GEMINI_URL_TMPL = (
 )
 
 _CACHE_STORE_VERSION = 1
+
+# Bumped whenever the prompt or the candidate handling changes in a way that
+# could turn a past failure into a success. Cached *misses* from an older
+# revision are ignored so the improvement applies on the next artwork change;
+# cached hits are untouched, since a confirmed identification stays valid.
+#   1 — original "confirm a candidate or nothing" prompt
+#   2 — candidate de-noising + identification from the model's own knowledge
+_PIPELINE_REVISION = 2
 _HTTP_TIMEOUT = 45  # seconds per external call
 # Output token budget for the confirmation reply. Must fit the whole JSON —
 # title + three prose fields in every LANGS language — or the reply is
@@ -174,11 +182,18 @@ class ArtIdentifyCache:
         """Return a non-expired cached result, or None.
 
         A hit (identified) is kept effectively forever; a miss is retried after
-        ``ART_CACHE_TTL_MISS``. Expired entries return None so the caller
-        re-runs the pipeline.
+        ``ART_CACHE_TTL_MISS``, or immediately if it was produced by an older
+        pipeline revision. Expired entries return None so the caller re-runs
+        the pipeline.
         """
         entry = self._data.get(key)
         if not entry:
+            return None
+        if not entry.get("identified") and entry.get("_rev") != _PIPELINE_REVISION:
+            # A failure recorded by an older prompt/candidate logic says nothing
+            # about the current one. Without this, improving identification had
+            # no visible effect for up to ART_CACHE_TTL_MISS (14 days) on
+            # exactly the artworks the improvement was written for.
             return None
         ttl = ART_CACHE_TTL_HIT if entry.get("identified") else ART_CACHE_TTL_MISS
         if time.time() - entry.get("_fetched_at", 0) > ttl:
@@ -191,6 +206,7 @@ class ArtIdentifyCache:
         """Store a fresh result (hit or miss) and persist it. Errors are not cached."""
         entry = {k: result.get(k) for k in RESULT_KEYS}
         entry["_fetched_at"] = time.time()
+        entry["_rev"] = _PIPELINE_REVISION
         self._data[key] = entry
         await self._store.async_save(self._data)
 

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.0b3"
+  "version": "8.6.0b4"
 }


### PR DESCRIPTION
Follow-up to #191. The identification fixes shipped there could not take effect on the artworks they were written for.

## The symptom

A Keith Haring *Flying Baby* (`SAM-S1000068`) still showed **Œuvre non identifiée** after the fix — while Google Lens names it immediately.

## What the logs show

```
10:29:27  Vision candidates best_guess=['illustration'] | entities=['Illustration','Art',…]
10:29:32  identified=False conf=0.05
10:47:10  cache HIT (identified=False title=None)
11:18:55  cache HIT (identified=False title=None)
```

The pipeline last actually ran at **10:29** — before #191 existed, with the un-denoised candidates (`best_guess` unfiltered, five painting tutorials in `pages`). Every lookup since replayed that negative result from cache.

`ART_CACHE_TTL_MISS` is **14 days**. So a failure is remembered for a fortnight, and the artworks an improvement targets are precisely the ones that cannot benefit from it.

## The fix

Cached entries now record the pipeline revision that produced them (`_PIPELINE_REVISION`, bumped to 2 for the de-noising + own-knowledge identification of #191). A **miss** from an older revision is ignored, so the artwork is re-identified on the next change. **Hits are untouched** — a confirmed identification does not go stale, and nothing is needlessly re-fetched.

| cached entry | result |
|---|---|
| miss, revision 1 | `None` → pipeline re-runs |
| miss, revision 2 | served from cache |
| hit, revision 1 | served from cache *(unchanged)* |
| freshly stored miss | carries `_rev=2`, served from cache |

Exercised directly against `ArtIdentifyCache.get` / `async_put`.

## On this particular artwork

Google Lens identifies it; the Vision **Web Detection** API — a different, weaker product on artwork — returned only `Illustration / Art / Design`. So it is branch 2 of the new prompt that should catch it: the model recognises a Keith Haring easily, and will report it with `matched_candidate: null` and confidence capped at 0.6.

Version bumped to `8.6.0b4`; release notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_