### PR TITLE
docs: finalise 8.6.0 for release

### DIFF
--- a/Frame_Art_Gallery.md
+++ b/Frame_Art_Gallery.md
@@ -411,6 +411,19 @@ action:
 
 This feature lets you browse images stored on your Home Assistant server and upload them directly to the Frame TV from the Lovelace UI — no Samsung app needed.
 
+> **Want to upload a photo straight from your phone instead?** The gallery card
+> shows images that are *already on the HA server*. For picking an image on
+> whatever device you are holding and pushing it to the Frame in one step, use
+> the bundled **`samsung-art-upload-card`** — no folder sensor, no pre-placed
+> file. It is documented in the [main README](README.md#entities). The two cards
+> complement each other: this one for a curated library, that one for a
+> spur-of-the-moment photo.
+>
+> Both go through the same upload path, so images are normalised for the panel
+> the same way (baseline JPEG, fitted to your screen resolution, EXIF rotation
+> applied, HEIC accepted) — see
+> [What happens to your image](README.md#what-happens-to-your-image).
+
 ### How It Works
 
 1. You store your images in `/config/media/<folder>/` (exposed via HA's Media Source)
@@ -516,8 +529,17 @@ A few details worth knowing:
   path does not end in `store`/`personal` and the image isn't already a
   `SAM-`/`MY_` artwork. Select/favourite/delete actions on TV-resident artwork are
   unaffected and keep using the configured `entity_id`.
-- **Single-Frame setups are unchanged.** With exactly one Frame TV detected, the
-  upload goes straight through to the configured entity with no extra prompt.
+- **With exactly one Frame detected, that Frame is used** — no prompt. Note it
+  is the *discovered* Frame, not the one named in your card config. Those are
+  normally the same TV, but they diverge when a second Frame is switched off at
+  the mains or has been removed: discovery only lists TVs currently exposing
+  `art_mode_status`, so an unreachable one drops out. Falling back to the
+  configured entity in that situation used to send uploads to the very TV
+  discovery had just excluded, silently and with no chooser to reveal it.
+- **An upload to an unreachable TV fails immediately**, with
+  *"&lt;host&gt; is unreachable — cannot upload"*, instead of waiting on a
+  power-on that can never complete. A Frame in standby still answers its REST
+  endpoint and is woken normally; one that is unplugged or faulty does not.
 - **No configuration needed.** Frames are discovered automatically from the
   `art_mode_status` attribute that the integration adds to each Frame's
   `media_player`. Any Frame the integration manages shows up in the chooser.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode su
 - [Automations & Tips](#automations--tips)
 - [Troubleshooting](#troubleshooting)
   - [Integration not appearing in Add Integration](#integration-not-appearing-in-add-integration)
+  - [Picture mode does not change the TV at all](#picture-mode-does-not-change-the-tv-at-all)
   - [IP Control reports Art Mode "on" when it isn't](#ip-control-reports-art-mode-on-when-it-isnt)
 - [Credits](#credits)
 
@@ -606,8 +607,19 @@ obscure works, and identifies photographs too).
 
 **Enable it** under **Settings → Devices & Services → your TV → Configure →
 Art Identification**: turn it on, paste a Google Vision API key, pick the LLM
-provider and paste its key (an optional model field defaults sensibly). Keys are
-stored in the config entry, never in YAML.
+provider and paste its key. Keys are stored in the config entry, never in YAML.
+
+Once a provider and key are saved, the **Model** field becomes a dropdown of
+the models your key can actually use, read live from the provider — so a model
+the provider retires no longer breaks identification silently. It stays
+free-text-capable for a brand-new model or a fine-tune, and **leaving it blank
+picks the best available model automatically**.
+
+Reverse image search fails more often than you would expect on artwork, so when
+it returns nothing usable the model may identify a piece it recognises on its
+own. Those answers are capped at **confidence 0.6**, so the attribute stays
+meaningful: above 0.6 means corroborated by the web, at or below means the
+model recognised it unaided.
 
 Once enabled, **`sensor.<tv>_art_metadata`** identifies each artwork
 automatically as it changes (debounced) and exposes the metadata as attributes,
@@ -824,6 +836,46 @@ The SmartThings `supportedInputSources` attribute returns empty on some 2024 Fra
 ### Picture mode not updating after change
 
 SmartThings caches the picture mode value. This fork automatically sends a `refresh` command after any `setPictureMode` call to force the TV to report the new value. If the `select` entity still shows a stale value, wait a few seconds for the next poll cycle.
+
+### Picture mode does not change the TV at all
+
+The error now names the response SmartThings gave for every attempt, and the
+code tells you where the problem is:
+
+| response | meaning | what to do |
+|---|---|---|
+| **422** Unprocessable Entity | that capability does not exist on your model | nothing — the other capability is tried automatically |
+| **429** Too Many Requests | rate limited | wait a minute; avoid changing mode repeatedly in quick succession |
+| **409** Conflict on *every* attempt | the cloud will not deliver commands to your TV | see below |
+
+Also look for this warning, which is the decisive one:
+
+```text
+SmartThings accepted refresh/refresh but the TV did not execute it (result: FAILED)
+— the TV is registered in the cloud but the cloud cannot reach it.
+```
+
+**A `FAILED` result, or a 409 on every attempt, is not an integration problem.**
+It means Samsung's cloud has your TV registered but cannot talk to it, so it
+serves the last state it knows while accepting and dropping every command. The
+tell-tale signs: nothing works from the **SmartThings mobile app** either, and
+changes made on the TV with its own remote never appear in Home Assistant.
+
+The usual cause is the TV's own internet access being filtered — Pi-hole,
+AdGuard Home or a router blocklist catching Samsung's cloud endpoints as
+"telemetry". To check:
+
+1. In your DNS filter's query log, filter by the TV's IP address and look for
+   **blocked** entries.
+2. Allow `*.samsungcloudsolution.com`, `*.samsungcloudsolution.net`,
+   `*.samsungiotcloud.com`, `*.samsungosp.com` and `*.samsungqbe.com`.
+3. **Power-cycle the TV at the mains** — a standby toggle is not enough, the
+   cloud connection is only re-established on a cold boot.
+
+Picture mode also has a local fallback: a WebSocket remote key is sent straight
+to the TV alongside the cloud command, which works on TVs that honour those
+keys regardless of SmartThings. `FILMMAKER MODE` and `Natural` have no
+dedicated key and are cloud-only.
 
 ### Frame Art services not working
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode su
   - [Options](#options)
   - [Reconfigure](#reconfigure)
 - [Entities](#entities)
+  - [Detecting Art Mode vs. watching TV](#detecting-art-mode-vs-watching-tv)
 - [Services](#services)
   - [Standard TV Services](#standard-tv-services)
   - [Frame Art Services](#frame-art-services)
 - [Frame Art Mode](#frame-art-mode)
+  - [What happens to your image](#what-happens-to-your-image)
   - [Thumbnail Downloads](#thumbnail-downloads)
   - [Artwork Identification](#artwork-identification)
 - [Automations & Tips](#automations--tips)
@@ -53,6 +55,7 @@ This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode su
 - **Artwork identification (opt-in)** — reverse image search (Google Vision) confirmed by an LLM (Claude / OpenAI / Gemini) shows the title, artist, date and bio of the art on your Frame, in 5 languages
 - New dedicated entities: Art Mode switch and Frame Art sensor
 - **Picture mode control** — `select` entity with dual-strategy (SmartThings API + WS fallback for HDMI inputs)
+- **Audio output selection** — `select` entity for TV speaker / external / **Q-Symphony** when a compatible Samsung soundbar is paired
 - **Improved source detection** — REST fallback for Frame 2024 TVs where `supportedInputSources` returns empty; supports custom source names
 - **App name resolution** — unknown SmartThings app IDs are parsed and resolved to display names
 - Improved WebSocket connection stability — prevents zombie connections and saturation
@@ -61,6 +64,7 @@ This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode su
 - Logo fetching for apps and sources
 - `folder-gallery-card` Lovelace card bundled — no manual installation required
 - `samsung-art-upload-card` Lovelace card bundled — pick an image on any device (phone, laptop) and push it straight to the Frame in one tap
+- **Uploads are prepared for the panel** — baseline JPEG, fitted to your screen resolution (8K and portrait included), EXIF rotation applied, **HEIC/HEIF from iPhone accepted**, and never switching the TV away from what you are watching
 
 ---
 
@@ -340,7 +344,16 @@ Each configured TV creates the following entities:
 | `switch.<tv_name>_art_mode` | Switch | Toggle Art Mode on/off (Frame TVs only) |
 | `sensor.<tv_name>_frame_art` | Sensor | Currently displayed artwork info (Frame TVs only) |
 | `sensor.<tv_name>_personal` / `_store` / `_other` | Sensor | Thumbnail folder size (MB) per subdirectory, with a `file_list` attribute for gallery cards (Frame TVs only, auto-created in v7) |
+| `sensor.<tv_name>_art_metadata` | Sensor | Title, artist and description of the current artwork (Frame TVs, requires [Artwork Identification](#artwork-identification)) |
 | `select.<tv_name>_picture_mode` | Select | Change picture mode (Standard, Movie, etc.) |
+| `select.<tv_name>_color_tone` | Select | Colour tone / white balance preset |
+| `select.<tv_name>_speaker_select` | Select | Audio output — TV speaker, external, or Q-Symphony when a compatible soundbar is paired |
+| `select.<tv_name>_matte_type` / `_matte_color` | Select | Art Mode matte style and colour (Frame TVs only) |
+| `select.<tv_name>_motion_sensitivity` / `_motion_timer` / `_brightness_sensor` | Select | Frame motion detector and ambient light sensor settings |
+| `number.<tv_name>_art_mode_brightness` / `_art_mode_color_temperature` | Number | Art Mode panel brightness and colour temperature (Frame TVs only) |
+| `number.<tv_name>_backlight` | Number | Panel backlight level |
+| `button.<tv_name>_reboot` | Button | Reboot the TV |
+| `remote.<tv_name>` | Remote | Send remote key sequences |
 
 > **Note:** The `folder-gallery-card` Lovelace card is bundled with this integration and registered automatically. No manual installation or resource configuration required.
 
@@ -359,13 +372,47 @@ Each configured TV creates the following entities:
 
 In addition to standard media player attributes, the following are available:
 
-- `device_model`, `device_name`, `device_os`, `device_mac`
 - `picture_mode`, `picture_mode_list`
 - `sound_mode`, `sound_mode_list`
 - `channel`, `channel_name`, `channel_number`
-- `app_id`, `app_name`
-- `frame_art_mode` — whether Art Mode is active
-- `frame_art_current` — content ID of the current artwork
+- `app_id`, `source`, `source_list`
+- `ip_address`, `config_entry_id`
+- `screen_resolution` — the panel's native resolution (e.g. `3840x2160`), used
+  to fit uploaded images to the screen
+- `art_mode_status` — `on` or `off` on Frame TVs; **absent** when the TV is in
+  standby. See [Detecting Art Mode vs. watching TV](#detecting-art-mode-vs-watching-tv)
+- `frame_art_last_result` — outcome of the last Frame Art service call
+
+### Detecting Art Mode vs. watching TV
+
+A Frame is a **tri-state** device — standby, Art Mode, or actually being
+watched — while a `media_player` only has `on` and `off`:
+
+| the panel is | `media_player` state | `art_mode_status` |
+|---|---|---|
+| in standby | `off` | *(absent)* |
+| showing artwork | `on` | `on` |
+| being watched | `on` | `off` |
+
+Art Mode reports `on` because the panel *is* powered: it answers commands,
+accepts uploads, and `turn_on` would do nothing. The third state lives in the
+attribute. To automate on "someone is actually watching":
+
+```yaml
+template:
+  - binary_sensor:
+      - name: TV actually being watched
+        state: >
+          {{ is_state('media_player.YOUR_TV', 'on')
+             and state_attr('media_player.YOUR_TV', 'art_mode_status') != 'on' }}
+        delay_on: "00:00:05"
+```
+
+The `delay_on` matters: waking from standby powers the panel *before*
+`art_mode_status` settles (up to ~30–45 s when the value comes from the
+SmartThings cloud rather than local IP Control), so without it a TV waking
+straight into Art Mode briefly looks like someone switched it on. Debouncing
+the rise only keeps "turned off" instantaneous.
 
 ### Frame Art Sensor Attributes
 
@@ -449,7 +496,7 @@ These services require a Samsung **Frame TV** with Art Mode. They are called on 
 | `samsungtv_smart.art_available` | List all available artworks (optionally filtered by category) |
 | `samsungtv_smart.art_get_current` | Get info about the currently displayed artwork |
 | `samsungtv_smart.art_select_image` | Display a specific artwork by content ID |
-| `samsungtv_smart.art_upload` | Upload a local image to the TV |
+| `samsungtv_smart.art_upload` | Upload a local image to the TV — see [What happens to your image](#what-happens-to-your-image) |
 | `samsungtv_smart.art_upload_batch` | Upload every image in a folder — idempotent re-runs (skips unchanged files) + throttle for large batches + optional perceptual duplicate check |
 | `samsungtv_smart.art_identify` | Identify the current artwork (reverse image search + LLM) and return its metadata. Requires the Art Identification option to be configured |
 | `samsungtv_smart.art_delete` | Delete a user-uploaded artwork (MY-* IDs only) |
@@ -565,6 +612,27 @@ Format: `type_color`
 ### Photo Filters
 
 Available filters: `none`, `mono`, `original`, `ink`, `watercolor`, `oil`, `pastel`, `posterize`, `noir`, `quartertone`
+
+### What happens to your image
+
+Frame TVs are strict about what they accept, and a rejected upload usually
+fails as a grey rectangle rather than an error. Every upload — from the
+`art_upload` and `art_upload_batch` services, the upload card and the gallery
+card alike — is therefore normalised first:
+
+- **Converted to baseline JPEG** (never progressive), 4:2:0 chroma, quality 92.
+  Maximum quality was tried and the TVs refuse it.
+- **Fitted to your panel's resolution**, read from the `screen_resolution`
+  attribute — so 8K panels are not downscaled to 4K, and **portrait images keep
+  their orientation** instead of being fitted to a landscape box.
+- **EXIF orientation applied, then all metadata stripped.** Photos that
+  appeared rotated on the TV no longer do.
+- **HEIC/HEIF accepted.** Photos straight from an iPhone work without
+  converting them first.
+
+Uploading does **not** change what is on screen: it never switches the TV into
+Art Mode, and never pulls it away from the input you are watching. The artwork
+is added to the Frame's library, exactly as the SmartThings app does it.
 
 ### Thumbnail Downloads
 

--- a/RELEASE_NOTES_8.6.0.md
+++ b/RELEASE_NOTES_8.6.0.md
@@ -4,10 +4,10 @@ If this project is useful to you, you can support its development:
 
 # <a href="https://buymeacoffee.com/thefab21" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-black.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
-> **Status: stable release.** Focused on Artwork Identification: it stops
-> breaking when a provider retires a model, and it works with the current
-> generation of reasoning models. No breaking changes; existing configurations
-> keep working.
+> **Status: stable release.** Two themes: Artwork Identification stops breaking
+> when a provider retires a model and now recognises works it used to refuse,
+> and picture mode failures finally say what is wrong instead of failing
+> silently. No breaking changes; existing configurations keep working.
 
 ## Highlights
 
@@ -15,8 +15,12 @@ If this project is useful to you, you can support its development:
   hardcoded — so a retired model no longer silently breaks identification.
 - **Gemini 3.x models work.** Identification failed with a cryptic JSON error
   on the newer models; the cause was the reply being cut off, not malformed.
-- **A model that becomes unavailable now tells you so**, and lists the models
-  your key can actually use.
+- **Famous artworks are identified again.** Well-known pieces came back
+  "not identified" because of how we phrased the question, not because the
+  model could not answer it.
+- **Picture mode failures are diagnosable.** They used to report *"failed via
+  any capability/form"* and nothing else; they now name the exact response from
+  SmartThings — including commands the cloud accepts but never delivers.
 
 ---
 
@@ -224,6 +228,64 @@ Two error paths that used to mislead:
 
 ---
 
+## Picture mode: saying what actually failed
+
+A report of picture mode simply not working ([#197](https://github.com/TheFab21/ha-samsungtv-smart/issues/197))
+turned into four separate defects, none of which changed the panel but all of
+which hid the real cause.
+
+**The error said nothing.** `Failed to set picture mode 'Movie' via any
+capability/form` means every attempt was rejected — but the HTTP errors behind
+those rejections were logged at debug level only, so a bug report contained
+nothing to act on. They are now named in the error itself:
+
+```text
+Failed to set picture mode 'Movie' — every attempt was rejected by SmartThings:
+custom.picturemode (name='Movie'): 409 Conflict;
+samsungvd.pictureMode (id='modeMovie'): 422 Unprocessable Entity
+```
+
+**We were causing our own rate limiting.** Each change fires up to four
+commands (two capabilities × two argument forms), plus a refresh and a
+read-back. A 422 is a verdict on the *capability*, so retrying it with the
+other argument form is a guaranteed-wasted request — and enough of those walk
+the device into SmartThings' rate limiter, after which everything fails
+regardless. A 422 now marks the capability unsupported, and a 429 abandons the
+remaining attempts instead of digging deeper.
+
+**Localized mode names arrived padded.** Samsung returns them with leading
+whitespace in some locales (` Prirodzený`, ` Dynamický`), which we passed
+straight into the dropdown and back out as the command argument. Now stripped.
+
+**The local fallback was locked to three languages.** When the cloud cannot
+apply a picture mode, the integration also sends a WebSocket remote key
+directly to the TV. That key was looked up by *display name*, and only English,
+French and German were listed — so on any other locale the fallback silently
+never fired. It is now looked up by the internal mode id (`modeStandard`,
+`modeDynamic`, …), which is the same in every language.
+
+> **Note:** `FILMMAKER MODE` and `Natural` still have no remote key. Rather
+> than send an approximation, they send nothing — the table maps "natural" to
+> the *Movie* key, and quietly setting the wrong mode is worse than setting
+> none.
+
+**And the most consequential one: a command can be accepted and never run.**
+`HTTP 200` from SmartThings only means the request was accepted; whether the TV
+executed it is in the body:
+
+```json
+{"results": [{"id": "…", "status": "FAILED"}]}
+```
+
+We logged that verbatim and never read it. In the report above, `refresh`
+returned `FAILED` on all twelve calls while the log read like a success — which
+is exactly what a TV looks like when it is registered in the SmartThings cloud
+but can no longer reach it (commonly: DNS or ad-blocking rules catching
+`samsung*` domains). That now raises an explicit warning naming the cause,
+rather than leaving a working-looking log and a TV that ignores everything.
+
+---
+
 ## Upgrade notes
 
 - No configuration changes. Update via HACS and restart Home Assistant.
@@ -231,8 +293,10 @@ Two error paths that used to mislead:
   Identification*, clear the **Model** field and save: the best available model
   for your key is selected automatically. Re-opening the page then shows the
   full dropdown.
-- Nothing else in the integration is affected — this release touches only the
-  identification pipeline and its configuration step.
+- **If picture mode has never worked on your TV**, the new error message now
+  says why. A `FAILED` result or a 409 on every attempt means the SmartThings
+  cloud cannot reach the TV itself — check the TV's own internet access before
+  suspecting the integration.
 
 ---
 
@@ -265,3 +329,17 @@ Two error paths that used to mislead:
   model may identify a work it recognises unaided (confidence capped at 0.6).
 - **Fix:** an upload to an unreachable TV fails immediately with a clear
   message instead of hanging on a power-on that cannot happen.
+- **Fix:** a failed picture mode change names the SmartThings response for
+  every attempt instead of reporting only "via any capability/form"
+  ([#197](https://github.com/TheFab21/ha-samsungtv-smart/issues/197)).
+- **Fix:** a 422 no longer triggers a second attempt on the same capability,
+  and a 429 stops the remaining attempts — the retry matrix was walking devices
+  into SmartThings' rate limiter.
+- **Fix:** localized picture mode names are stripped of the leading whitespace
+  Samsung returns in some locales.
+- **Fix:** the local WebSocket key fallback for picture mode is resolved by
+  mode id instead of display name, so it works outside English, French and
+  German.
+- **New:** a command the cloud accepts but the TV never executes
+  (`{"status": "FAILED"}`) raises a warning naming the likely cause, instead of
+  appearing in the log as a success.

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.0b12"
+  "version": "8.6.0"
 }


### PR DESCRIPTION
Documentation pass before publishing 8.6.0 as latest. Version set to `8.6.0`.

## Why

The release notes were written when identification was the only theme, and never caught up with the work that came out of [#197](https://github.com/TheFab21/ha-samsungtv-smart/issues/197). Four picture mode defects and the accepted-but-never-executed command were shipped with no user-facing description at all.

## Release notes

- **Summary and highlights** rewritten around both themes instead of one.
- **New section — "Picture mode: saying what actually failed"**, covering:
  - the error that reported only *"via any capability/form"*, with the new message shown;
  - the retry matrix walking devices into SmartThings' rate limiter, and why a 422 makes the second argument form pointless;
  - localized mode names arriving with leading whitespace;
  - the WebSocket key fallback silently locked to English, French and German — including an explicit note that `Natural` and `FILMMAKER MODE` deliberately send *nothing* rather than an approximation, since the table maps "natural" to the *Movie* key;
  - `HTTP 200` with `{"status": "FAILED"}` — a command accepted by the cloud and never delivered to the TV.
- **Upgrade notes** now tell a user what a 409 on every attempt actually means, so they check the TV's connectivity before suspecting the integration.
- **Changelog** extended with the six corresponding entries.

## README

- **New troubleshooting section — "Picture mode does not change the TV at all"**: a response-code table (422 / 429 / 409), the decisive `FAILED` warning, how to recognise that the fault is outside Home Assistant (fails in the SmartThings app too; changes made on the TV never reach HA), and the DNS/ad-blocking check with the Samsung domains to allow and the reminder that a cold power cycle is required. This symptom will bring other Pi-hole and AdGuard users to the tracker, so it belongs here rather than buried in an issue.
- **Artwork Identification** section updated for what 8.6.0 actually does: the live model dropdown, blank = best available model, and what the 0.6 confidence cap means (above it, corroborated by the web; at or below, recognised by the model unaided).
- Table of contents entry added for the new section.

No code changes beyond the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_