### PR TITLE
fix(smartthings): strip padded picture mode names, report why sends fail

### DIFF
--- a/custom_components/samsungtv_smart/api/smartthings.py
+++ b/custom_components/samsungtv_smart/api/smartthings.py
@@ -521,6 +521,11 @@ class SmartThingsTV:
                             m_id = m_name = entry
                         else:
                             continue
+                        # Samsung's localized names arrive padded in some
+                        # locales (" Prirodzený", " Dynamický" -- see #197).
+                        # A leading space is not part of the name: it would
+                        # show in the UI and be sent back as the argument.
+                        m_name = m_name.strip() or m_id
                         if m_id:
                             new_map[m_name] = m_id
                     if new_map:
@@ -531,7 +536,10 @@ class SmartThingsTV:
             if not self._picture_mode_list:
                 _sk = "supportedPictureModes"
                 if _sk in picture_mode_cap:
-                    self._picture_mode_list = picture_mode_cap[_sk].value
+                    self._picture_mode_list = [
+                        m.strip() if isinstance(m, str) else m
+                        for m in (picture_mode_cap[_sk].value or [])
+                    ] or None
 
             # If pysmartthings did not expose supportedPictureModesMap,
             # fetch it directly from the REST capability status endpoint.
@@ -612,6 +620,11 @@ class SmartThingsTV:
                             m_id = m_name = entry
                         else:
                             continue
+                        # Samsung's localized names arrive padded in some
+                        # locales (" Prirodzený", " Dynamický" -- see #197).
+                        # A leading space is not part of the name: it would
+                        # show in the UI and be sent back as the argument.
+                        m_name = m_name.strip() or m_id
                         if m_id:
                             new_map[m_name] = m_id
                     if new_map:
@@ -1014,6 +1027,7 @@ class SmartThingsTV:
             _add(capability, "id")
 
         any_sent = False
+        failures: list[str] = []
         for capability, form in attempts:
             argument = forms[form]
             try:
@@ -1030,6 +1044,10 @@ class SmartThingsTV:
                     argument,
                     err,
                 )
+                # Kept so the final error can say WHY every attempt failed.
+                # Reporting only "failed via any capability/form" (#197) left
+                # nothing to act on without turning on debug logging first.
+                failures.append(f"{capability} ({form}={argument!r}): {err}")
                 continue
             self._log.debug(
                 "Picture mode '%s' sent via %s (%s form: %s)",
@@ -1068,7 +1086,10 @@ class SmartThingsTV:
 
         if not any_sent:
             self._log.error(
-                "Failed to set picture mode '%s' via any capability/form", mode
+                "Failed to set picture mode '%s' — every attempt was rejected "
+                "by SmartThings: %s",
+                mode,
+                "; ".join(failures) or "no attempt was made",
             )
         else:
             # All accepted-but-unapplied (or the last one unverifiable).

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.0b8"
+  "version": "8.6.0b9"
 }


### PR DESCRIPTION
Two defects surfaced by [#197](https://github.com/TheFab21/ha-samsungtv-smart/issues/197) (UE50RU7172, Slovak locale). Neither is proven to be *the* cause of picture mode not applying on that TV — see the caveat at the end.

## 1. Localized mode names arrive padded

Straight from the reporter's log:

```
Failed to set picture mode ' Prirodzený' via any capability/form
Failed to set picture mode ' Dynamický' via any capability/form
Failed to set picture mode ' Dynamic'   via any capability/form
```

Note the leading space. It is not ours: Samsung returns it inside `supportedPictureModesMap`, and we passed the name through untouched into the select options *and* back out as the command argument. Names are now stripped at both map-building sites (`_update_picture_mode` and the REST `_fetch_picture_mode_map`) and in the names-only fallback list, falling back to the id if a name is nothing but whitespace.

## 2. The error said nothing actionable

`Failed to set picture mode 'X' via any capability/form` means every `(capability, argument form)` attempt raised — but `_send_rest_command` uses `raise_for_status=True`, so those are real HTTP errors from SmartThings, and they were logged at **debug** level only. A user reporting the bug therefore had nothing to hand over without first enabling debug logging.

The failures are now collected and named in the error itself:

```
Failed to set picture mode 'Movie' — every attempt was rejected by SmartThings:
samsungvd.pictureMode (name='Movie'): 422 …; custom.picturemode (id='modeMovie'): 409 …
```

## Caveat

This does **not** explain why the sends are rejected on this TV — the padding alone shouldn't, since `Dynamic` without the space failed too, and the id form is looked up from the map either way. What it does is make the next log say why, so the real cause can be diagnosed rather than guessed at. The reporter's second error (`Field "components" … missing in DeviceStatus`, 3 occurrences) is a pysmartthings deserialization failure on an incomplete cloud payload and is not touched here.

Version `8.6.0b9`. Test suite unchanged (the 3 collection errors are pre-existing: `pytest` is absent from this environment, identical before and after).

Refs #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_