### PR TITLE
refactor: remove _force_art_coordinator_refresh, which never ran

### DIFF
--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.7"
+  "version": "8.6.8"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -3737,18 +3737,6 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             self._log.error("Frame Art: Error ensuring Art Mode: %s", ex)
             return False
 
-    async def _force_art_coordinator_refresh(self):
-        """Force immediate refresh of Frame Art coordinator after artwork changes."""
-        try:
-            coordinator = self.hass.data[DOMAIN][self._entry_id].get(
-                "frame_art_coordinator"
-            )
-            if coordinator:
-                await coordinator.async_request_refresh()
-                self._log.debug("Forced Frame Art coordinator refresh")
-        except Exception as ex:
-            self._log.debug("Could not force coordinator refresh: %s", ex)
-
     async def async_art_select_image(
         self,
         content_id: str,
@@ -3767,9 +3755,6 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         # Select the artwork
         try:
             await self._art_api.select_image(content_id, category_id, show)
-
-            # Force immediate update 🚀
-            await self._force_art_coordinator_refresh()
 
             return {"success": True, "content_id": content_id}
         except Exception as ex:
@@ -3824,9 +3809,6 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 self._log.info(
                     "Frame Art: Upload successful, content_id=%s", content_id
                 )
-
-                # Force immediate update 🚀
-                await self._force_art_coordinator_refresh()
 
                 # The TV often needs a while (sometimes minutes) to generate the
                 # thumbnail for a just-uploaded image, so the immediate batch
@@ -3906,7 +3888,6 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
         # Reflect the new art and fetch the (delayed) TV-side thumbnails.
         if result.get("uploaded"):
-            await self._force_art_coordinator_refresh()
             for content_id in result["uploaded"]:
                 self.hass.async_create_task(self._retry_new_thumbnail(content_id))
 
@@ -3946,8 +3927,6 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                     "Frame Art: thumbnail for %s is now available (delayed retry)",
                     content_id,
                 )
-                # Nudge the gallery/sensor so it shows the new thumbnail now.
-                await self._force_art_coordinator_refresh()
                 return
         self._log.debug(
             "Frame Art: thumbnail for %s still unavailable after delayed retries",
@@ -3963,9 +3942,6 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             return {"error": "Can only delete user-uploaded content (MY-*)"}
         try:
             await self._art_api.delete(content_id)
-
-            # Force immediate update 🚀
-            await self._force_art_coordinator_refresh()
 
             return {"success": True}
         except Exception as ex:


### PR DESCRIPTION
`_force_art_coordinator_refresh()` has never done anything, and its existence actively misled a bug report.

## It cannot run

```python
coordinator = self.hass.data[DOMAIN][self._entry_id].get("frame_art_coordinator")
if coordinator:
    await coordinator.async_request_refresh()
```

**Nothing ever writes that key.** Verified four ways:

| check | result |
|---|---|
| every write to `hass.data[DOMAIN][entry_id][...]` in the component | `DATA_ART_API` ×3, `DATA_CFG_YAML` — that is all |
| the store dict at creation (`__init__.py:1241`) | `DATA_CFG`, `DATA_OPTIONS`, `DATA_ENTRY_DATA` |
| constant values | `"art_api"`, `"cfg"`, `"options"`, … none is `"frame_art_coordinator"` |
| the word `coordinator` component-wide | only `number.py`'s IP Control coordinator (passed directly to entities) and these six lines |

The `FrameArtCoordinator` built at `sensor.py:370` stays a **local variable**, captured by the entity and callback closures and never published.

So `coordinator` was always `None`, the guarded refresh never happened, and the debug line `"Forced Frame Art coordinator refresh"` could not have been emitted once — in any version. Removing the method and its five call sites is **behaviour-preserving by construction**.

## Why remove it rather than leave it

[#220](https://github.com/TheFab21/ha-samsungtv-smart/issues/220) attributes a ~2 s `media_player.state` flicker to this function, with a detailed timeline of it polling the REST endpoint and caching a stale `PowerState="off"`. None of that is possible. The report also has the dependency backwards: `FrameArtCoordinator._is_tv_powered_off()` (`sensor.py:987`) *reads* the media_player's state from the entity registry — the sensor follows the media player, never the reverse.

Code that looks like a mechanism but is inert sends people diagnosing real symptoms down imaginary paths. That is what happened here.

## Nothing is lost

The sensor still refreshes after an artwork change, through the `content_changed` broadcast wired to `_on_art_content` (`sensor.py:377`) — which also sets `_trust_next_content_id` so the new id is accepted immediately rather than waiting for the two-poll confirmation. That is the path that actually works, and it is untouched.

The reporter's *symptom* may well be real; only the named cause and the proposed fix are not. That is being followed up in the issue.

Version `8.6.8`. Lint and tests pass.

Refs #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_