### PR TITLE
Add local tuner channel info via IP Control

### DIFF
--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -541,6 +541,15 @@ class SamsungIPControl:
         """
         return await self._async_request("getTVStates")
 
+    async def async_get_channel(self) -> dict[str, Any]:
+        """Return the current tuner channel state, when supported.
+
+        Some tuner-equipped Samsung TVs expose ``atvDtv``, ``airCable`` and
+        ``channelNum`` through ``directChannelControl``. Models without this
+        capability may return ``-32601``.
+        """
+        return await self._async_request("directChannelControl")
+
     async def async_get_video_states(self) -> dict[str, Any]:
         """Return the TV's picture-level snapshot (read-only).
 

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -1906,6 +1906,28 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
         return self._ip_input_source
 
+    def _get_ip_control_channel(self) -> str | None:
+        """Return the latest tuner channel from the shared IP Control snapshot."""
+        if self._get_ip_control_client() is None:
+            return None
+
+        coordinator = self._get_ip_control_state_coordinator()
+        data = getattr(coordinator, "data", None)
+        if not isinstance(data, dict) or data.get("powered_off"):
+            return None
+
+        channel_states = data.get("channel")
+        if not isinstance(channel_states, dict):
+            return None
+
+        value = channel_states.get("channelNum")
+        if isinstance(value, (str, int)):
+            channel = str(value).strip()
+            if channel:
+                return channel
+
+        return None
+
     def _get_source(self):
         """Return the current input source."""
         if self.state != MediaPlayerState.ON:
@@ -2680,10 +2702,16 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
     @property
     def media_channel(self):
         """Channel currently playing."""
-        if self._state == MediaPlayerState.ON:
-            if self._st:
-                if self._st.source in ["digitalTv", "TV"] and self._st.channel != "":
-                    return self._st.channel
+        if self._state != MediaPlayerState.ON:
+            return None
+
+        if local_channel := self._get_ip_control_channel():
+            return local_channel
+
+        if self._st:
+            if self._st.source in ["digitalTv", "TV"] and self._st.channel != "":
+                return self._st.channel
+
         return None
 
     @property

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -48,6 +48,7 @@ from .api.ipcontrol import (
     SamsungIPControlAuthError,
     SamsungIPControlError,
     SamsungIPControlTransportError,
+    SamsungIPControlUnsupportedError,
 )
 from .const import (
     ART_IDENTIFY_DEBOUNCE,
@@ -2624,9 +2625,11 @@ class SmartThingsPowerConsumptionSensor(CoordinatorEntity, SensorEntity):
 class IPControlStateCoordinator(DataUpdateCoordinator):
     """Polls getTVStates over IP Control for the read-only state sensors.
 
-    A single coordinator feeds all the getTVStates sensors, so each cycle issues
-    one JSON-RPC call (plus a cheap power-state check) regardless of how many
-    sensors are enabled. The TV is skipped while it is powered off, both to
+    A single coordinator feeds all the getTVStates sensors, so each cycle shares
+    one getTVStates request (plus a cheap power-state check) regardless of how
+    many sensors are enabled. When a non-Frame TV is on a tuner input, one
+    optional directChannelControl request may also fetch local channel metadata.
+    The TV is skipped while it is powered off, both to
     avoid pointless traffic and because the state getters return stale values in
     standby. (The getVideoStates picture fields moved to settable number
     sliders with their own coordinator — see number.py.)
@@ -2650,6 +2653,7 @@ class IPControlStateCoordinator(DataUpdateCoordinator):
         self._host = host
         self._ip_control: SamsungIPControl | None = None
         self._ip_control_token: str | None = None
+        self._channel_control_supported: bool | None = None
 
     def _device_title(self) -> str:
         entry = self.hass.config_entries.async_get_entry(self._entry.entry_id)
@@ -2694,10 +2698,36 @@ class IPControlStateCoordinator(DataUpdateCoordinator):
                 )
                 return {"tv": {}, "powered_off": True}
 
-            # Only getTVStates is consumed now (the getVideoStates fields moved
-            # to settable `number` sliders that read/write directly), so this
-            # coordinator issues a single JSON-RPC call per cycle.
+            # getTVStates remains the primary shared snapshot. On non-Frame TVs
+            # with the tuner active, also query optional local channel metadata.
             tv_states = await client.async_get_tv_states()
+
+            channel_states: dict[str, Any] = {}
+            input_source = tv_states.get("inputSource")
+            tuner_active = isinstance(
+                input_source, str
+            ) and input_source.casefold() in {"tv", "digitaltv", "dtv"}
+
+            if (
+                not self._entry.data.get(CONF_IS_FRAME_TV, False)
+                and tuner_active
+                and self._channel_control_supported is not False
+            ):
+                try:
+                    channel_states = await client.async_get_channel()
+                    self._channel_control_supported = True
+                except SamsungIPControlUnsupportedError:
+                    self._channel_control_supported = False
+                    self._log.debug(
+                        "IP Control channel state is not supported on this TV"
+                    )
+                except SamsungIPControlAuthError:
+                    raise
+                except SamsungIPControlError as ex:
+                    # Channel metadata is optional. A transient failure must not
+                    # invalidate the normal getTVStates snapshot.
+                    self._log.debug("IP Control channel state read failed: %s", ex)
+
         except SamsungIPControlAuthError as ex:
             notify_token_problem(
                 self.hass,
@@ -2724,7 +2754,11 @@ class IPControlStateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"IP Control state read failed: {ex}") from ex
 
         clear_token_problem(self.hass, self._entry.entry_id, METHOD_IP_CONTROL)
-        return {"tv": tv_states, "powered_off": False}
+        return {
+            "tv": tv_states,
+            "channel": channel_states,
+            "powered_off": False,
+        }
 
 
 class IPControlStateSensor(CoordinatorEntity, SensorEntity):

--- a/tests/api/test_ipcontrol_channel.py
+++ b/tests/api/test_ipcontrol_channel.py
@@ -1,0 +1,118 @@
+"""Tests for Samsung IP Control tuner channel state."""
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+def _load_ipcontrol_module():
+    """Load ipcontrol.py with a minimal Home Assistant type stub."""
+    homeassistant = types.ModuleType("homeassistant")
+    homeassistant_core = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:
+        """Type stub used only while importing the module."""
+
+    homeassistant_core.HomeAssistant = HomeAssistant
+    sys.modules.setdefault("homeassistant", homeassistant)
+    sys.modules.setdefault("homeassistant.core", homeassistant_core)
+
+    module_path = (
+        Path(__file__).parents[2]
+        / "custom_components"
+        / "samsungtv_smart"
+        / "api"
+        / "ipcontrol.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "ipcontrol_channel_under_test", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ipcontrol = _load_ipcontrol_module()
+
+
+class _FakeHass:
+    """Minimal executor bridge used by the async client."""
+
+    async def async_add_executor_job(self, func, *args):
+        """Run executor work inline for the unit test."""
+        return func(*args)
+
+
+class ChannelControlTest(unittest.IsolatedAsyncioTestCase):
+    """Verify local tuner channel state without network access."""
+
+    def _client(self):
+        """Return a paired client with a fake Home Assistant instance."""
+        ipcontrol._HOST_LOCKS.clear()
+        return ipcontrol.SamsungIPControl(
+            _FakeHass(),
+            "192.0.2.1",
+            token="test-token",
+        )
+
+    async def test_get_channel_emits_expected_payload_and_returns_state(self):
+        """directChannelControl returns tuner metadata unchanged."""
+        client = self._client()
+        sent = {}
+
+        def fake_post(payload, timeout):
+            sent.update(json.loads(payload))
+            return json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "atvDtv": "dtv",
+                        "airCable": "air",
+                        "channelNum": "5",
+                    },
+                }
+            )
+
+        client._sync_post = fake_post
+
+        result = await client.async_get_channel()
+
+        self.assertEqual(sent["method"], "directChannelControl")
+        self.assertEqual(sent["params"], {"AccessToken": "test-token"})
+        self.assertEqual(
+            result,
+            {
+                "atvDtv": "dtv",
+                "airCable": "air",
+                "channelNum": "5",
+            },
+        )
+
+    async def test_method_not_found_surfaces_as_unsupported(self):
+        """A JSON-RPC -32601 remains an unsupported capability/state error."""
+        client = self._client()
+
+        def fake_post(payload, timeout):
+            return json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {
+                        "code": -32601,
+                        "message": "Method not found",
+                    },
+                }
+            )
+
+        client._sync_post = fake_post
+
+        with self.assertRaises(ipcontrol.SamsungIPControlUnsupportedError):
+            await client.async_get_channel()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ipcontrol_channel_coordinator.py
+++ b/tests/test_ipcontrol_channel_coordinator.py
@@ -1,0 +1,191 @@
+"""Tests for optional local tuner channel polling."""
+
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, patch
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+# The repository test requirements do not install pysmartthings.
+# Provide the symbols required while importing sensor.py.
+if "pysmartthings" not in sys.modules:
+    pysmartthings = ModuleType("pysmartthings")
+
+    class _Names:
+        def __getattr__(self, name):
+            return name
+
+    pysmartthings.Attribute = _Names()
+    pysmartthings.Capability = _Names()
+    pysmartthings.SmartThings = object
+    sys.modules["pysmartthings"] = pysmartthings
+
+
+from custom_components.samsungtv_smart.api.ipcontrol import (  # noqa: E402
+    SamsungIPControlError,
+    SamsungIPControlUnsupportedError,
+)
+from custom_components.samsungtv_smart.const import (  # noqa: E402
+    CONF_IS_FRAME_TV,
+    DOMAIN,
+)
+from custom_components.samsungtv_smart.sensor import (  # noqa: E402
+    IPControlStateCoordinator,
+)
+
+HOST = "192.0.2.10"
+
+
+def _entry(hass, *, is_frame=False):
+    """Create a minimal TV config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test Samsung TV",
+        unique_id="test-samsung-tv",
+        data={
+            CONF_IS_FRAME_TV: is_frame,
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _client(*, source="TV"):
+    """Create a fake IP Control client."""
+    client = AsyncMock()
+    client.async_get_power_state.return_value = "powerOn"
+    client.async_get_tv_states.return_value = {
+        "inputSource": source,
+    }
+    client.async_get_channel.return_value = {
+        "atvDtv": "dtv",
+        "airCable": "air",
+        "channelNum": "5",
+    }
+    return client
+
+
+async def _update(coordinator, client):
+    """Run one coordinator update using the fake client."""
+    with (
+        patch.object(
+            coordinator,
+            "_get_ip_control",
+            return_value=client,
+        ),
+        patch("custom_components.samsungtv_smart.sensor.clear_token_problem"),
+    ):
+        return await coordinator._async_update_data()
+
+
+async def test_tuner_channel_is_added_for_non_frame_tv(hass):
+    """A non-Frame TV on its tuner exposes local channel metadata."""
+    entry = _entry(hass)
+    coordinator = IPControlStateCoordinator(hass, entry, HOST)
+    client = _client(source="TV")
+
+    data = await _update(coordinator, client)
+
+    assert data == {
+        "tv": {"inputSource": "TV"},
+        "channel": {
+            "atvDtv": "dtv",
+            "airCable": "air",
+            "channelNum": "5",
+        },
+        "powered_off": False,
+    }
+    assert coordinator._channel_control_supported is True
+    client.async_get_channel.assert_awaited_once_with()
+
+
+async def test_frame_tv_never_queries_channel_control(hass):
+    """A known Frame TV never receives directChannelControl."""
+    entry = _entry(hass, is_frame=True)
+    coordinator = IPControlStateCoordinator(hass, entry, HOST)
+    client = _client(source="TV")
+
+    data = await _update(coordinator, client)
+
+    assert data["tv"] == {"inputSource": "TV"}
+    assert data["channel"] == {}
+    assert data["powered_off"] is False
+    assert coordinator._channel_control_supported is None
+    client.async_get_channel.assert_not_awaited()
+
+
+async def test_hdmi_never_queries_channel_control(hass):
+    """A non-tuner input never triggers a channel metadata query."""
+    entry = _entry(hass)
+    coordinator = IPControlStateCoordinator(hass, entry, HOST)
+    client = _client(source="HDMI1")
+
+    data = await _update(coordinator, client)
+
+    assert data["tv"] == {"inputSource": "HDMI1"}
+    assert data["channel"] == {}
+    assert data["powered_off"] is False
+    assert coordinator._channel_control_supported is None
+    client.async_get_channel.assert_not_awaited()
+
+
+async def test_unsupported_channel_control_is_probed_only_once(hass):
+    """A confirmed -32601 prevents repeated capability probes."""
+    entry = _entry(hass)
+    coordinator = IPControlStateCoordinator(hass, entry, HOST)
+    client = _client(source="TV")
+    client.async_get_channel.side_effect = SamsungIPControlUnsupportedError(
+        "Method not found"
+    )
+
+    first = await _update(coordinator, client)
+    second = await _update(coordinator, client)
+
+    assert first["tv"] == {"inputSource": "TV"}
+    assert first["channel"] == {}
+    assert first["powered_off"] is False
+
+    assert second["tv"] == {"inputSource": "TV"}
+    assert second["channel"] == {}
+    assert second["powered_off"] is False
+
+    assert coordinator._channel_control_supported is False
+
+    # Only the first poll probes directChannelControl.
+    assert client.async_get_channel.await_count == 1
+    assert client.async_get_tv_states.await_count == 2
+
+
+async def test_transient_channel_error_does_not_disable_capability(hass):
+    """A transient channel read failure does not invalidate the TV snapshot."""
+    entry = _entry(hass)
+    coordinator = IPControlStateCoordinator(hass, entry, HOST)
+    client = _client(source="TV")
+
+    client.async_get_channel.side_effect = SamsungIPControlError(
+        "Temporary channel read failure"
+    )
+
+    first = await _update(coordinator, client)
+
+    assert first == {
+        "tv": {"inputSource": "TV"},
+        "channel": {},
+        "powered_off": False,
+    }
+    assert coordinator._channel_control_supported is None
+    client.async_get_channel.assert_awaited_once_with()
+
+    # A later poll must be allowed to retry the optional capability.
+    client.async_get_channel.side_effect = None
+    client.async_get_channel.return_value = {
+        "atvDtv": "dtv",
+        "airCable": "air",
+        "channelNum": "7",
+    }
+
+    second = await _update(coordinator, client)
+
+    assert second["channel"]["channelNum"] == "7"
+    assert coordinator._channel_control_supported is True
+    assert client.async_get_channel.await_count == 2

--- a/tests/test_media_channel.py
+++ b/tests/test_media_channel.py
@@ -1,0 +1,76 @@
+"""Tests for local tuner channel exposure on the media player."""
+
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+# The repository test requirements do not install pysmartthings.
+# This is the same minimal import stub used by existing tests.
+if "pysmartthings" not in sys.modules:
+    pysmartthings = ModuleType("pysmartthings")
+    pysmartthings.SmartThings = object
+    sys.modules["pysmartthings"] = pysmartthings
+
+
+from custom_components.samsungtv_smart.const import DEFAULT_APP  # noqa: E402
+from custom_components.samsungtv_smart.media_player import SamsungTVDevice  # noqa: E402
+from homeassistant.components.media_player import (  # noqa: E402
+    MediaPlayerState,
+    MediaType,
+)
+
+
+def _device(*, st=None):
+    """Create only the state needed by the media properties."""
+    device = object.__new__(SamsungTVDevice)
+    device._state = MediaPlayerState.ON
+    device._st = st
+    device._running_app = DEFAULT_APP
+    return device
+
+
+def test_local_channel_is_preferred_over_smartthings():
+    """Local IP Control channel wins when both sources have data."""
+    device = _device(
+        st=SimpleNamespace(
+            source="TV",
+            channel="42",
+        )
+    )
+
+    with patch.object(
+        SamsungTVDevice,
+        "_get_ip_control_channel",
+        return_value="7",
+    ):
+        assert device.media_channel == "7"
+
+
+def test_smartthings_channel_remains_fallback():
+    """Existing SmartThings channel behavior remains available."""
+    device = _device(
+        st=SimpleNamespace(
+            source="digitalTv",
+            channel="42",
+        )
+    )
+
+    with patch.object(
+        SamsungTVDevice,
+        "_get_ip_control_channel",
+        return_value=None,
+    ):
+        assert device.media_channel == "42"
+
+
+def test_local_channel_sets_channel_media_type():
+    """A local tuner channel is exposed as channel media."""
+    device = _device()
+
+    with patch.object(
+        SamsungTVDevice,
+        "_get_ip_control_channel",
+        return_value="7",
+    ):
+        assert device.media_channel == "7"
+        assert device.media_content_type == MediaType.CHANNEL


### PR DESCRIPTION
## Summary

Expose the current local tuner channel number through Samsung IP Control when available.

Some tuner-equipped Samsung TVs return tuner metadata from the
`directChannelControl` JSON-RPC method, including:

- `atvDtv`
- `airCable`
- `channelNum`

This PR uses that local `channelNum` value for `media_player.media_channel`,
while keeping SmartThings as the existing fallback.

## Implementation

- Add `SamsungIPControl.async_get_channel()` using `directChannelControl`.
- Reuse the existing shared IP Control state coordinator.
- Query channel metadata only when the current physical input is a tuner input
  (`TV`, `digitalTv`, or `dtv`).
- Never call `directChannelControl` on TVs configured as Frame TVs.
- Cache JSON-RPC `-32601 Method not found` as unsupported for the coordinator
  session to avoid repeatedly probing unsupported TVs.
- Treat other channel-read errors as optional/transient, so they do not
  invalidate the normal `getTVStates` snapshot.
- Prefer the local channel number in `media_channel`, with the existing
  SmartThings channel value as fallback.
- Do not synthesize a channel title/name.

## Testing

Tested on a Samsung UE50DU7170UXZT running Tizen 9.0.

Verified manually that:

- changing terrestrial TV channels with the physical remote updates
  `media_channel`;
- changing channels through Home Assistant also updates `media_channel`;
- switching from TV to HDMI removes the tuner channel;
- switching back to TV restores the correct channel number.

Frame TV hardware was not available for manual testing. Frame safety is handled
by explicitly skipping `directChannelControl` for known Frame TVs and is covered
by unit tests.

Automated tests cover:

- the `directChannelControl` request and response;
- `-32601` unsupported handling;
- Frame TVs not being queried;
- HDMI/non-tuner inputs not being queried;
- unsupported capability being probed only once per coordinator session;
- transient channel-read failures being retried without invalidating TV state;
- local channel preference over SmartThings;
- SmartThings fallback;
- `MediaType.CHANNEL` exposure.

Relevant local test results:

- 12 pytest tests passed, including the new coordinator and media-channel tests
- 9 related IP Control unittest tests passed, including the new
  `directChannelControl` tests
- flake8 passed
- isort passed
- black passed
- `git diff --check` passed

## AI assistance

This contribution was developed with the assistance of ChatGPT (OpenAI),
including code generation, test development, code review, and preparation of
the pull request documentation.

All generated changes were manually reviewed, tested against the existing
codebase, and the functional behavior was verified on real hardware before
submitting this PR.

## Polling interval

Channel metadata currently follows the existing IP Control state coordinator
refresh interval, so it is not intended to be instantaneous. On the tested TV,
physical channel changes were typically reflected in Home Assistant after about
18–21 seconds.

A possible future improvement would be a dedicated shorter poll (for example
around 5 seconds) of only `channelNum` while the tuner is active, without
increasing the global IP Control polling frequency for every TV.