### PR TITLE
docs: state the My Home Assistant prerequisite for OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,27 @@ Three methods are available. Choose **one**.
 
 This method authenticates via your Samsung account. Tokens are refreshed automatically.
 
+> **Prerequisite — My Home Assistant.** The redirect URI below
+> (`https://my.home-assistant.io/redirect/oauth`) is a **relay**, not a page on
+> your server: after you authorise, your browser goes to my.home-assistant.io,
+> which sends you back to *your* instance using the URL registered there. So
+> before starting:
+>
+> - the **My Home Assistant** integration must be enabled (it is part of
+>   `default_config`, but not of a stripped-down `configuration.yaml`);
+> - **Settings → System → Network** must have your instance URL set;
+> - <https://my.home-assistant.io> must have the same URL under *My Home
+>   Assistant Instance URL*, including scheme and port
+>   (e.g. `http://192.168.1.50:8123`).
+>
+> If any of these is missing, clicking **Authorize** ends on a **404: Not
+> found** ([#204](https://github.com/TheFab21/ha-samsungtv-smart/issues/204)) —
+> the authorisation itself succeeded, the way back did not. This bites Docker
+> installs in particular, where no external URL is configured by default. If
+> you would rather not use My Home Assistant at all, use the
+> [Personal Access Token](#option-2--personal-access-token-pat) method, which
+> involves no redirect.
+
 **Step 1 — Create a SmartThings OAuth App (one time)**
 
 > ⚠️ The SmartThings Developer Portal web UI no longer supports creating OAuth apps. Use the SmartThings CLI instead.

--- a/README.md
+++ b/README.md
@@ -202,10 +202,26 @@ This method authenticates via your Samsung account. Tokens are refreshed automat
 > If any of these is missing, clicking **Authorize** ends on a **404: Not
 > found** ([#204](https://github.com/TheFab21/ha-samsungtv-smart/issues/204)) —
 > the authorisation itself succeeded, the way back did not. This bites Docker
-> installs in particular, where no external URL is configured by default. If
-> you would rather not use My Home Assistant at all, use the
-> [Personal Access Token](#option-2--personal-access-token-pat) method, which
-> involves no redirect.
+> installs in particular, where no external URL is configured by default.
+>
+> ⚠️ **Do not replace the hostname with your own.** `https://my.home-assistant.io/redirect/oauth`
+> works as a whole; `https://your-ha.example.com/redirect/oauth` gives a 404,
+> because `/redirect/oauth` is a route on the relay, not on your server.
+
+**Prefer not to use My Home Assistant?** You can point SmartThings at your own
+instance instead — Home Assistant uses this form automatically when My Home
+Assistant is not in use. Register this redirect URI instead of the one above:
+
+```text
+https://your-ha.example.com/auth/external/callback
+```
+
+`/auth/external/callback` is the route Home Assistant genuinely serves. Set the
+same URL as your external URL under **Settings → System → Network**. This keeps
+the callback on your own domain, with no third-party hop — it does require your
+instance to be reachable over HTTPS at that address. Failing that, the
+[Personal Access Token](#option-2--personal-access-token-pat) method involves no
+redirect at all.
 
 **Step 1 — Create a SmartThings OAuth App (one time)**
 


### PR DESCRIPTION
Doc gap surfaced by [#204](https://github.com/TheFab21/ha-samsungtv-smart/issues/204): a user gets a bare **404: Not found** immediately after clicking *Authorize*, with nothing in the logs.

## What is actually missing

The OAuth instructions tell you to register `https://my.home-assistant.io/redirect/oauth` as the redirect URI, but never say what that URL *is*. It is a **relay**, not a page on the user's server: the browser goes to my.home-assistant.io, which sends it back to their instance using the URL registered there.

So the flow silently depends on three things we never mention:

- the **My Home Assistant** integration being enabled (part of `default_config`, but not of a stripped-down `configuration.yaml`);
- an instance URL set in **Settings → System → Network**;
- the same URL registered at my.home-assistant.io, with scheme and port.

If any is missing, authorisation *succeeds* and the way back fails — which is exactly the confusing part: the user sees a 404 and assumes the integration rejected them, while no integration code has run yet. There is no `redirect_uri` or callback handling anywhere in this component; it inherits `AbstractOAuth2FlowHandler` and core owns the redirect entirely.

Docker installs hit this hardest, since they commonly have no external URL configured.

## The change

A prerequisite note at the top of *Option 1 — OAuth2*, listing the three requirements, naming the 404 symptom with a link to the issue, and pointing at the PAT method for anyone who would rather not involve My Home Assistant at all.

Docs only — no code changes. Anchors verified, including the cross-reference to the PAT section.

Refs #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_