### PR TITLE
fix(art-identify): send the thumbnail with its real media type

### DIFF
--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -337,6 +337,35 @@ def denoise_candidates(candidates: dict[str, list[str]]) -> dict[str, list[str]]
     }
 
 
+# Base64 prefixes of the magic bytes of the formats a Frame thumbnail can be
+# in. Every thumbnail is saved as ``current.jpg`` whatever the TV actually
+# sent (the Art API reports the real type in its header), so the extension is
+# not evidence of the content.
+_B64_MAGIC = (
+    ("/9j/", "image/jpeg"),
+    # Only the bytes that are constant in the signature: base64 encodes three
+    # bytes per four characters, so a longer prefix would start depending on
+    # the payload and stop matching.
+    ("iVBORw0K", "image/png"),
+    ("R0lG", "image/gif"),
+    ("UklGR", "image/webp"),
+)
+
+
+def media_type_from_b64(img_b64: str) -> str:
+    """Return the real image media type, sniffed from the encoded bytes.
+
+    All three providers are told the media type explicitly; announcing
+    ``image/jpeg`` for a PNG is at best undefined behaviour and at worst a
+    rejected request. Falls back to JPEG, which is what a Frame thumbnail
+    usually is.
+    """
+    for prefix, media_type in _B64_MAGIC:
+        if img_b64.startswith(prefix):
+            return media_type
+    return "image/jpeg"
+
+
 def _build_llm_prompt(candidates: dict[str, list[str]]) -> str:
     """Prompt that hands the reverse-search candidates to the LLM for checking.
 
@@ -474,6 +503,7 @@ async def async_llm_confirm(
     chat APIs. Raises on transport/parse failure (not cached).
     """
     prompt = _build_llm_prompt(candidates)
+    media_type = media_type_from_b64(img_b64)
     if provider == "anthropic":
         headers = {
             "x-api-key": api_key,
@@ -491,7 +521,7 @@ async def async_llm_confirm(
                             "type": "image",
                             "source": {
                                 "type": "base64",
-                                "media_type": "image/jpeg",
+                                "media_type": media_type,
                                 "data": img_b64,
                             },
                         },
@@ -532,7 +562,7 @@ async def async_llm_confirm(
                         {"type": "text", "text": prompt},
                         {
                             "type": "image_url",
-                            "image_url": {"url": f"data:image/jpeg;base64,{img_b64}"},
+                            "image_url": {"url": f"data:{media_type};base64,{img_b64}"},
                         },
                     ],
                 }
@@ -548,7 +578,7 @@ async def async_llm_confirm(
                         {"text": prompt},
                         {
                             "inline_data": {
-                                "mime_type": "image/jpeg",
+                                "mime_type": media_type,
                                 "data": img_b64,
                             }
                         },

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.0b4"
+  "version": "8.6.0b5"
 }


### PR DESCRIPTION
Found while chasing why a Keith Haring *Flying Baby* comes back unidentified even with the cache bypassed (`force: true`, so #191 + #192 are demonstrably active).

## The evidence

The forced run returns a description of an image the model clearly cannot make out:

> A simple cartoon-style drawing on a light blue background showing a small white **dog-like or abstract figure**, outlined in thick black lines. The figure is **crouched or mid-run**…

The artwork is a winged baby. No wings, no halo rays — the model is not being coy about a work it recognises, it is describing something else. That points at the image we send, not at the prompt.

## The bug

All three providers are told the media type explicitly, and all three were told `image/jpeg` unconditionally:

```python
"media_type": "image/jpeg"                       # Anthropic
{"url": f"data:image/jpeg;base64,{img_b64}"}     # OpenAI
"mime_type": "image/jpeg"                        # Gemini
```

But a Frame thumbnail is saved as `current.jpg` **whatever the TV actually sent** — the Art API reports the real type in its own header (`header.get("fileType", "jpg")`, `api/art.py:1141`), and Art Store items are not all JPEG. So a PNG or WebP thumbnail was announced as JPEG: undefined behaviour at best, a rejected request at worst, and a plausible cause of a mis-decoded image.

## The fix

The type is sniffed from the encoded bytes rather than assumed. The base64 prefixes are cut at a group boundary (four characters per three bytes) so they stay constant regardless of the payload that follows — a longer prefix would silently stop matching:

| bytes | media type |
|---|---|
| `\xff\xd8\xff` | `image/jpeg` |
| `\x89PNG` | `image/png` |
| `GIF87a` / `GIF89a` | `image/gif` |
| `RIFF…WEBP` | `image/webp` |
| anything else | `image/jpeg` *(what a Frame thumbnail usually is)* |

Verified against real signatures for all five cases.

## Honest scope

This is a real bug, but it is **not proven** to be the cause of this particular artwork failing — that depends on whether this thumbnail is actually a PNG. If it turns out to be a genuine JPEG, the remaining suspect is model capability: identification now leans on the model's own knowledge when reverse image search returns nothing, and `gpt-5.4-mini` is the cheapest tier. Worth testing a full-size model from the dropdown before changing any default.

Version bumped to `8.6.0b5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_