### PR TITLE
fix(hue-sync): do not declare the model incapable on a 422

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,11 +559,13 @@ These services require SmartThings and a Samsung TV with the Philips Hue Sync
 TV app and `samsungvd.lightControl` capability. They do not launch the app or
 change the active input.
 
-> **Not every model has this capability**, and no setting can add it. Verified
-> working on an S95C; reported missing on a 2022 Frame (`QE65LS03BAUXXH`).
-> Calling the service on a TV without it raises *"Hue Sync is not available on
-> this TV"*. To check before trying, with your SmartThings token and device id
-> (both visible in *Download diagnostics*):
+> **Not every TV exposes this capability.** Verified working on an S95C;
+> reported absent on a 2022 Frame (`QE65LS03BAUXXH`). Two things can cause that,
+> and the error does not tell them apart: the model may not support it at all,
+> or the capability may only appear **once the Philips Hue Sync TV app is
+> installed on the TV and paired with a Hue bridge**. Set that up first, then
+> re-check. To check, with your SmartThings token and device id (both visible in
+> *Download diagnostics*):
 >
 > ```bash
 > curl -s -H "Authorization: Bearer YOUR_TOKEN" \

--- a/custom_components/samsungtv_smart/api/smartthings.py
+++ b/custom_components/samsungtv_smart/api/smartthings.py
@@ -29,10 +29,12 @@ class SmartThingsCapabilityUnsupported(Exception):
     """The TV does not expose the capability a command needs.
 
     SmartThings answers 422 Unprocessable Entity for a command sent against a
-    capability the device does not implement — the same code seen when
+    capability absent from the device profile — the same code seen when
     samsungvd.pictureMode is addressed on a model that only has
-    custom.picturemode. It is a property of the model, not a transient failure,
-    so callers should surface it as "not supported here" rather than retry.
+    custom.picturemode. It is not a transient failure, so retrying is
+    pointless; but "absent" does not always mean "unsupported by the model",
+    since some capabilities only appear once the matching feature is set up on
+    the TV. Callers should say both rather than declare the model incapable.
     """
 
 
@@ -982,14 +984,16 @@ class SmartThingsTV:
             )
         except ClientResponseError as err:
             if err.status == 422:
-                # The capability is absent from this model's profile. Reported
-                # on a 2022 Frame (QE65LS03BAUXXH); the feature was developed
-                # against an S95C. Raised as its own type so the caller can say
-                # so plainly instead of surfacing a bare traceback.
+                # The capability is not in the device profile as SmartThings
+                # sees it. Reported on a 2022 Frame (QE65LS03BAUXXH); the
+                # feature was developed against an S95C. Whether it is missing
+                # for good or only until the Hue Sync TV app is set up is not
+                # something the error distinguishes, so the message says both.
                 self._log.warning(
-                    "Hue Sync is not available on this TV: SmartThings rejected "
-                    "%s with 422, which means the model does not expose that "
-                    "capability",
+                    "SmartThings rejected %s with 422: this TV does not expose "
+                    "that capability right now. It may be absent on the model, "
+                    "or only appear once the Hue Sync TV app is installed and "
+                    "paired with a bridge",
                     CAP_LIGHT_CONTROL,
                 )
                 raise SmartThingsCapabilityUnsupported(CAP_LIGHT_CONTROL) from err

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -3409,10 +3409,12 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             await self._st.async_set_hue_sync(enabled)
         except SmartThingsCapabilityUnsupported as err:
             raise HomeAssistantError(
-                "Hue Sync is not available on this TV: it does not expose the "
-                f"{err} SmartThings capability. This is a property of the model "
-                "(reported on 2022 Frames), not a configuration problem — no "
-                "setting can enable it."
+                f"This TV does not currently expose the {err} SmartThings "
+                "capability, so Hue Sync cannot be controlled. Check that the "
+                "Philips Hue Sync TV app is installed on the TV and paired with "
+                "your Hue bridge — on some models the capability only appears "
+                "once it is set up. If it is already set up, the model does not "
+                "support this."
             ) from err
 
     async def async_start_hue_sync(self) -> None:


### PR DESCRIPTION
Follow-up to the Hue Sync error handling merged in #225. The message I wrote overclaimed, and the maintainer caught it before the user acted on it.

## What was wrong

The error said:

> This is a property of the model (reported on 2022 Frames), not a configuration problem — **no setting can enable it.**

I cannot support that. A **422** means `samsungvd.lightControl` is absent from the device profile *at that moment*. It does not distinguish:

- a model that genuinely lacks the capability, from
- a capability that only appears **once the Philips Hue Sync TV app is installed on the TV and paired with a Hue bridge**.

The reporter on [#226](https://github.com/TheFab21/ha-samsungtv-smart/issues/226) may simply not have set Hue Sync up on the TV at all. Telling him the hardware could not do it would have ended the investigation on my guess, and he would have stopped looking.

## What changed

The user-facing message now states both possibilities and says what to check first:

> This TV does not currently expose the `samsungvd.lightControl` SmartThings capability, so Hue Sync cannot be controlled. Check that the Philips Hue Sync TV app is installed on the TV and paired with your Hue bridge — on some models the capability only appears once it is set up. If it is already set up, the model does not support this.

The log line, the exception docstring and the README caveat are reworded the same way. The README now presents the two causes side by side rather than asserting the model is incapable.

**No behavioural change** — same detection, same exception, same control flow. Only what we tell the user.

Version stays `8.6.9`; lint passes.

Refs #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_