### PR TITLE
feat(smartthings): add Hue Sync controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode su
 - Full Samsung Smart TV (Tizen OS) control via WebSocket
 - Power on/off, volume, source selection, app launching
 - SmartThings integration for enhanced status polling (channel info, picture mode, sound mode…)
+- Background Philips Hue Sync start/stop control on supported Samsung TVs
 - **Three SmartThings authentication methods**: OAuth2, Personal Access Token, or existing ST integration
 - **Samsung Frame TV Art Mode** — full artwork management via a dedicated async API
 - **Self-healing Art WebSocket** — auto-reconnect + a zombie-channel circuit breaker fix the long-standing "Art Mode turns off randomly, needs a reload" problem
@@ -504,6 +505,8 @@ These are called on the `media_player` entity.
 | `media_player.select_source` | Switch input source or launch an app |
 | `media_player.play_media` | Send a key command or launch a URL |
 | `samsungtv_smart.select_picture_mode` | Change picture mode |
+| `samsungtv_smart.start_hue_sync` | Start Philips Hue Sync without opening the TV app |
+| `samsungtv_smart.stop_hue_sync` | Stop Philips Hue Sync without opening the TV app |
 | `samsungtv_smart.send_text` | Type a text string into a native Tizen text field |
 | `remote.send_command` | Send raw key commands (via remote entity) |
 
@@ -527,6 +530,19 @@ target:
 data:
   text: "hello"
 ```
+
+**Starting Philips Hue Sync in the background:**
+
+```yaml
+action: samsungtv_smart.start_hue_sync
+target:
+  entity_id: media_player.samsung_tv
+```
+
+Use `samsungtv_smart.stop_hue_sync` with the same target to stop syncing.
+These services require SmartThings and a Samsung TV with the Philips Hue Sync
+TV app and `samsungvd.lightControl` capability. They do not launch the app or
+change the active input.
 
 > **Scope — read this before expecting it to work in streaming apps.** This uses
 > Samsung's `SendInputString` (the native **Tizen IME**). It only produces text

--- a/custom_components/samsungtv_smart/api/smartthings.py
+++ b/custom_components/samsungtv_smart/api/smartthings.py
@@ -19,6 +19,10 @@ CAP_AUDIO_VOLUME = "audioVolume"
 CAP_AUDIO_MUTE = "audioMute"
 CAP_TV_CHANNEL = "tvChannel"
 CAP_MEDIA_INPUT_SOURCE = "mediaInputSource"
+CAP_LIGHT_CONTROL = "samsungvd.lightControl"
+
+HUE_SYNC_MODE_OFF = "TurnOff"
+HUE_SYNC_MODE_ON = "TurnOn"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -953,6 +957,19 @@ class SmartThingsTV:
             )
         except Exception as err:
             self._log.error("Error selecting VD source: %s", err)
+            raise
+
+    async def async_set_hue_sync(self, enabled: bool) -> None:
+        """Start or stop Philips Hue Sync without opening the TV app."""
+        mode = HUE_SYNC_MODE_ON if enabled else HUE_SYNC_MODE_OFF
+        try:
+            await self._send_rest_command(
+                capability=CAP_LIGHT_CONTROL,
+                command="setLightControlMode",
+                arguments=[mode],
+            )
+        except Exception as err:
+            self._log.error("Error setting Hue Sync mode: %s", err)
             raise
 
     # ──────────────────────────────────────────────────────────────────────────

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -236,6 +236,8 @@ RESULT_SUCCESS = "success"
 RESULT_WRONG_APIKEY = "wrong_api_key"
 
 SERVICE_SELECT_PICTURE_MODE = "select_picture_mode"
+SERVICE_START_HUE_SYNC = "start_hue_sync"
+SERVICE_STOP_HUE_SYNC = "stop_hue_sync"
 
 # Frame Art Extended Services
 SERVICE_ART_GET_ARTMODE = "art_get_artmode"

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -172,6 +172,8 @@ from .const import (
     SERVICE_ART_UPLOAD_BATCH,
     SERVICE_SELECT_PICTURE_MODE,
     SERVICE_SEND_TEXT,
+    SERVICE_START_HUE_SYNC,
+    SERVICE_STOP_HUE_SYNC,
     SIGNAL_CONFIG_ENTITY,
     ST_POLL_OFF_INTERVAL,
     STD_APP_LIST,
@@ -326,6 +328,16 @@ async def async_setup_entry(
         SERVICE_SELECT_PICTURE_MODE,
         {vol.Required(ATTR_PICTURE_MODE): cv.string},
         "async_select_picture_mode",
+    )
+    platform.async_register_entity_service(
+        SERVICE_START_HUE_SYNC,
+        {},
+        "async_start_hue_sync",
+    )
+    platform.async_register_entity_service(
+        SERVICE_STOP_HUE_SYNC,
+        {},
+        "async_stop_hue_sync",
     )
 
     # Frame Art Extended Services
@@ -3388,6 +3400,18 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 picture_mode,
                 mode_id or "unknown",
             )
+
+    async def async_start_hue_sync(self) -> None:
+        """Start Philips Hue Sync without opening the TV app."""
+        if not self._st:
+            raise HomeAssistantError("SmartThings is not configured for this TV")
+        await self._st.async_set_hue_sync(True)
+
+    async def async_stop_hue_sync(self) -> None:
+        """Stop Philips Hue Sync without opening the TV app."""
+        if not self._st:
+            raise HomeAssistantError("SmartThings is not configured for this TV")
+        await self._st.async_set_hue_sync(False)
 
     # ==========================================
     # Frame Art Extended Service Methods

--- a/custom_components/samsungtv_smart/services.yaml
+++ b/custom_components/samsungtv_smart/services.yaml
@@ -14,6 +14,20 @@ select_picture_mode:
       selector:
         text:
 
+start_hue_sync:
+  name: Start Hue Sync
+  description: Start Philips Hue Sync without opening the app on the TV.
+  target:
+    entity:
+      integration: samsungtv_smart
+
+stop_hue_sync:
+  name: Stop Hue Sync
+  description: Stop Philips Hue Sync without opening the app on the TV.
+  target:
+    entity:
+      integration: samsungtv_smart
+
 send_text:
   name: Send Text
   description: >-

--- a/tests/api/test_smartthings_hue_sync.py
+++ b/tests/api/test_smartthings_hue_sync.py
@@ -1,0 +1,65 @@
+"""Tests for Philips Hue Sync SmartThings commands."""
+
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+if "pysmartthings" not in sys.modules:
+    pysmartthings = ModuleType("pysmartthings")
+    pysmartthings.SmartThings = object
+    sys.modules["pysmartthings"] = pysmartthings
+
+import smartthings as smartthings_module  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("enabled", "mode"),
+    [
+        (True, "TurnOn"),
+        (False, "TurnOff"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_set_hue_sync_sends_expected_mode(enabled, mode):
+    """Hue Sync uses the Samsung light-control capability in the background."""
+    response = AsyncMock()
+    response.status = 200
+    response.json.return_value = {"results": [{"status": "COMPLETED"}]}
+    response_context = AsyncMock()
+    response_context.__aenter__.return_value = response
+    session = MagicMock()
+    session.post.return_value = response_context
+
+    with patch.object(smartthings_module, "SmartThings") as smartthings_client:
+        client = smartthings_module.SmartThingsTV(
+            api_key="test-api-key",
+            device_id="test-device-id",
+            session=session,
+        )
+        smartthings_client.return_value.authenticate.assert_called_once_with(
+            "test-api-key"
+        )
+
+    await client.async_set_hue_sync(enabled)
+
+    session.post.assert_called_once_with(
+        "https://api.smartthings.com/v1/devices/test-device-id/commands",
+        headers={
+            "Authorization": "Bearer test-api-key",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        json={
+            "commands": [
+                {
+                    "component": "main",
+                    "capability": "samsungvd.lightControl",
+                    "command": "setLightControlMode",
+                    "arguments": [mode],
+                }
+            ]
+        },
+        raise_for_status=True,
+    )


### PR DESCRIPTION
## What this adds

- Adds `samsungtv_smart.start_hue_sync` and `samsungtv_smart.stop_hue_sync` entity services.
- Sends `samsungvd.lightControl.setLightControlMode` with the verified `TurnOn` and `TurnOff` modes through this fork’s existing SmartThings REST client.
- Returns a clear Home Assistant error when SmartThings is not configured for the TV.
- Documents both services and adds exact request-payload tests.

## Why

Launching the Philips Hue Sync TV app in the foreground interrupts viewing and requires switching back to the active source. These commands start and stop syncing in the background instead.

The behavior was verified live on a Samsung S95C: syncing starts and stops, the Hue app does not open in the foreground, and the active HDMI source remains unchanged.

Related discussion: ollo69/ha-samsungtv-smart#398
Equivalent upstream contribution: ollo69/ha-samsungtv-smart#427

## Test plan

- `flake8 custom_components`
- `isort --diff --check custom_components`
- `black --line-length 88 --diff --check custom_components`
- New Hue Sync payload tests: 2 passed
- Remaining non-broken repository suite: 27 passed
- `services.yaml` parsed and both service targets verified

The full suite currently has 17 pre-existing Art API collection errors because its test fixture imports `art.py` as a standalone module after that module gained relative imports. An untouched `master` worktree produces the same 17 errors; this PR does not alter that code.

Release note: Added background start and stop controls for the Philips Hue Sync TV app.