### PR TITLE
fix(ip-control): stop blaming the picture mode for a failed state read

### DIFF
--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -103,6 +103,20 @@ ERROR_PARSE_STALE_TOKEN = -32700
 # accept them. Not a transport or pairing problem: retrying after switching
 # picture mode succeeds.
 ERROR_SERVER = -32002
+# Methods whose -32002 genuinely means "the current picture mode forbids this
+# write". Reads (notably getTVStates) return the same code for unrelated
+# reasons, so the picture-mode advice must not be attached to them.
+PICTURE_WRITE_METHODS = frozenset(
+    {
+        "backlightControl",
+        "brightnessControl",
+        "colorControl",
+        "colorToneControl",
+        "contrastControl",
+        "sharpnessControl",
+        "tintControl",
+    }
+)
 # JSON-RPC "Method not found". AMBIGUOUS on Frames: the SAME code is returned
 # both when a method genuinely doesn't exist on the model AND when it exists but
 # isn't available in the current TV state — notably the picture controls while
@@ -645,11 +659,20 @@ class SamsungIPControl:
                     f"token rejected (code {code}): {message} — re-pair required"
                 )
             if code == ERROR_SERVER:
+                # The picture-mode explanation only applies to the expert
+                # picture WRITES it was written for. getTVStates also returns
+                # -32002 occasionally, and telling someone to change picture
+                # mode to fix a state READ sends them nowhere.
+                if method in PICTURE_WRITE_METHODS:
+                    raise SamsungIPControlModeLockedError(
+                        f"{method} returned error {code}: {message} — the "
+                        "current picture mode likely blocks this control (e.g. "
+                        "Dynamic/HDR-dynamic); switch to Standard/Movie/"
+                        "Filmmaker and retry"
+                    )
                 raise SamsungIPControlModeLockedError(
-                    f"TV returned error {code}: {message} — the current "
-                    "picture mode likely blocks this control (e.g. "
-                    "Dynamic/HDR-dynamic); switch to Standard/Movie/"
-                    "Filmmaker and retry"
+                    f"{method} returned error {code}: {message} — the TV "
+                    "refused it in its current state; usually transient"
                 )
             if code == ERROR_METHOD_NOT_FOUND:
                 raise SamsungIPControlUnsupportedError(

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.11"
+  "version": "8.6.12"
 }


### PR DESCRIPTION
Found while going through a five-day maintainer log, not from a user report.

## The problem

`getTVStates` occasionally returns `-32002`, and **every** `-32002` was answered with the same message:

```text
Error fetching IP Control state Frame chambre data: IP Control state read failed:
TV returned error -32002: Server error — the current picture mode likely blocks
this control (e.g. Dynamic/HDR-dynamic); switch to Standard/Movie/Filmmaker and retry
```

That advice was written for the **expert picture writes** it genuinely applies to — `colorToneControl` and friends are rejected in Dynamic/HDR-dynamic mode. For a **state read** it is meaningless: reading the TV's current state has nothing to do with which picture mode is active. Anyone following it changes a setting for no reason and the errors keep coming.

It surfaced **six times over five days** on an otherwise healthy TV, logged at ERROR level.

## The change

The picture-mode explanation is now attached only to the methods it describes:

```python
PICTURE_WRITE_METHODS = frozenset({
    "backlightControl", "brightnessControl", "colorControl", "colorToneControl",
    "contrastControl", "sharpnessControl", "tintControl",
})
```

Everything else gets a factual message instead. Verified across both paths:

| method | message |
|---|---|
| `colorToneControl` | *…the current picture mode likely blocks this control…* |
| `backlightControl` | *…the current picture mode likely blocks this control…* |
| `getTVStates` | *…the TV refused it in its current state; usually transient* |
| `getVideoStates` | *…the TV refused it in its current state; usually transient* |
| `powerControl` | *…the TV refused it in its current state; usually transient* |

Both messages now also name the **method**, which the old one omitted — so a `-32002` in a log says what actually failed rather than only that something did.

No behavioural change: same exception type, same control flow, same callers. Only the text.

Version `8.6.12`; lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_