### PR TITLE
docs: say which channel each entity needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,24 +373,37 @@ To change connection or credentials after setup, open **Settings → Devices & S
 
 ## Entities
 
-Each configured TV creates the following entities:
+**Not every TV gets every entity** — most are created only when the channel
+they depend on is available. A plain (non-Frame) TV without SmartThings or IP
+Control gets just the media player and remote; that is expected, not a fault.
+The **Requires** column below says what each one needs.
 
-| Entity | Type | Description |
-|---|---|---|
-| `media_player.<tv_name>` | Media Player | Main TV control entity |
-| `switch.<tv_name>_art_mode` | Switch | Toggle Art Mode on/off (Frame TVs only) |
-| `sensor.<tv_name>_frame_art` | Sensor | Currently displayed artwork info (Frame TVs only) |
-| `sensor.<tv_name>_personal` / `_store` / `_other` | Sensor | Thumbnail folder size (MB) per subdirectory, with a `file_list` attribute for gallery cards (Frame TVs only, auto-created in v7) |
-| `sensor.<tv_name>_art_metadata` | Sensor | Title, artist and description of the current artwork (Frame TVs, requires [Artwork Identification](#artwork-identification)) |
-| `select.<tv_name>_picture_mode` | Select | Change picture mode (Standard, Movie, etc.) |
-| `select.<tv_name>_color_tone` | Select | Colour tone / white balance preset |
-| `select.<tv_name>_speaker_select` | Select | Audio output — TV speaker, external, or Q-Symphony when a compatible soundbar is paired |
-| `select.<tv_name>_matte_type` / `_matte_color` | Select | Art Mode matte style and colour (Frame TVs only) |
-| `select.<tv_name>_motion_sensitivity` / `_motion_timer` / `_brightness_sensor` | Select | Frame motion detector and ambient light sensor settings |
-| `number.<tv_name>_art_mode_brightness` / `_art_mode_color_temperature` | Number | Art Mode panel brightness and colour temperature (Frame TVs only) |
-| `number.<tv_name>_backlight` | Number | Panel backlight level |
-| `button.<tv_name>_reboot` | Button | Reboot the TV |
-| `remote.<tv_name>` | Remote | Send remote key sequences |
+| Entity | Type | Requires | Description |
+|---|---|---|---|
+| `media_player.<tv_name>` | Media Player | — | Main TV control entity |
+| `remote.<tv_name>` | Remote | — | Send remote key sequences |
+| `select.<tv_name>_picture_mode` | Select | SmartThings | Change picture mode (Standard, Movie, etc.) |
+| `select.<tv_name>_speaker_select` | Select | SmartThings **or** IP Control | Audio output — TV speaker, external, or Q-Symphony when a compatible soundbar is paired |
+| `select.<tv_name>_color_tone` | Select | **IP Control** | Colour tone / white balance preset |
+| `number.<tv_name>_backlight` | Number | **IP Control** | Panel backlight level |
+| `number.<tv_name>_contrast` / `_brightness` / `_sharpness` / … | Number | **IP Control** | Expert picture calibration sliders (normal viewing only) |
+| `button.<tv_name>_reboot` | Button | **IP Control** | Reboot the TV |
+| `switch.<tv_name>_art_mode` | Switch | Frame TV | Toggle Art Mode on/off |
+| `sensor.<tv_name>_frame_art` | Sensor | Frame TV | Currently displayed artwork info |
+| `sensor.<tv_name>_personal` / `_store` / `_other` | Sensor | Frame TV | Thumbnail folder size (MB) per subdirectory, with a `file_list` attribute for gallery cards (auto-created in v7) |
+| `select.<tv_name>_matte_type` / `_matte_color` | Select | Frame TV | Art Mode matte style and colour |
+| `select.<tv_name>_motion_sensitivity` / `_motion_timer` / `_brightness_sensor` | Select | Frame TV | Frame motion detector and ambient light sensor settings |
+| `number.<tv_name>_art_mode_brightness` / `_art_mode_color_temperature` | Number | Frame TV | Art Mode panel brightness and colour temperature |
+| `sensor.<tv_name>_art_metadata` | Sensor | Frame TV + [Artwork Identification](#artwork-identification) | Title, artist and description of the current artwork |
+
+Where:
+
+- **SmartThings** — an API key and device ID are configured (see [SmartThings Authentication](#smartthings-authentication)).
+- **IP Control** — the local JSON-RPC channel (port 1516) is **paired** *and*
+  *Enable IP Control* is on, under **Reconfigure → IP Control**. Pairing is
+  optional and is **not** done automatically: if you have never paired it, none
+  of the entities marked *IP Control* exist. See [Reconfigure](#reconfigure).
+- **Frame TV** — the TV reports Art Mode support. Detected automatically.
 
 > **Note:** The `folder-gallery-card` Lovelace card is bundled with this integration and registered automatically. No manual installation or resource configuration required.
 


### PR DESCRIPTION
Doc defect reported as a bug in [#206](https://github.com/TheFab21/ha-samsungtv-smart/issues/206): a user on a UE82NU8005 (2018, non-Frame) gets 5 entities, reads the README table listing 16, and concludes the integration is broken. It is not — but the table gave him every reason to think so, and that table is two days old, so the omission is mine.

## The problem

The Entities table listed all entities flatly, with conditions mentioned only in passing prose for some Frame ones ("Frame TVs only") and not at all for the rest. Nothing said that `number.<tv>_backlight` — the entity he specifically wanted — requires the **IP Control** channel to be paired, and that pairing is a manual, optional step that never happens on its own.

## The change

A **Requires** column, verified against the platform setup code rather than assumed:

| condition | gate in code | entities |
|---|---|---|
| SmartThings | `api_key and device_id` | picture mode, speaker select (ST variant) |
| IP Control | `CONF_IP_CONTROL_TOKEN` **and** `CONF_ENABLE_IP_CONTROL` (`_ip_control_active`) | colour tone, speaker select (IP variant), backlight, the 5 picture sliders, reboot button |
| Frame TV | `CONF_IS_FRAME_TV` cached, else `art_api.supported()` | art mode switch, frame art sensors, mattes, motion/brightness selects, art numbers, art metadata |

Also:

- The **five expert picture sliders** (`contrast`, `brightness`, `sharpness`, …) were not documented anywhere. Added.
- A sentence up front stating that a plain TV with neither SmartThings nor IP Control gets only the media player and remote, and that this is expected rather than a fault — which is the sentence that would have prevented this issue.
- An explicit note that IP Control pairing is **not** automatic, with a pointer to *Reconfigure → IP Control*.

Docs only. Anchors verified.

Refs #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_