### PR TITLE
fix(art-identify): tell the model the web entities are fragments

### DIFF
--- a/RELEASE_NOTES_8.6.0.md
+++ b/RELEASE_NOTES_8.6.0.md
@@ -179,6 +179,19 @@ and it showed: the model described a winged figure as *"a small dog-like
 figure, crouched or mid-run"*. The type is now sniffed from the bytes, and
 the description came back correct.
 
+**Web entities are explained for what they are: fragments.** Vision returns an
+unordered bag — a title here, a holding museum there, the artist somewhere
+else, mixed with generic labels. Presented as a flat "candidate" list, the
+model treated each one as a whole answer to accept or reject, and rejected
+them all. For William Merritt Chase's *The Kimono* it was handed
+`The Kimono` **and** `Thyssen-Bornemisza National Museum` — the title and the
+museum that actually holds it — and still declined four times out of four,
+explaining that *"the specific work is not confidently recognizable"*. The
+prompt now says the entities are fragments to be read together, and that
+naming one specific work from fragments plus the image counts as a
+confirmation, with the artist and date filled in from the model's own
+knowledge.
+
 **A lone "not identified" is checked twice.** When there is no candidate to
 confirm, the answer rests entirely on what the model recalls — and that is not
 deterministic. On one artwork, everything else held constant, four runs gave

--- a/custom_components/samsungtv_smart/art_identify.py
+++ b/custom_components/samsungtv_smart/art_identify.py
@@ -101,7 +101,9 @@ _CACHE_STORE_VERSION = 1
 #   3 — real image media type sent; prompt no longer implies "old master
 #       painting", which made the model withhold graphic/contemporary works
 #   4 — a lone "not identified" with no candidate is re-sampled once
-_PIPELINE_REVISION = 4
+#   5 — web entities explained as unordered fragments (title / museum /
+#       artist), which the model may combine to pin down a work
+_PIPELINE_REVISION = 5
 _HTTP_TIMEOUT = 45  # seconds per external call
 # Output token budget for the confirmation reply. Must fit the whole JSON —
 # title + three prose fields in every LANGS language — or the reply is
@@ -406,10 +408,18 @@ def _build_llm_prompt(candidates: dict[str, list[str]]) -> str:
         f"- Best guess: {' / '.join(candidates.get('best_guess') or []) or '(none)'}\n"
         f"- Web entities: {', '.join(candidates.get('entities') or []) or '(none)'}\n"
         f"- Page titles: {' | '.join(candidates.get('pages') or []) or '(none)'}\n\n"
+        "The web entities are unordered FRAGMENTS, not a formatted answer: one "
+        "may be the title, another the museum that holds the work, another the "
+        "artist, mixed in with generic labels. Read them together — a title "
+        "plus a holding institution is often enough to pin down a specific "
+        "work you know.\n\n"
         "Your task, in this order:\n"
         "1. If a candidate is consistent with what you actually SEE in the "
         'image, confirm it: set "identified": true, name it in '
-        '"matched_candidate", and use your normal confidence.\n'
+        '"matched_candidate", and use your normal confidence. A fragment does '
+        "not have to arrive complete: if the fragments plus the image let you "
+        "name one specific work you know, that IS a confirmation — fill in the "
+        "artist and date yourself, and say which fragment you matched.\n"
         "2. The candidate list is often empty or generic, because reverse "
         "image search regularly fails on artwork. In that case you MAY still "
         "identify the work from your OWN knowledge, whenever you genuinely "

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.0b7"
+  "version": "8.6.0b8"
 }


### PR DESCRIPTION
A different failure mode from #195, on William Merritt Chase's *The Kimono* (`SAM-S2811`). Here the re-sampling of #195 does not apply — and would not have helped.

## The model rejects candidates that are correct

Four forced runs, `gpt-5.4`, all refusing, and remarkably stable about it:

```
identified=False  conf=0.18   12.1s
identified=False  conf=0.18    8.4s
identified=False  conf=0.19   10.0s
identified=False  conf=0.20    8.9s
```

This is not the coin toss of #195 — it is a consistent "no". And the candidates it said no to:

```
entities = ['The Kimono', 'Thyssen-Bornemisza National Museum', 'Painting', 'Art', …]
```

The **title** of the work and the **museum that actually holds it**. Google Lens resolves the same image to *"Le Kimono, William Merritt Chase, ~1895, Museo Thyssen-Bornemisza"*. The model's own words:

> The style suggests a late 19th-century or Japoniste-inspired painting, but **the specific work is not confidently recognizable**.

## Why

Vision's `webEntities` is an **unordered bag of fragments**: a title here, a holding institution there, sometimes the artist, mixed with generic labels. We presented it as a flat list under the heading "CANDIDATES", so each entry reads as a *whole answer* to accept or reject. `The Kimono` on its own is a title with no artist attached — impossible to "confirm" as stated — so it was rejected, and the museum sitting next to it was never connected to it.

## The fix

The prompt now states what the list actually is:

> The web entities are unordered FRAGMENTS, not a formatted answer: one may be the title, another the museum that holds the work, another the artist, mixed in with generic labels. Read them together — a title plus a holding institution is often enough to pin down a specific work you know.

And branch 1 accepts an incomplete fragment:

> A fragment does not have to arrive complete: if the fragments plus the image let you name one specific work you know, that IS a confirmation — fill in the artist and date yourself, and say which fragment you matched.

This *tightens* the evidence bar rather than lowering it: the result is corroborated by the reverse search, so it takes the normal confidence path with `matched_candidate` naming the fragment matched — unlike the own-knowledge branch, which stays capped at 0.6. The anti-hallucination rules of #194 are untouched.

`_PIPELINE_REVISION` bumped to 5, so the failures cached under the previous prompt are retried automatically. Version `8.6.0b8`; release notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_