### PR TITLE
fix(art-identify): stop the prompt implying every artwork is a painting

### DIFF
--- a/RELEASE_NOTES_8.6.0.md
+++ b/RELEASE_NOTES_8.6.0.md
@@ -161,6 +161,24 @@ So a high confidence still means "corroborated by the web", and anything at
 0.6 or below means "the model recognised it unaided" — the two remain
 distinguishable in the sensor attributes.
 
+**The Art Store is not a museum of oil paintings.** Even once it could answer
+freely, the model kept declining on graphic works — its own description gave
+the reason: *"looks like a modern icon or doodle rather than a traditional
+painting"*. It was echoing the instruction, which asked it to recognise "a
+famous painting". The catalogue is full of photography, prints, posters,
+street art, cartoons and contemporary illustration, so the prompt now says so
+explicitly, and an artist's named signature motif counts as an
+identification. The refusal rule is unchanged: recognising a style is still
+not recognising the work.
+
+**The thumbnail is sent with its real media type.** Every provider was told
+`image/jpeg` unconditionally, but a Frame thumbnail is stored as
+`current.jpg` whatever the TV actually sent — the Art API reports the true
+type in its header. A PNG or WebP announced as JPEG is undefined behaviour,
+and it showed: the model described a winged figure as *"a small dog-like
+figure, crouched or mid-run"*. The type is now sniffed from the bytes, and
+the description came back correct.
+
 **Past failures are retried instead of being served from cache.** A failed
 identification was cached for 14 days, so the artworks an improvement is
 written for were precisely the ones that could not benefit from it — the old

--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -98,7 +98,9 @@ _CACHE_STORE_VERSION = 1
 # cached hits are untouched, since a confirmed identification stays valid.
 #   1 — original "confirm a candidate or nothing" prompt
 #   2 — candidate de-noising + identification from the model's own knowledge
-_PIPELINE_REVISION = 2
+#   3 — real image media type sent; prompt no longer implies "old master
+#       painting", which made the model withhold graphic/contemporary works
+_PIPELINE_REVISION = 3
 _HTTP_TIMEOUT = 45  # seconds per external call
 # Output token budget for the confirmation reply. Must fit the whole JSON —
 # title + three prose fields in every LANGS language — or the reply is
@@ -387,15 +389,25 @@ def _build_llm_prompt(candidates: dict[str, list[str]]) -> str:
         '"matched_candidate", and use your normal confidence.\n'
         "2. The candidate list is often empty or generic, because reverse "
         "image search regularly fails on artwork. In that case you MAY still "
-        "identify the work from your OWN knowledge, but only if you genuinely "
-        "recognise this specific piece — a famous painting you can name with "
-        'its artist. Then set "identified": true, leave '
-        '"matched_candidate": null, and cap "confidence" at 0.6 to mark that '
-        "no external source corroborates it.\n"
+        "identify the work from your OWN knowledge, whenever you genuinely "
+        'recognise what you are looking at. Then set "identified": true, '
+        'leave "matched_candidate": null, and cap "confidence" at 0.6 to mark '
+        "that no external source corroborates it.\n"
+        "   The Samsung Art Store is not limited to old master paintings: it "
+        "sells photography, prints, posters, graphic design, street art, "
+        "cartoons, calligraphy and contemporary illustration. Do NOT withhold "
+        "an identification because the image looks like an icon, a doodle, "
+        "clip art or a logo rather than a traditional painting — that is "
+        "exactly what a large part of the catalogue is. A signature motif you "
+        "can name together with its artist (for instance an artist's "
+        "recurring emblematic figure) counts as recognising the work: give "
+        "the motif's usual name as the title.\n"
         '3. If you do not recognise the work, set "identified": false and '
-        "leave artist/date null. A recognisable STYLE, period or school is NOT "
-        "recognising the work — do not guess a plausible title, and never "
-        "attribute it to an artist merely because it looks like their manner.\n"
+        "leave artist/date null. Recognising a STYLE, period or school alone "
+        "is NOT recognising the work — do not guess a plausible title, and "
+        "never attribute a piece to an artist merely because it looks like "
+        "their manner. The test is whether you can name it, not whether it "
+        "reminds you of someone.\n"
         "Do NOT invent facts. Separate the visual description from the factual "
         "identification. confidence is a number from 0 to 1. Always fill "
         "visual_description, even when the work is not identified.\n"

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.0b5"
+  "version": "8.6.0b6"
 }


### PR DESCRIPTION
Follow-up to #193, which fixed the image but not the answer.

## The media-type fix worked

With the real media type sent, the model now describes the artwork correctly:

> A simple cartoon-like illustration of a **white winged figure** … rounded head and body, small legs, and **stylized wings**, with short black **motion lines** around it.

Compare the run before #193, on the same artwork:

> a small white **dog-like or abstract figure** … **crouched or mid-run**

So the image is no longer being mis-decoded. It is a Keith Haring flying baby, and the model sees it.

## And it still refused

`identified: false`, confidence 0.09 — **on `gpt-5.4` as well as `gpt-5.4-mini`** (both runs are in the logs). So it is neither the image nor the model tier, which rules out the two remaining suspects from #193.

The reason is in the model's own words, at the end of its description:

> The image looks graphic and playful, **more like a modern icon or doodle than a traditional painting**.

It was echoing the instruction. Branch 2 of the prompt said it could identify from its own knowledge *"only if you genuinely recognise this specific piece — **a famous painting** you can name with its artist"*. A Haring flying baby is not a painting, so the model concluded it was out of scope and withheld a work it plainly recognised.

## The fix

The prompt now states what the catalogue actually contains — photography, prints, posters, graphic design, street art, cartoons, calligraphy, contemporary illustration — and says explicitly that looking like an icon, a doodle, clip art or a logo is **not** grounds to withhold, because that is a large part of the Art Store. An artist's named signature motif counts as recognising the work, with the motif's usual name as the title.

The guard against invented attributions is kept and sharpened rather than loosened:

> Recognising a STYLE, period or school alone is NOT recognising the work … never attribute a piece to an artist merely because it looks like their manner. **The test is whether you can name it, not whether it reminds you of someone.**

`_PIPELINE_REVISION` bumped to 3, so the failures cached under the old prompt are retried automatically (the mechanism added in #192).

Version `8.6.0b6`; release notes updated with this and the media-type finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_