### PR TITLE
fix(picture-mode): resolve the local remote key in any language

### DIFF
--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.2"
+  "version": "8.6.3"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -115,7 +115,6 @@ from .const import (
     CONF_IP_CONTROL_FW_VERSION,
     CONF_IP_CONTROL_MODEL_ID,
     CONF_IP_CONTROL_TOKEN,
-    ip_control_port,
     CONF_LOGO_OPTION,
     CONF_OAUTH_TOKEN,
     CONF_PING_PORT,
@@ -180,6 +179,7 @@ from .const import (
     AppLaunchMethod,
     AppLoadMethod,
     PowerOnMethod,
+    ip_control_port,
 )
 from .entity import SamsungTVEntity
 from .logo import LOGO_OPTION_DEFAULT, LocalImageUrl, Logo, LogoOption

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -183,6 +183,7 @@ from .const import (
 )
 from .entity import SamsungTVEntity
 from .logo import LOGO_OPTION_DEFAULT, LocalImageUrl, Logo, LogoOption
+from .picture_mode_keys import picture_mode_ws_key
 from .token_notify import (
     METHOD_IP_CONTROL,
     METHOD_LOCAL,
@@ -3286,30 +3287,6 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         the SmartThings API to return COMPLETED but the TV to show
         "function not available".
         """
-        # Map picture mode display names / internal ids to WS key codes.
-        # Only Dynamic, Standard, Movie and Eco have dedicated keys.
-        # Filmmaker Mode has no dedicated key.
-        _PICTURE_MODE_KEYS = {
-            # Dynamic
-            "dynamic": "KEY_DYNAMIC",
-            "dynamique": "KEY_DYNAMIC",
-            "dynamisch": "KEY_DYNAMIC",
-            "modedynamic": "KEY_DYNAMIC",
-            # Standard
-            "standard": "KEY_STANDARD",
-            "modestandard": "KEY_STANDARD",
-            # Movie / Film / Cinema
-            "movie": "KEY_MOVIE1",
-            "film": "KEY_MOVIE1",
-            "cinéma (étalonné)": "KEY_MOVIE1",
-            "modemovie": "KEY_MOVIE1",
-            "natural": "KEY_MOVIE1",
-            # Eco
-            "eco": "KEY_ESAVING",
-            "éco": "KEY_ESAVING",
-            "modeeco": "KEY_ESAVING",
-        }
-
         # 1. Try SmartThings API (works for native TV sources)
         if self._st:
             try:
@@ -3317,21 +3294,12 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             except Exception:
                 pass
 
-        # 2. Also send WS key as fallback (bypasses HDMI restrictions)
-        #
-        # Look the key up by the INTERNAL ID first ("modeStandard", ...), and
-        # only then by the display name. The names above cover English, French
-        # and German; every other locale missed entirely, so the local fallback
-        # never fired exactly where it is needed most — on #197 (Slovak) the
-        # cloud rejected setPictureMode with 409 and only "Film" happened to
-        # match, leaving Dynamický / Štandardný / Prirodzený with no path at
-        # all. The id is language-independent, so this covers every locale.
+        # 2. Also send WS key as fallback (bypasses HDMI restrictions, and is
+        # the only path left when the cloud refuses the command entirely).
         mode_id = ""
         if self._st:
             mode_id = self._st.picture_mode_map.get(picture_mode, "")
-        ws_key = _PICTURE_MODE_KEYS.get(mode_id.lower()) or _PICTURE_MODE_KEYS.get(
-            picture_mode.lower()
-        )
+        ws_key = picture_mode_ws_key(picture_mode, mode_id)
         if ws_key:
             await self.async_send_command(ws_key)
             self._log.debug(
@@ -3341,9 +3309,9 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             )
         else:
             self._log.debug(
-                "No direct WS key for '%s', skipping WS fallback "
-                "(FILMMAKER MODE has no dedicated remote key)",
+                "No WS key for picture mode '%s' (id=%s) — skipping WS fallback",
                 picture_mode,
+                mode_id or "unknown",
             )
 
     # ==========================================

--- a/custom_components/samsungtv_smart/number.py
+++ b/custom_components/samsungtv_smart/number.py
@@ -42,7 +42,6 @@ from .api.ipcontrol import (
 from .const import (
     CONF_ENABLE_IP_CONTROL,
     CONF_IP_CONTROL_TOKEN,
-    ip_control_port,
     CONF_IS_FRAME_TV,
     CONF_WS_NAME,
     DATA_ART_API,
@@ -50,6 +49,7 @@ from .const import (
     DEFAULT_PORT,
     DOMAIN,
     WS_PREFIX,
+    ip_control_port,
 )
 from .token_notify import METHOD_IP_CONTROL, clear_token_problem, notify_token_problem
 

--- a/custom_components/samsungtv_smart/picture_mode_keys.py
+++ b/custom_components/samsungtv_smart/picture_mode_keys.py
@@ -1,0 +1,101 @@
+"""Map a picture mode to the remote key that selects it locally.
+
+Samsung TVs accept a handful of dedicated remote keys that jump straight to a
+picture mode. That is the only path left when the SmartThings cloud refuses
+``setPictureMode`` — which happens on models whose cloud link cannot actuate
+them (#197) and on HDMI sources with content protection.
+
+Matching is deliberately layered, most reliable first:
+
+1. **The internal mode id** (``modeStandard``, ``modeDynamic``, …). Identical in
+   every language, so this is the answer whenever the TV exposes
+   ``supportedPictureModesMap``.
+2. **The display name, normalised.** Many TVs — including every model that only
+   offers ``custom.picturemode`` — expose no id map at all, leaving the
+   localized name as the only handle. Accents and case are stripped and the
+   name is matched on a *prefix*, because Samsung's translations of the same
+   four modes overwhelmingly share a stem: Dynamic / Dynamique / Dynamisch /
+   Dynamisk / Dinamico / Dinâmico / Dinamik / Dynamiczny / Dynamický all begin
+   with ``dynam`` or ``dinam``. Exact per-language tables were tried first and
+   failed exactly where they were needed: a Slovak TV (#197) and a Norwegian
+   one (#206) each got a key for only the one mode that happened to be spelled
+   like English.
+
+Two deliberate refusals, because sending the wrong mode is worse than sending
+none:
+
+* **FILMMAKER MODE** has no remote key, and contains "film" — it must be
+  rejected before the movie rule, or it would silently select Movie.
+* **Natural** has no key of its own. The legacy table mapped it to the *Movie*
+  key; that is preserved for the exact English word so existing setups do not
+  change behaviour, but it is deliberately not extended to other languages.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+KEY_DYNAMIC = "KEY_DYNAMIC"
+KEY_STANDARD = "KEY_STANDARD"
+KEY_MOVIE = "KEY_MOVIE1"
+KEY_ECO = "KEY_ESAVING"
+
+# Internal ids, which are the same on every TV and in every language.
+_ID_KEYS = {
+    "modedynamic": KEY_DYNAMIC,
+    "modestandard": KEY_STANDARD,
+    "modemovie": KEY_MOVIE,
+    "modeeco": KEY_ECO,
+}
+
+# Names that must never produce a key, checked before everything else.
+# Substrings, since "FILMMAKER MODE" carries a trailing word.
+_NO_KEY_MARKERS = ("filmmaker",)
+
+# Legacy exact names kept verbatim from the original table, so behaviour on
+# setups that already worked is untouched. "natural" -> Movie is dubious (see
+# module docstring) but pre-existing; it is not generalised below.
+_EXACT_NAMES = {
+    "cinema (etalonne)": KEY_MOVIE,
+    "natural": KEY_MOVIE,
+}
+
+# Prefixes of the localized names, normalised (lowercase, accents stripped).
+# Ordered: the first prefix that matches wins, so more specific stems must come
+# before shorter ones that would also match them.
+_NAME_PREFIXES: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("dynam", "dinam"), KEY_DYNAMIC),
+    (("standar", "estandar", "standaard", "normal", "vakio"), KEY_STANDARD),
+    (("movie", "film", "cine", "pelicul", "elokuv"), KEY_MOVIE),
+    (("eco", "eko", "oko", "energi"), KEY_ECO),
+)
+
+
+def _normalise(value: str) -> str:
+    """Lowercase and strip accents, so "Dinâmico" and "Dynamický" compare."""
+    decomposed = unicodedata.normalize("NFKD", value.strip().casefold())
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+
+
+def picture_mode_ws_key(display_name: str, mode_id: str = "") -> str | None:
+    """Return the remote key for a picture mode, or None if there is none.
+
+    ``mode_id`` is the TV's internal id when known (from
+    ``supportedPictureModesMap``); ``display_name`` is what the user picked.
+    """
+    if mode_id:
+        key = _ID_KEYS.get(_normalise(mode_id))
+        if key:
+            return key
+
+    name = _normalise(display_name)
+    if not name:
+        return None
+    if any(marker in name for marker in _NO_KEY_MARKERS):
+        return None
+    if name in _EXACT_NAMES:
+        return _EXACT_NAMES[name]
+    for prefixes, key in _NAME_PREFIXES:
+        if name.startswith(prefixes):
+            return key
+    return None

--- a/custom_components/samsungtv_smart/select.py
+++ b/custom_components/samsungtv_smart/select.py
@@ -42,7 +42,6 @@ from .const import (
     CONF_DEVICE_ID,
     CONF_ENABLE_IP_CONTROL,
     CONF_IP_CONTROL_TOKEN,
-    ip_control_port,
     CONF_IS_FRAME_TV,
     CONF_OAUTH_TOKEN,
     CONF_WS_NAME,
@@ -51,6 +50,7 @@ from .const import (
     DEFAULT_PORT,
     DOMAIN,
     WS_PREFIX,
+    ip_control_port,
 )
 from .token_notify import METHOD_IP_CONTROL, clear_token_problem, notify_token_problem
 

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -56,7 +56,6 @@ from .const import (
     CONF_DEVICE_ID,
     CONF_ENABLE_IP_CONTROL,
     CONF_IP_CONTROL_TOKEN,
-    ip_control_port,
     CONF_IS_FRAME_TV,
     CONF_OAUTH_TOKEN,
     CONF_SLIDESHOW_API,
@@ -69,6 +68,7 @@ from .const import (
     DOMAIN,
     ST_POLL_OFF_INTERVAL,
     WS_PREFIX,
+    ip_control_port,
 )
 from .token_notify import METHOD_IP_CONTROL, clear_token_problem, notify_token_problem
 

--- a/custom_components/samsungtv_smart/switch.py
+++ b/custom_components/samsungtv_smart/switch.py
@@ -39,7 +39,6 @@ from .const import (
     CONF_AUTH_METHOD,
     CONF_ENABLE_IP_CONTROL,
     CONF_IP_CONTROL_TOKEN,
-    ip_control_port,
     CONF_IS_FRAME_TV,
     CONF_WS_NAME,
     DATA_ART_API,
@@ -47,6 +46,7 @@ from .const import (
     DEFAULT_PORT,
     DOMAIN,
     WS_PREFIX,
+    ip_control_port,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/test_picture_mode_keys.py
+++ b/tests/test_picture_mode_keys.py
@@ -1,0 +1,131 @@
+"""Tests for the picture mode -> remote key resolution."""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+# Loaded straight from its file: the module depends only on the standard
+# library, and importing it through the package would drag in aiohttp and the
+# whole Home Assistant integration just to test a pure function.
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "samsungtv_smart"
+    / "picture_mode_keys.py"
+)
+_spec = importlib.util.spec_from_file_location("picture_mode_keys", _MODULE_PATH)
+_pmk = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_pmk)
+
+KEY_DYNAMIC = _pmk.KEY_DYNAMIC
+KEY_ECO = _pmk.KEY_ECO
+KEY_MOVIE = _pmk.KEY_MOVIE
+KEY_STANDARD = _pmk.KEY_STANDARD
+picture_mode_ws_key = _pmk.picture_mode_ws_key
+
+
+class TestModeId(unittest.TestCase):
+    """The internal id wins whenever the TV exposes one."""
+
+    def test_ids_resolve(self):
+        for mode_id, expected in (
+            ("modeDynamic", KEY_DYNAMIC),
+            ("modeStandard", KEY_STANDARD),
+            ("modeMovie", KEY_MOVIE),
+            ("modeEco", KEY_ECO),
+        ):
+            with self.subTest(mode_id=mode_id):
+                self.assertEqual(picture_mode_ws_key("whatever", mode_id), expected)
+
+    def test_unknown_id_falls_through_to_the_name(self):
+        # modeNatural has no key; the name must still be consulted rather than
+        # the whole lookup giving up.
+        self.assertEqual(
+            picture_mode_ws_key("Dynamisk", "modeNatural"),
+            KEY_DYNAMIC,
+        )
+
+
+class TestLocalisedNames(unittest.TestCase):
+    """Real mode lists taken from the issues, where no id map was available."""
+
+    def test_norwegian_206(self):
+        self.assertEqual(picture_mode_ws_key("Dynamisk"), KEY_DYNAMIC)
+        self.assertEqual(picture_mode_ws_key("Standard"), KEY_STANDARD)
+
+    def test_slovak_197(self):
+        self.assertEqual(picture_mode_ws_key("Dynamický"), KEY_DYNAMIC)
+        self.assertEqual(picture_mode_ws_key("Štandardný"), KEY_STANDARD)
+        self.assertEqual(picture_mode_ws_key("Film"), KEY_MOVIE)
+        # Prirodzený (Natural) deliberately has no key.
+        self.assertIsNone(picture_mode_ws_key("Prirodzený"))
+
+    def test_other_locales(self):
+        cases = {
+            KEY_DYNAMIC: [
+                "Dynamic",
+                "Dynamique",
+                "Dynamisch",
+                "Dinamico",
+                "Dinâmico",
+                "Dinamik",
+                "Dynamiczny",
+                "Dinamikus",
+            ],
+            KEY_STANDARD: [
+                "Standard",
+                "Estándar",
+                "Standaard",
+                "Standardowy",
+                "Štandardný",
+                "Standart",
+                "Normál",
+                "Vakio",
+            ],
+            KEY_MOVIE: ["Movie", "Film", "Cinéma", "Película", "Elokuva"],
+            KEY_ECO: ["Eco", "Éco", "Öko", "Eko"],
+        }
+        for expected, names in cases.items():
+            for name in names:
+                with self.subTest(name=name):
+                    self.assertEqual(picture_mode_ws_key(name), expected)
+
+
+class TestRefusals(unittest.TestCase):
+    """Sending the wrong mode is worse than sending none."""
+
+    def test_filmmaker_never_maps_to_movie(self):
+        # "FILMMAKER MODE" contains "film" and must be rejected first.
+        for name in ("FILMMAKER MODE", "Filmmaker Mode", "filmmaker"):
+            with self.subTest(name=name):
+                self.assertIsNone(picture_mode_ws_key(name))
+
+    def test_unknown_names(self):
+        for name in ("", "   ", "Ambient", "Game", "Sports", "HDR+"):
+            with self.subTest(name=name):
+                self.assertIsNone(picture_mode_ws_key(name))
+
+    def test_natural_english_only(self):
+        # Legacy behaviour kept verbatim for the English word...
+        self.assertEqual(picture_mode_ws_key("Natural"), KEY_MOVIE)
+        # ...and deliberately not generalised to other languages.
+        for name in ("Naturlig", "Naturel", "Natürlich", "Naturale", "Přirozený"):
+            with self.subTest(name=name):
+                self.assertIsNone(picture_mode_ws_key(name))
+
+
+class TestRobustness(unittest.TestCase):
+    """Inputs that must not raise."""
+
+    def test_padding_and_case(self):
+        # Samsung pads localized names in some locales (#197).
+        self.assertEqual(picture_mode_ws_key("  Dynamisk  "), KEY_DYNAMIC)
+        self.assertEqual(picture_mode_ws_key("DYNAMIC"), KEY_DYNAMIC)
+
+    def test_empty_inputs(self):
+        self.assertIsNone(picture_mode_ws_key("", ""))
+        self.assertIsNone(picture_mode_ws_key(" "))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to #201, from the logs in [#206](https://github.com/TheFab21/ha-samsungtv-smart/issues/206).

## The gap

The 1515 pairing works — a 2018 NU8005 now has IP Control entities. But the same log shows the local picture mode fallback still half-failing:

```
Picture mode 'Standard' also sent via WS key KEY_STANDARD
No direct WS key for 'Dynamisk', skipping WS fallback
```

`Standard` matched **by spelling coincidence**. `Dynamisk` got nothing.

#201 fixed this by looking the key up from the internal mode id (`modeDynamic`), which is language-independent. But this TV reports `cap=custom.picturemode` and exposes **no `supportedPictureModesMap`** — so there is no id to look up, and the code fell back to a name table listing English, French and German only. The Slovak TV in #197 hit the identical wall: only `Film` matched, again by coincidence.

So on any TV without an id map, in any language other than three, the fallback that exists precisely for when the cloud refuses commands silently does nothing.

## The fix

Exact per-language tables lose this game — there are too many locales and Samsung translates all four modes. But the translations share a stem almost everywhere, so matching now normalises the name (casefold + strip accents) and compares **prefixes**:

| prefixes | key |
|---|---|
| `dynam`, `dinam` | `KEY_DYNAMIC` |
| `standar`, `estandar`, `standaard`, `normal`, `vakio` | `KEY_STANDARD` |
| `movie`, `film`, `cine`, `pelicul`, `elokuv` | `KEY_MOVIE1` |
| `eco`, `eko`, `oko`, `energi` | `KEY_ESAVING` |

The internal id is still tried first whenever the TV provides one.

## Two deliberate refusals

- **FILMMAKER MODE** contains "film" and is rejected *before* the movie rule — otherwise it would silently select Movie.
- **Natural** keeps its legacy English-only mapping instead of being generalised. That mapping points at the *Movie* key, which looks wrong; as in #201 I am not touching it without evidence, but I am equally not spreading it to `Naturlig` / `Natürlich` / `Prirodzený`.

## Verification

Moved into its own module and unit-tested (10 tests, all passing) against the real mode lists from both issues, the refusals, and padded/uppercase input.

Checked old-vs-new for every name involved:

| name | before | after |
|---|---|---|
| Dynamic / Standard / Movie / Eco / Natural / Film / Cinéma (étalonné) / Éco | key | **same key** |
| FILMMAKER MODE / Prirodzený | none | **none** |
| Dynamisk / Dynamický / Štandardný / Dinâmico / Öko | none | **new key** |

Nothing that worked changes; only names that got nothing gain a key.

The three collection errors in the suite are pre-existing (`pytest` and `pytest_homeassistant_custom_component` are absent from this environment), identical before and after.

Version `8.6.3`.

Refs #206, #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_