### PR TITLE
fix(picture-mode): find the local WS key by mode id, not by display name

### DIFF
--- a/custom_components/samsungtv_smart/api/smartthings.py
+++ b/custom_components/samsungtv_smart/api/smartthings.py
@@ -235,6 +235,16 @@ class SmartThingsTV:
         """Return picture mode list."""
         return self._picture_mode_list
 
+    @property
+    def picture_mode_map(self) -> dict[str, str]:
+        """Return the display name -> internal id map for picture modes.
+
+        The ids (``modeStandard``, ``modeMovie``, ...) are the only
+        language-independent handle on a picture mode; the display names are
+        localized by the TV.
+        """
+        return dict(self._picture_mode_map)
+
     def get_source_name(self, source_key: str) -> str:
         """Get source name from key."""
         if not self._source_list_map or source_key not in self._source_list_map:

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.0b10"
+  "version": "8.6.0b11"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -3312,7 +3312,20 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 pass
 
         # 2. Also send WS key as fallback (bypasses HDMI restrictions)
-        ws_key = _PICTURE_MODE_KEYS.get(picture_mode.lower())
+        #
+        # Look the key up by the INTERNAL ID first ("modeStandard", ...), and
+        # only then by the display name. The names above cover English, French
+        # and German; every other locale missed entirely, so the local fallback
+        # never fired exactly where it is needed most — on #197 (Slovak) the
+        # cloud rejected setPictureMode with 409 and only "Film" happened to
+        # match, leaving Dynamický / Štandardný / Prirodzený with no path at
+        # all. The id is language-independent, so this covers every locale.
+        mode_id = ""
+        if self._st:
+            mode_id = self._st.picture_mode_map.get(picture_mode, "")
+        ws_key = _PICTURE_MODE_KEYS.get(mode_id.lower()) or _PICTURE_MODE_KEYS.get(
+            picture_mode.lower()
+        )
         if ws_key:
             await self.async_send_command(ws_key)
             self._log.debug(


### PR DESCRIPTION
The full log and diagnostics from [#197](https://github.com/TheFab21/ha-samsungtv-smart/issues/197) changed the picture. Two findings, one of them fixable here.

## Finding 1 — the cloud command path is dead on that TV, and it is not our doing

Every `setPictureMode` is refused (409 on `custom.picturemode`, 422 on `samsungvd.pictureMode`). But the decisive line is elsewhere in the log:

```
REST command refresh/refresh sent, status: 200,
response: {'results': [{'id': 'e148ad2e-…', 'status': 'FAILED'}
```

A **different** command, to the **same** device, accepted at HTTP level — and reported `FAILED` by the cloud. So the PAT is valid, the device id is right, the request reaches SmartThings. Samsung's cloud simply cannot actuate this device. Nothing on our side fixes that.

## Finding 2 — our local fallback was silently locale-locked

`async_select_picture_mode` already sends a WebSocket remote key alongside the cloud call, precisely for when the cloud path does not work. But `_PICTURE_MODE_KEYS` is keyed on **display names**, in English, French and German only:

```python
"dynamic": "KEY_DYNAMIC", "dynamique": …, "dynamisch": …,
"standard": "KEY_STANDARD",
"movie": "KEY_MOVIE1", "film": …, "cinéma (étalonné)": …,
"eco": "KEY_ESAVING", "éco": …,
```

The TV localizes those names. This user's are `Dynamický`, `Štandardný`, `Prirodzený`, `Film` — only *Film* matched, by coincidence of spelling. Hence the one line in his log:

```
Picture mode 'Film' also sent via WS key KEY_MOVIE1
```

and nothing for the other three. The last working path was disabled by language.

## The fix

The internal id (`modeStandard`, `modeDynamic`, `modeMovie`, `modeEco`) is language-independent, and we already have it from `supportedPictureModesMap`. It is now looked up first, with the display name kept as fallback for TVs that expose no map. A `picture_mode_map` property was added to `SmartThingsTV` rather than reaching into the private dict.

Verified against the real mode lists:

| locale | before | after |
|---|---|---|
| Slovak (#197) | `Film` only | `Dynamický`→`KEY_DYNAMIC`, `Štandardný`→`KEY_STANDARD`, `Film`→`KEY_MOVIE1` |
| English | all 4 | all 4 *(unchanged)* |
| no map available | by name | by name *(unchanged)* |

`Prirodzený` (Natural) still resolves to nothing — see below. `FILMMAKER MODE` has no remote key on any locale, as before.

## One thing I did not change

`_PICTURE_MODE_KEYS` maps `"natural"` to `KEY_MOVIE1` — which would set **Movie** when the user asked for **Natural**. That looks wrong, but it predates this change and I have no evidence about which models it was added for, so I have not touched it. Deliberately *not* adding `"modenatural"` to the map: silently sending the wrong mode is worse than sending none.

Version `8.6.0b11`.

Refs #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_