### PR TITLE
Add local IP Control source selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ After initial setup, click **Configure** on the integration card to access these
 
 | Option | Description |
 |---|---|
-| **Source list** | Define custom input sources (JSON: `{"HDMI 1": "KEY_HDMI1", ...}`) |
+| **Source list** | Define custom input sources (JSON: `{"HDMI 1": "KEY_HDMI1", ...}`); on supported IP Control TVs, local sources can use values such as `IP_HDMI1` |
 | **App list** | Define custom app shortcuts (JSON) |
 | **App load method** | How to load the app list: All, Default, or Disabled |
 | **App launch method** | Standard, Remote, or REST |
@@ -321,6 +321,29 @@ After initial setup, click **Configure** on the integration card to access these
 | **WS name** | Name shown on the TV when pairing (default: `[Home Assistant]`) |
 
 > **IP Control moved.** Pairing and the *Enable IP Control* / *Enable IP Control Art Mode* toggles are no longer in this Options screen — they now live under **Reconfigure → IP Control** (see [Reconfigure](#reconfigure) below).
+
+---
+#### Local source selection via IP Control
+
+On TVs that support `inputSourceControl`, input sources can be selected
+locally without SmartThings by using the `IP_` prefix in the Source list.
+
+For example:
+
+```yaml
+HDMI 1: IP_HDMI1
+HDMI 2: IP_HDMI2
+HDMI 3: IP_HDMI3
+HDMI 4: IP_HDMI4
+```
+
+The `IP_` prefix is removed before the value is sent to the TV, so
+`IP_HDMI4` calls `inputSourceControl` with `HDMI4`.
+
+IP Control must be paired and enabled under **Reconfigure → IP Control**.
+
+Support for `inputSourceControl` is model- and firmware-dependent.
+TVs that do not expose this method may return `-32601 "Method not found"`.
 
 ---
 ### How control works — and what *App launch method* actually does
@@ -351,7 +374,7 @@ each with its own job:
 |---|---|---|
 | **WebSocket** | Local, ports 8001/8002 | Primary control: power, keys, volume, sources, app launching, and Frame Art Mode. |
 | **SmartThings** | Cloud (OAuth2 / PAT) | Status polling (power, input, channel, picture/sound mode) and optional power-on. Read-mostly — not a local command channel. |
-| **IP Control** | Local JSON-RPC, port 1516 | Optional. Reliable power on/off without SmartThings, plus optional Art Mode control. Paired and toggled under [Reconfigure](#reconfigure). |
+| **IP Control** | Local JSON-RPC, port 1516 | Optional. Reliable power on/off without SmartThings, local source selection on supported TVs, plus optional Art Mode control. Paired and toggled under [Reconfigure](#reconfigure). |
 
 > The three layers are complementary, not alternatives. *App launch method* sits **on top of**
 > the WebSocket layer (two of its three values are WebSocket channels); it is not a fourth

--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -503,15 +503,27 @@ class SamsungIPControl:
             "serialNumber": str(result.get("serialNumber", "")),
         }
 
+    async def async_set_input_source(self, value: str) -> str:
+        """Select an input source via local IP Control."""
+        result = await self._async_request(
+            "inputSourceControl",
+            {"inputSource": value},
+        )
+        response_value = result.get("inputSource", value)
+        if not isinstance(response_value, str) or not response_value:
+            raise SamsungIPControlError(f"invalid inputSource response: {result!r}")
+        return response_value
+
     async def async_get_tv_states(self) -> dict[str, Any]:
         """Return the TV's general state snapshot (read-only).
 
-        ``getTVStates`` reports, on a Frame 2024/2025:
+        ``getTVStates`` reports, on recent Samsung TVs:
         ``speakerSelect, volume, mute, pictureSize, pictureMode, soundMode,
-        inputSource``. These are all read-only over IP Control on consumer
-        Frames (the matching setters return ``-32601 "Method not found"``), so
-        this is exposed only as diagnostic sensors. Setting these values must
-        go through SmartThings / the WebSocket.
+        inputSource``. Availability of matching setters is model-dependent.
+        Some TVs may reject setters such as ``inputSourceControl`` with
+        ``-32601``, while others support direct local control. Setting values
+        without a supported local setter must go through SmartThings /
+        the WebSocket.
         """
         return await self._async_request("getTVStates")
 

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -41,6 +41,7 @@ DATA_OPTIONS = "options"
 DATA_ENTRY_DATA = "entry_data"  # Snapshot of entry.data to detect data changes
 DATA_ART_API = "art_api"  # Shared Frame Art API instance
 DATA_ART_CACHE = "art_cache"  # Shared ArtIdentifyCache instance (per entry)
+DATA_IP_CONTROL_STATE_COORDINATOR = "ip_control_state_coordinator"
 CONF_IS_FRAME_TV = "is_frame_tv"  # Persisted flag: TV confirmed as Frame TV
 # V7: persisted capability flags for the dedicated brightness / colour-temp
 # WebSocket requests. On TVs that don't respond (e.g. Frame 2024) we learn

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -139,6 +139,7 @@ from .const import (
     CONF_WS_NAME,
     DATA_ART_API,
     DATA_CFG,
+    DATA_IP_CONTROL_STATE_COORDINATOR,
     DATA_OPTIONS,
     DEFAULT_APP,
     DEFAULT_PORT,
@@ -698,6 +699,9 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         # PowerState='standby' override or the potentially-stale art_api cache.
         self._ip_control_client: SamsungIPControl | None = None
         self._ip_control_token_cached: str | None = None
+        # Current physical input reported by the shared getTVStates coordinator.
+        # Also updated optimistically after a successful local source change.
+        self._ip_input_source: str | None = None
         self._ip_art_mode: bool | None = None
         # Consecutive transport-failure count; the cache is cleared once it
         # reaches IP_ART_MODE_MAX_FAILURES so a TV that stops answering on
@@ -1752,11 +1756,12 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         """
         if not self._source_list:
             return None
-        # source_list is {display_name: source_key} e.g. {"Home cinéma": "ST_HDMI3"}
-        # Check if source_id matches the ST_ suffix in any value
-        st_key = "ST_" + source_id
+        # source_list is {display_name: source_key}, e.g.
+        # {"Home cinéma": "ST_HDMI3"} or {"PlayStation": "IP_HDMI2"}
+        # Check if source_id matches a SmartThings or IP Control source key.
+        source_keys = (f"ST_{source_id}", f"IP_{source_id}")
         for display_name, source_key in self._source_list.items():
-            if source_key == st_key:
+            if source_key in source_keys:
                 return (display_name, source_key)
         # Also check for TV variant (dtv, digitalTv -> ST_TV)
         if source_id.upper() in ["DTV", "DIGITALTV", "TV"]:
@@ -1871,14 +1876,58 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             )
             self._dump_apps = False
 
+    def _get_ip_control_state_coordinator(self):
+        """Return the shared getTVStates coordinator created by sensor.py."""
+        return (
+            self.hass.data.get(DOMAIN, {})
+            .get(self._entry_id, {})
+            .get(DATA_IP_CONTROL_STATE_COORDINATOR)
+        )
+
+    def _get_ip_control_input_source(self) -> str | None:
+        """Return the latest physical input from the shared IP Control snapshot."""
+        # Do not consume a stale coordinator/cache after IP Control was disabled
+        # or unpaired in Reconfigure.
+        if self._get_ip_control_client() is None:
+            self._ip_input_source = None
+            return None
+
+        coordinator = self._get_ip_control_state_coordinator()
+        data = getattr(coordinator, "data", None)
+        if isinstance(data, dict) and not data.get("powered_off"):
+            tv_states = data.get("tv")
+            if isinstance(tv_states, dict):
+                value = tv_states.get("inputSource")
+                if isinstance(value, str) and value:
+                    self._ip_input_source = value
+
+        return self._ip_input_source
+
     def _get_source(self):
         """Return the current input source."""
         if self.state != MediaPlayerState.ON:
             self._source = None
             return self._source
 
+        # A running app is more specific than the physical TV input.
+        if self._running_app != DEFAULT_APP:
+            self._source = self._running_app
+            return self._source
+
+        # When IP Control is paired, prefer its local getTVStates.inputSource
+        # over SmartThings. Resolve HDMI1/HDMI2/... back to the configured
+        # display name (e.g. "PC" / "Chromecast") so media_player.source stays
+        # consistent with source_list and mini-media-player selectors.
+        if local_source := self._get_ip_control_input_source():
+            if resolved := self._resolve_source_by_id(local_source):
+                self._source = resolved[0]
+                return self._source
+            if self._source_list and local_source in self._source_list:
+                self._source = local_source
+                return self._source
+
         use_st: bool = self._st is not None and self._st.state == STStatus.STATE_ON
-        if self._running_app != DEFAULT_APP or not use_st:
+        if not use_st:
             self._source = self._running_app
             return self._source
 
@@ -3004,6 +3053,47 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         else:
             self.send_command("KEY_REWIND")
 
+    async def _async_ip_control_source(self, source_key: str) -> bool:
+        """Select an input source through local Samsung IP Control."""
+        input_source = source_key.removeprefix("IP_")
+        if not input_source:
+            self._log.error("Invalid IP Control source command: %s", source_key)
+            return False
+
+        client = self._get_ip_control_client()
+        if client is None:
+            self._log.error(
+                "IP Control is not paired or is disabled. Command not sent: %s",
+                source_key,
+            )
+            return False
+
+        try:
+            selected_source = await client.async_set_input_source(input_source)
+        except SamsungIPControlError as ex:
+            self._log.error("IP Control input source %s failed: %s", input_source, ex)
+            return False
+
+        # Keep media_player.source and the existing diagnostic input-source
+        # sensor in sync immediately. The next coordinator poll will confirm the
+        # physical state; no extra JSON-RPC request is needed here.
+        self._ip_input_source = selected_source
+        coordinator = self._get_ip_control_state_coordinator()
+        if coordinator is not None:
+            current_data = getattr(coordinator, "data", None)
+            updated_data = dict(current_data) if isinstance(current_data, dict) else {}
+            current_tv = updated_data.get("tv")
+            tv_states = dict(current_tv) if isinstance(current_tv, dict) else {}
+            tv_states["inputSource"] = selected_source
+            updated_data["tv"] = tv_states
+            updated_data["powered_off"] = False
+            set_updated_data = getattr(coordinator, "async_set_updated_data", None)
+            if callable(set_updated_data):
+                set_updated_data(updated_data)
+
+        self._log.debug("IP Control input source selected: %s", selected_source)
+        return True
+
     async def _async_send_keys(self, source_key):
         """Send key / chained keys."""
         prev_wait = True
@@ -3024,12 +3114,18 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                     if not prev_wait:
                         await asyncio.sleep(KEYPRESS_DEFAULT_DELAY)
                     prev_wait = False
-                    if this_key.startswith("ST_"):
+                    if this_key.startswith("IP_"):
+                        if not await self._async_ip_control_source(this_key):
+                            return False
+                    elif this_key.startswith("ST_"):
                         await self._smartthings_keys(this_key)
                     else:
                         await self.async_send_command(this_key)
 
             return True
+
+        if source_key.startswith("IP_"):
+            return await self._async_ip_control_source(source_key)
 
         if source_key.startswith("ST_"):
             return await self._smartthings_keys(source_key)

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -63,6 +63,7 @@ from .const import (
     CONF_WS_NAME,
     DATA_ART_API,
     DATA_CFG,
+    DATA_IP_CONTROL_STATE_COORDINATOR,
     DEFAULT_PORT,
     DEFAULT_ST_POLL_ON_INTERVAL,
     DOMAIN,
@@ -188,12 +189,12 @@ class SamsungIPControlSensorDescription(SensorEntityDescription):
     source: str = "tv"
 
 
-# getTVStates fields exposed as diagnostic sensors. These particular fields
-# (inputSource, pictureMode, soundMode, pictureSize, speakerSelect, mute,
-# volume) mirror media_player / select state and are read-only over IP Control.
-# The getVideoStates fields (contrast/brightness/sharpness/color/tint) are NOT
-# here — they are settable `number` sliders (see number.py), written via their
-# <field>Control methods when the picture mode allows it.
+# getTVStates fields exposed as diagnostic sensors. Setter availability for
+# matching IP Control fields is model-dependent; these remain read-only sensor
+# entities even when a corresponding local setter (such as inputSourceControl)
+# is available. The getVideoStates fields (contrast/brightness/sharpness/color/
+# tint) are NOT here — they are settable `number` sliders (see number.py),
+# written via their <field>Control methods when the picture mode allows it.
 IP_CONTROL_STATE_SENSORS: tuple[SamsungIPControlSensorDescription, ...] = (
     # getTVStates
     SamsungIPControlSensorDescription(
@@ -587,6 +588,9 @@ async def async_setup_entry(  # noqa: C901
     # coordinator so each poll issues just two JSON-RPC calls for all 12.
     if _ip_control_active(entry):
         state_coordinator = IPControlStateCoordinator(hass, entry, host)
+        hass.data[DOMAIN][entry.entry_id][
+            DATA_IP_CONTROL_STATE_COORDINATOR
+        ] = state_coordinator
         entities.extend(
             IPControlStateSensor(
                 state_coordinator, entry, description, device_name, device_unique_id
@@ -602,6 +606,8 @@ async def async_setup_entry(  # noqa: C901
             device_name,
             len(IP_CONTROL_STATE_SENSORS),
         )
+    else:
+        hass.data[DOMAIN][entry.entry_id].pop(DATA_IP_CONTROL_STATE_COORDINATOR, None)
 
     if entities:
         async_add_entities(entities)

--- a/tests/api/test_ipcontrol_input_source.py
+++ b/tests/api/test_ipcontrol_input_source.py
@@ -1,0 +1,103 @@
+"""Tests for Samsung IP Control input source selection."""
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+def _load_ipcontrol_module():
+    """Load ipcontrol.py with a minimal Home Assistant type stub."""
+    homeassistant = types.ModuleType("homeassistant")
+    homeassistant_core = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:
+        """Type stub used only while importing the module."""
+
+    homeassistant_core.HomeAssistant = HomeAssistant
+    sys.modules.setdefault("homeassistant", homeassistant)
+    sys.modules.setdefault("homeassistant.core", homeassistant_core)
+
+    module_path = (
+        Path(__file__).parents[2]
+        / "custom_components"
+        / "samsungtv_smart"
+        / "api"
+        / "ipcontrol.py"
+    )
+    spec = importlib.util.spec_from_file_location("ipcontrol_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ipcontrol = _load_ipcontrol_module()
+
+
+class _FakeHass:
+    """Minimal executor bridge used by the async client."""
+
+    async def async_add_executor_job(self, func, *args):
+        """Run executor work inline for the unit test."""
+        return func(*args)
+
+
+class InputSourceControlTest(unittest.IsolatedAsyncioTestCase):
+    """Verify local input source selection without network access."""
+
+    def _client(self):
+        """Return a paired client with a fake Home Assistant instance."""
+        ipcontrol._HOST_LOCKS.clear()
+        return ipcontrol.SamsungIPControl(
+            _FakeHass(),
+            "192.0.2.1",
+            token="test-token",
+        )
+
+    async def test_set_input_source_emits_expected_payload(self):
+        """HDMI2 is sent through inputSourceControl with the access token."""
+        client = self._client()
+        sent = {}
+
+        def fake_post(payload, timeout):
+            sent.update(json.loads(payload))
+            return json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"inputSource": "HDMI2"},
+                }
+            )
+
+        client._sync_post = fake_post
+
+        self.assertEqual(await client.async_set_input_source("HDMI2"), "HDMI2")
+        self.assertEqual(sent["method"], "inputSourceControl")
+        self.assertEqual(
+            sent["params"],
+            {"AccessToken": "test-token", "inputSource": "HDMI2"},
+        )
+
+    async def test_method_not_found_surfaces_as_unsupported(self):
+        """A JSON-RPC -32601 remains a capability/state error."""
+        client = self._client()
+
+        def fake_post(payload, timeout):
+            return json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32601, "message": "Method not found"},
+                }
+            )
+
+        client._sync_post = fake_post
+
+        with self.assertRaises(ipcontrol.SamsungIPControlUnsupportedError):
+            await client.async_set_input_source("HDMI2")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds local input source selection through Samsung IP Control using
`inputSourceControl`.

Custom source entries using the `IP_` prefix are routed through the paired
IP Control client instead of WebSocket or SmartThings. For example:

- `IP_HDMI1` → `inputSourceControl("HDMI1")`
- `IP_HDMI2` → `inputSourceControl("HDMI2")`
- `IP_HDMI3` → `inputSourceControl("HDMI3")`
- `IP_HDMI4` → `inputSourceControl("HDMI4")`

This allows discrete local HDMI source selection without SmartThings on TVs
that expose `inputSourceControl`.

Support for this method is model- and firmware-dependent. TVs that do not
support it may return `-32601 "Method not found"`.

### Tested

Tested on Samsung QE55QN90CAUXCE (QN90C, 2023).

Verified locally over IP Control port 1516:

- HDMI1 → success
- HDMI2 → success
- HDMI3 → success
- HDMI4 → success
- `getTVStates` correctly reports the selected input
- no SmartThings connection/token required