### PR TITLE
fix(smartthings): stop the picture mode retry matrix triggering rate limits

### DIFF
--- a/custom_components/samsungtv_smart/api/smartthings.py
+++ b/custom_components/samsungtv_smart/api/smartthings.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from enum import Enum
 import logging
 
-from aiohttp import ClientSession
+from aiohttp import ClientResponseError, ClientSession
 from pysmartthings import SmartThings
 
 from homeassistant.util import Throttle
@@ -1028,7 +1028,17 @@ class SmartThingsTV:
 
         any_sent = False
         failures: list[str] = []
+        # Capabilities this device has already refused as unsupported. The
+        # matrix tries each capability twice (name form, id form); a 422 is a
+        # verdict on the capability itself, so the second form is a wasted
+        # request -- and wasted requests are what push SmartThings into rate
+        # limiting (#197: a UE50RU7172 answered 422 for samsungvd.pictureMode
+        # and 409 for custom.picturemode, then 429 for everything once the
+        # four-request matrix had run a few times).
+        unsupported: set[str] = set()
         for capability, form in attempts:
+            if capability in unsupported:
+                continue
             argument = forms[form]
             try:
                 await self._send_rest_command(
@@ -1048,6 +1058,21 @@ class SmartThingsTV:
                 # Reporting only "failed via any capability/form" (#197) left
                 # nothing to act on without turning on debug logging first.
                 failures.append(f"{capability} ({form}={argument!r}): {err}")
+                status = (
+                    getattr(err, "status", None)
+                    if isinstance(err, ClientResponseError)
+                    else None
+                )
+                if status == 429:
+                    # Rate limited. Every remaining attempt would fail the same
+                    # way and dig the hole deeper, so stop here.
+                    self._log.warning(
+                        "SmartThings is rate limiting this device (429) — "
+                        "abandoning the remaining picture mode attempts"
+                    )
+                    break
+                if status == 422:
+                    unsupported.add(capability)
                 continue
             self._log.debug(
                 "Picture mode '%s' sent via %s (%s form: %s)",

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.0b9"
+  "version": "8.6.0b10"
 }


### PR DESCRIPTION
The improved error message from #198 did its job. From [#197](https://github.com/TheFab21/ha-samsungtv-smart/issues/197) on a UE50RU7172:

```
custom.picturemode    (name='Dynamický'):  409 Conflict
custom.picturemode    (id='modeDynamic'):  409 Conflict
samsungvd.pictureMode (name='Dynamický'):  422 Unprocessable Entity
samsungvd.pictureMode (id='modeDynamic'):  422 Unprocessable Entity
```

and then, two mode changes later, **429 Too Many Requests on all four** — and on every attempt after that.

## What that says

- **422** on `samsungvd.pictureMode` — the capability does not exist on this 2019 RU-series panel. That is a verdict on the *capability*, not on the argument form, so retrying it with the other form is a guaranteed-wasted request.
- **409** on `custom.picturemode` — the cloud refuses the command for this device. Not something the client can work around.
- **429** — self-inflicted. Each mode change fires up to four commands, plus a refresh and a verification read. The reporter changed mode five times in 21 seconds and walked straight into SmartThings' rate limiter. Once that starts, the remaining attempts only dig the hole deeper, and the log becomes unreadable exactly when it matters.

## The change

| response | before | after |
|---|---|---|
| 422 | try the same capability again with the other form | capability marked unsupported, its remaining attempts skipped |
| 429 | keep firing the rest of the matrix | abandon immediately, explicit warning |
| anything else | next attempt | next attempt *(unchanged)* |

Worst case drops from four requests to two on a device that supports only one capability, which is the common case for older panels.

## Scope

This does **not** fix the 409, and I am not going to pretend otherwise: `custom.picturemode` exists on that TV and the cloud still refuses `setPictureMode` for it. What this does is stop the integration from making the situation worse and from burying the real error under rate-limit noise. The reporter is being asked whether changing picture mode works in the SmartThings app itself — if it fails there too, the command path is unavailable for that model and no client-side change will help.

Version `8.6.0b10`.

Refs #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_