### PR TITLE
fix(smartthings): back off and explain when the cloud refuses the device

### DIFF
--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.4"
+  "version": "8.6.5"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -187,6 +187,7 @@ from .picture_mode_keys import picture_mode_ws_key
 from .token_notify import (
     METHOD_IP_CONTROL,
     METHOD_LOCAL,
+    METHOD_SMARTTHINGS,
     clear_token_problem,
     notify_token_problem,
 )
@@ -221,6 +222,15 @@ KEYPRESS_MIN_DELAY = 0.2
 # #40). Mirrors the manual "home, wait, source" workaround.
 SOURCE_WAKE_DELAY = 1.5
 MAX_ST_ERROR_COUNT = 4
+# Consecutive authorization failures from SmartThings before we treat the
+# device as gone rather than the cloud as flaky, and slow the poll right down.
+MAX_ST_AUTH_ERROR_COUNT = 3
+# Poll interval (seconds) once SmartThings has refused the device id. A 403 is
+# not transient -- the id is wrong until the user reconfigures -- so retrying
+# every 5s only burns API quota and stretches the update cycle (#: a repaired
+# TV produced 1591 refusals in two hours). Long enough to be harmless, short
+# enough that a fix is noticed without a restart.
+ST_POLL_AUTH_ERROR_INTERVAL = 300
 MEDIA_TYPE_BROWSER = "browser"
 MEDIA_TYPE_KEY = "send_key"
 MEDIA_TYPE_TEXT = "send_text"
@@ -761,6 +771,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             )
 
         self._st_error_count = 0
+        self._st_auth_error_count = 0
         self._st_last_exc = None
         self._st_sources_loaded = False
         # SmartThings poll throttling: the local WebSocket is the primary state
@@ -2005,7 +2016,12 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         if wake_edge:
             self._st_last_poll = now
             return True
-        if self._state == MediaPlayerState.ON:
+        if self._st_auth_error_count >= MAX_ST_AUTH_ERROR_COUNT:
+            # SmartThings is refusing this device id outright. Keep a slow
+            # heartbeat so a reconfigure is picked up without a restart, but
+            # stop polling at the normal cadence.
+            interval = ST_POLL_AUTH_ERROR_INTERVAL
+        elif self._state == MediaPlayerState.ON:
             interval = self._st_poll_on_interval
         else:
             interval = ST_POLL_OFF_INTERVAL
@@ -2013,6 +2029,20 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             self._st_last_poll = now
             return True
         return False
+
+    @staticmethod
+    def _st_error_is_authorization(exc: Exception) -> bool:
+        """True when SmartThings refused the device rather than merely failing.
+
+        pysmartthings does not expose a stable exception class for this, so the
+        check is deliberately loose: the class name and the message are both
+        inspected. A false positive only slows polling down and shows a notice
+        the user can dismiss; a false negative just keeps today's behaviour.
+        """
+        text = f"{type(exc).__name__} {exc}".lower()
+        return any(
+            marker in text for marker in ("forbidden", "unauthorized", "401", "403")
+        )
 
     async def _async_st_update(self, **kwargs) -> bool | None:
         """Update SmartThings state of device."""
@@ -2041,10 +2071,41 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                     exc,
                 )
             self._st_last_exc = exc
+            self._note_st_auth_error(exc)
             return False
 
         self._st_last_exc = None
+        if self._st_auth_error_count:
+            self._log.info(
+                "%s - SmartThings is answering again, resuming normal polling",
+                self.entity_id,
+            )
+            self._st_auth_error_count = 0
+            clear_token_problem(self.hass, self._entry_id, METHOD_SMARTTHINGS)
         return True
+
+    def _note_st_auth_error(self, exc: Exception) -> None:
+        """Count an authorization refusal and, past the threshold, act on it."""
+        if not self._st_error_is_authorization(exc):
+            self._st_auth_error_count = 0
+            return
+        if self._st_auth_error_count >= MAX_ST_AUTH_ERROR_COUNT:
+            return
+        self._st_auth_error_count += 1
+        if self._st_auth_error_count < MAX_ST_AUTH_ERROR_COUNT:
+            return
+        self._log.error(
+            "%s - SmartThings refused this device %d times in a row (%s). The "
+            "stored device id is probably no longer valid -- this happens "
+            "after a mainboard repair, or when the TV is re-added in the "
+            "SmartThings app. Slowing polling to %ds; reconfigure the "
+            "integration to select the TV again.",
+            self.entity_id,
+            self._st_auth_error_count,
+            exc,
+            ST_POLL_AUTH_ERROR_INTERVAL,
+        )
+        notify_token_problem(self.hass, self._entry_id, METHOD_SMARTTHINGS, self._name)
 
     async def async_update(self):
         """Update state of device."""

--- a/custom_components/samsungtv_smart/token_notify.py
+++ b/custom_components/samsungtv_smart/token_notify.py
@@ -36,15 +36,18 @@ from .const import DOMAIN
 # uses the native Repairs issue registry instead).
 METHOD_LOCAL = "local"
 METHOD_IP_CONTROL = "ip_control"
+METHOD_SMARTTHINGS = "smartthings"
 
 _TITLES: dict[str, dict[str, str]] = {
     "en": {
         METHOD_LOCAL: "Samsung TV — local connection not authorized",
         METHOD_IP_CONTROL: "Samsung TV — IP Control token rejected",
+        METHOD_SMARTTHINGS: "Samsung TV — SmartThings device no longer accessible",
     },
     "fr": {
         METHOD_LOCAL: "Téléviseur Samsung — connexion locale non autorisée",
         METHOD_IP_CONTROL: "Téléviseur Samsung — token IP Control rejeté",
+        METHOD_SMARTTHINGS: "Téléviseur Samsung — appareil SmartThings inaccessible",
     },
 }
 
@@ -70,6 +73,21 @@ _MESSAGES: dict[str, dict[str, str]] = {
             "screen.\n\nThis notification clears automatically once IP Control "
             "works again."
         ),
+        METHOD_SMARTTHINGS: (
+            "SmartThings refuses access to **{device_name}** (*Forbidden*). "
+            "The cloud features — channel name, picture mode, sound mode, "
+            "power metering — are paused; local control keeps working.\n\n"
+            "This usually means the TV is no longer the device Home Assistant "
+            "was configured with. It happens after a **mainboard repair or "
+            "replacement** (the TV re-registers under a new id), after the TV "
+            "is removed and re-added in the SmartThings app, or when the "
+            "account that owns it changes.\n\n"
+            "To fix it: open **Settings → Devices & services → Samsung TV "
+            "Smart → Reconfigure**, and select the TV again in the SmartThings "
+            "device list so the new id is stored.\n\n"
+            "Polling has been slowed down until it works again, and this "
+            "notice clears itself automatically."
+        ),
     },
     "fr": {
         METHOD_LOCAL: (
@@ -93,6 +111,24 @@ _MESSAGES: dict[str, dict[str, str]] = {
             "maintenant* téléviseur ALLUMÉ et **pas** en mode Art, puis "
             "acceptez l'invite à l'écran.\n\nCette notification disparaît "
             "automatiquement dès qu'IP Control refonctionne."
+        ),
+        METHOD_SMARTTHINGS: (
+            "SmartThings refuse l'accès à **{device_name}** (*Forbidden*). "
+            "Les fonctions cloud — nom de chaîne, mode image, mode son, "
+            "mesure de consommation — sont suspendues ; le contrôle local "
+            "continue de fonctionner.\n\n"
+            "Cela signifie généralement que le téléviseur n'est plus "
+            "l'appareil avec lequel Home Assistant a été configuré. Cela "
+            "arrive après un **remplacement de carte mère** (le téléviseur se "
+            "réenregistre sous un nouvel identifiant), après une suppression "
+            "puis un rajout dans l'application SmartThings, ou lors d'un "
+            "changement de compte propriétaire.\n\n"
+            "Pour corriger : ouvrez **Paramètres → Appareils et services → "
+            "Samsung TV Smart → Reconfigurer**, et sélectionnez à nouveau le "
+            "téléviseur dans la liste SmartThings pour enregistrer le nouvel "
+            "identifiant.\n\n"
+            "Les interrogations ont été espacées en attendant, et cette "
+            "notification disparaît automatiquement."
         ),
     },
 }


### PR DESCRIPTION
From a real case: a Frame went in for repair, came back with a **replaced mainboard** — new MAC, new UPnP UUID, and a new SmartThings device id. The stored id is refused forever after that.

## What the log showed

```text
[192.168.1.161] Error updating SmartThings status: Forbidden       ×1591 in 2h14
[192.168.1.161] media_player.samsung_hacs - SmartThings update failed,
                continuing with local control only: Forbidden
[192.168.1.161] media_player.samsung_hacs - Update took 6.9s,
                longer than the 5s scan interval
```

A 403 on the device id is **not transient** — it stays wrong until the user reconfigures. We retried it every 5 seconds anyway: 1591 refused calls in a little over two hours, burning API quota and stretching the update cycle past its own scan interval. The only user-visible clue was a single warning, with nothing saying what had happened or what to do about it.

## The change

Three consecutive authorization refusals now:

- **slow SmartThings polling to a 300s heartbeat** — slow enough to be harmless, frequent enough that a reconfigure is picked up without a restart;
- **raise a notification** naming the likely causes (mainboard repair, TV removed and re-added in the SmartThings app, ownership change) and the fix (*Reconfigure* → reselect the TV), in English and French;
- **log once at error level** instead of leaving the diagnosis to the reader.

Both clear themselves on the first successful poll. **Local control is untouched** throughout — only the cloud-only fields (channel name, picture mode, sound mode, power metering) pause.

| | before | after |
|---|---|---|
| calls over 2 h | 1440 | 26 |
| user guidance | one warning line | notification with cause and fix |
| recovery | — | automatic, on first success |

## On the detection

`pysmartthings` exposes no stable exception class for this, and the error does not arrive as a `ClientResponseError` — it lands in the broad handler with `str(exc) == "Forbidden"`. So detection inspects the class name and message for `forbidden` / `unauthorized` / `401` / `403`.

That is deliberately loose, and documented as such in the code: a false positive only slows polling and shows a dismissable notice; a false negative keeps exactly today's behaviour. I preferred that to importing an exception class I cannot verify from here.

## Verification

Simulated the state machine rather than assuming it:

- transient timeouts, rate-limit and connection errors → never trip it;
- two refusals followed by a success → counter resets, nothing raised;
- refusals 4, 5, 6… → counter caps, notification not re-raised;
- success after backoff → interval returns to normal, notice cleared.

Version `8.6.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_