### PR TITLE
fix(smartthings): report commands the cloud accepted but the TV never ran

### DIFF
--- a/custom_components/samsungtv_smart/api/smartthings.py
+++ b/custom_components/samsungtv_smart/api/smartthings.py
@@ -322,6 +322,24 @@ class SmartThingsTV:
                 resp.status,
                 result,
             )
+            # HTTP 200 only means SmartThings accepted the request; the body
+            # says whether the device executed it. A FAILED result here means
+            # the TV is registered in the cloud but not reachable by it --
+            # typically because the TV itself cannot reach Samsung's servers
+            # (blocked DNS, firewall). That looked like success in the log
+            # while nothing happened on the panel (#197), so say it plainly.
+            if any(
+                (item or {}).get("status") == "FAILED"
+                for item in (result or {}).get("results", [])
+            ):
+                self._log.warning(
+                    "SmartThings accepted %s/%s but the TV did not execute it "
+                    "(result: FAILED) — the TV is registered in the cloud but "
+                    "the cloud cannot reach it. Check the TV's own internet "
+                    "access (DNS/ad-blocking rules on samsung* domains).",
+                    capability,
+                    command,
+                )
 
     async def _update_source_list(self, main_comp: dict) -> None:
         """Update source list from device status, with custom name support.

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.0b11"
+  "version": "8.6.0b12"
 }


### PR DESCRIPTION
A blind spot exposed by [#197](https://github.com/TheFab21/ha-samsungtv-smart/issues/197).

## The problem

`HTTP 200` from `/devices/{id}/commands` only means SmartThings **accepted** the request. Whether the device actually executed it is in the body:

```json
{"results": [{"id": "e148ad2e-…", "status": "FAILED"}]}
```

We logged that verbatim at debug level and never looked at it. In the reporter's log the `refresh` command returned `FAILED` on **all twelve** calls, so the log read as a clean success while nothing reached the panel. It took a full log dump and a careful read to notice — the reporter had been chasing this for days, and I spent two rounds concluding the wrong things because the successful-looking line was right there.

That single field also explains the rest of that report: every `setPictureMode` refused with 409, status reads going stale, and changes made on the TV itself never appearing in Home Assistant. The device is registered in the cloud; the cloud simply cannot reach it.

## The change

A `FAILED` result now raises a warning that says what it means and where to look:

```
SmartThings accepted refresh/refresh but the TV did not execute it (result: FAILED)
— the TV is registered in the cloud but the cloud cannot reach it. Check the TV's
own internet access (DNS/ad-blocking rules on samsung* domains).
```

The ad-blocking hint is deliberate: the reporter runs Pi-hole, and Samsung's cloud endpoints are routinely caught by blocklists. A TV that cannot reach `*.samsungcloudsolution.com` still appears in the SmartThings app — it just stops responding to anything.

Parsing is defensive: missing body, missing `results`, empty list and `null` entries all evaluate false rather than raising inside a command send. Verified across those cases plus mixed `ACCEPTED`/`FAILED` results.

## Scope

This fixes no behaviour — it makes an invisible failure visible. Given how much time went into diagnosing #197 without it, that seems worth a warning line.

Version `8.6.0b12`.

Refs #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_