### PR TITLE
Preserve custom source list with SmartThings

### DIFF
--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -1743,6 +1743,17 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         return None
 
     def _get_st_sources(self):
+        # A manually configured source list must always have priority
+        custom_source_list = self._get_option(CONF_SOURCE_LIST, {})
+        if custom_source_list:
+            self._log.debug(
+                "Samsung TV: using custom source list: %s",
+                custom_source_list,
+            )
+            self._source_list = custom_source_list
+            self._default_source_used = False
+            return
+
         if not self._st:
             self._log.debug("SmartThings not configured, _get_st_sources not executed")
             return


### PR DESCRIPTION
## Summary

Preserve a manually configured source list when SmartThings source discovery is enabled.

## Problem

`_get_st_sources()` currently overwrites `self._source_list` with sources discovered through SmartThings even when the user has explicitly configured a custom source list.

This can cause manually configured sources to disappear after startup.

For example, with the following custom source list:

```yaml
HDMI: ST_VD:HDMI1
DisplayPort: ST_VD:Display Port
```

the config entry stores both sources correctly, but the media player may expose only the source discovered by SmartThings.

## Fix

Check `CONF_SOURCE_LIST` before SmartThings source discovery.

If a custom source list exists, keep it as `self._source_list` and return without replacing it.

SmartThings source discovery continues to work unchanged when no custom source list is configured.

## Tested

Tested with:

- Home Assistant 2026.8.1
- ha-samsungtv-smart 8.6.2
- Samsung Odyssey G7 / LS32DG702EIXCI
- SmartThings OAuth authentication

After the change, custom HDMI and DisplayPort sources are preserved and both source commands work correctly.