### PR TITLE
fix(art-identify): re-sample a lone unidentified verdict

### DIFF
--- a/RELEASE_NOTES_8.6.0.md
+++ b/RELEASE_NOTES_8.6.0.md
@@ -179,6 +179,16 @@ and it showed: the model described a winged figure as *"a small dog-like
 figure, crouched or mid-run"*. The type is now sniffed from the bytes, and
 the description came back correct.
 
+**A lone "not identified" is checked twice.** When there is no candidate to
+confirm, the answer rests entirely on what the model recalls — and that is not
+deterministic. On one artwork, everything else held constant, four runs gave
+two refusals and two correct identifications (Keith Haring, confidence
+0.58–0.60). Temperature cannot be lowered to settle it: the current reasoning
+models only accept the default. So when the model declines *and* the reverse
+search produced nothing to check against, one more sample is taken — a second
+refusal is evidence, a single one was a coin toss. Every other path still costs
+exactly one call.
+
 **Past failures are retried instead of being served from cache.** A failed
 identification was cached for 14 days, so the artworks an improvement is
 written for were precisely the ones that could not benefit from it — the old

--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -100,7 +100,8 @@ _CACHE_STORE_VERSION = 1
 #   2 — candidate de-noising + identification from the model's own knowledge
 #   3 — real image media type sent; prompt no longer implies "old master
 #       painting", which made the model withhold graphic/contemporary works
-_PIPELINE_REVISION = 3
+#   4 — a lone "not identified" with no candidate is re-sampled once
+_PIPELINE_REVISION = 4
 _HTTP_TIMEOUT = 45  # seconds per external call
 # Output token budget for the confirmation reply. Must fit the whole JSON —
 # title + three prose fields in every LANGS language — or the reply is
@@ -273,7 +274,14 @@ _GENERIC_ENTITIES = frozenset(
         "artwork",
         "acrylic paint",
         "canvas",
+        "cartoon",
+        "clip art",
+        "doodle",
         "drawing",
+        "graphic design",
+        "line art",
+        "logo",
+        "sketch",
         "design",
         "digital art",
         "digital illustration",
@@ -366,6 +374,21 @@ def media_type_from_b64(img_b64: str) -> str:
         if img_b64.startswith(prefix):
             return media_type
     return "image/jpeg"
+
+
+def _has_usable_candidate(candidates: dict[str, list[str]]) -> bool:
+    """True if the reverse search produced anything the LLM can confirm.
+
+    After de-noising, a candidate set made only of generic entities carries no
+    identifying power: the model is answering from memory alone, and a "no" is
+    then a judgement call rather than a rejection of a concrete name.
+    """
+    if candidates.get("best_guess"):
+        return True
+    return any(
+        e.strip().lower() not in _GENERIC_ENTITIES
+        for e in (candidates.get("entities") or [])
+    )
 
 
 def _build_llm_prompt(candidates: dict[str, list[str]]) -> str:
@@ -784,6 +807,22 @@ async def async_identify(
         result = await async_llm_confirm(
             session, provider, llm_key, model, img_b64, candidates
         )
+        if not result.get("identified") and not _has_usable_candidate(candidates):
+            # No candidate to check against, so the answer rests entirely on
+            # what the model recalls — and that is not deterministic. Observed
+            # on one artwork with everything else held constant: four runs,
+            # two "not identified", two correct (Keith Haring, confidence
+            # 0.58-0.60). Temperature cannot be lowered to fix it, since the
+            # reasoning models only accept the default. So take one more
+            # sample: a second "no" is evidence, a lone "no" was a coin toss.
+            # Only on failure, and only when there was nothing to confirm, so
+            # the common paths cost exactly one call as before.
+            _LOGGER.debug("Artwork %s: unidentified with no candidates — retrying", key)
+            retry = await async_llm_confirm(
+                session, provider, llm_key, model, img_b64, candidates
+            )
+            if retry.get("identified"):
+                result = retry
     except (VisionError, LLMError, ClientError, TimeoutError, ValueError) as err:
         _LOGGER.warning("Artwork identification failed for %s: %s", key, err)
         return {

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.0b6"
+  "version": "8.6.0b7"
 }


### PR DESCRIPTION
Follow-up to #194. The prompt fix works — but only about half the time, and the logs show why.

## Four runs, one artwork, nothing changed between them

```
identified=False  conf=0.11   8.2s   openai/gpt-5.4
identified=False  conf=0.13   7.1s   openai/gpt-5.4
identified=True   Winged Dog — Keith Haring   conf=0.58  15.9s  openai/gpt-5.4
identified=True   Winged Dog — Keith Haring   conf=0.60  18.8s  openai/gpt-5.4
```

Same image, same model, same candidates (`best_guess=[]`, entities all generic). The confidence cap of 0.6 is respected on both successes, so the own-knowledge branch behaves as designed — it just does not fire reliably.

This is inherent, not a bug to hunt: with no candidate to check against, the verdict rests entirely on what the model recalls, and sampling is stochastic. **Temperature cannot be lowered to settle it** — the current reasoning models only accept the default, which is why it was omitted in the first place.

## The fix

When the model declines **and** the reverse search produced nothing to confirm, take one more sample and keep it if it identifies. A second refusal is evidence; a single one was a coin toss.

- Fires only on failure, and only when there was nothing to confirm — every other path costs exactly one call, as before.
- Never overrides a positive result, and never turns a "yes" into a "no".
- Rejecting a *concrete* candidate is a meaningful answer, so those are not retried.

## One subtlety in `_has_usable_candidate`

It deliberately ignores page titles. On this very artwork, de-noising leaves one survivor — *"Off Book | The Art of Illustration - PBS"* — which is generic but not tutorial-shaped. Counting pages as a usable candidate would have masked the exact case this targets. A page carrying a real title is virtually always accompanied by a matching `best_guess` or entity, so nothing is lost; and the cost of judging wrongly is one extra call on a failure.

`cartoon`, `clip art`, `doodle`, `logo`, `sketch`, `line art` and `graphic design` joined the generic entity list — Vision returns them for every graphic work.

Checked against the real candidate sets from the logs:

| artwork | usable? | behaviour |
|---|---|---|
| Keith Haring (all generic) | no | re-sampled on refusal |
| Elliott Erwitt, Eiffel Tower | yes | one call, unchanged |
| *The Kimono* / Thyssen-Bornemisza | yes | one call, unchanged |
| Vision returned nothing | no | re-sampled on refusal |

`_PIPELINE_REVISION` bumped to 4. Version `8.6.0b7`; release notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_