### PR TITLE
feat(options): configurable IP Control poll interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ After initial setup, click **Configure** on the integration card to access these
 | **Sync turn on/off** | Optional entity to mirror TV power state |
 | **External power entity** | Use an external sensor to determine power state |
 | **Toggle Art Mode** | Toggle Art Mode when turning on a Frame TV that is already in Art Mode |
+| **IP Control poll interval** | How often the local IP Control state is read (5–600 s, default 10). This snapshot carries the input source, picture/sound modes and — on the tuner — the channel number, so it decides how fast those follow a change made with the remote. Local LAN calls, no cloud quota: lower is fine on modern panels, raise it if an older TV is slow to answer |
 | **Ping port** | Port used to detect TV presence |
 | **WS name** | Name shown on the TV when pairing (default: `[Home Assistant]`) |
 

--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -68,6 +68,7 @@ from .const import (
     CONF_DEVICE_NAME,
     CONF_ENABLE_IP_CONTROL,
     CONF_IP_CONTROL_ART_MODE,
+    CONF_IP_CONTROL_POLL_INTERVAL,
     CONF_LOAD_ALL_APPS,
     CONF_OAUTH_TOKEN,
     CONF_SCAN_APP_HTTP,
@@ -1308,12 +1309,14 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 # Options whose change adds/removes platforms or clients and therefore needs a
 # full reload (everything else is applied live via SIGNAL_CONFIG_ENTITY).
-# CONF_ST_POLL_ON_INTERVAL is included because the SmartThings power-sensor
-# coordinator fixes its update_interval at creation time; a reload re-creates it
-# with the new cadence (the media_player / selects read it live).
+# CONF_ST_POLL_ON_INTERVAL and CONF_IP_CONTROL_POLL_INTERVAL are included
+# because their coordinators fix update_interval at creation time; a reload
+# re-creates them with the new cadence (the media_player / selects read the
+# SmartThings one live).
 _RELOAD_OPTIONS = (
     CONF_ENABLE_IP_CONTROL,
     CONF_IP_CONTROL_ART_MODE,
+    CONF_IP_CONTROL_POLL_INTERVAL,
     CONF_ST_POLL_ON_INTERVAL,
 )
 

--- a/custom_components/samsungtv_smart/config_flow.py
+++ b/custom_components/samsungtv_smart/config_flow.py
@@ -82,6 +82,7 @@ from .const import (
     CONF_IP_CONTROL_ART_MODE,
     CONF_IP_CONTROL_FW_VERSION,
     CONF_IP_CONTROL_MODEL_ID,
+    CONF_IP_CONTROL_POLL_INTERVAL,
     CONF_IP_CONTROL_PORT,
     CONF_IP_CONTROL_TOKEN,
     CONF_LOGO_OPTION,
@@ -105,14 +106,17 @@ from .const import (
     CONF_WOL_REPEAT,
     CONF_WS_NAME,
     DEFAULT_CONTENT_LIST_INTERVAL,
+    DEFAULT_IP_CONTROL_POLL_INTERVAL,
     DEFAULT_PORT,
     DEFAULT_ST_POLL_ON_INTERVAL,
     DOMAIN,
     IP_CONTROL_PORTS,
     MAX_CONTENT_LIST_INTERVAL,
+    MAX_IP_CONTROL_POLL_INTERVAL,
     MAX_ST_POLL_ON_INTERVAL,
     MAX_WOL_REPEAT,
     MIN_CONTENT_LIST_INTERVAL,
+    MIN_IP_CONTROL_POLL_INTERVAL,
     MIN_ST_POLL_ON_INTERVAL,
     RESULT_ST_DEVICE_NOT_FOUND,
     RESULT_ST_DEVICE_USED,
@@ -163,6 +167,7 @@ ADVANCED_OPTIONS = [
     CONF_DUMP_APPS,
     CONF_EXT_POWER_ENTITY,
     CONF_PING_PORT,
+    CONF_IP_CONTROL_POLL_INTERVAL,
     CONF_ST_POLL_ON_INTERVAL,
     CONF_WOL_REPEAT,
     CONF_TOGGLE_ART_MODE,
@@ -1759,6 +1764,19 @@ class OptionsFlowHandler(OptionsFlow):
                     vol.Clamp(
                         min=MIN_ST_POLL_ON_INTERVAL,
                         max=MAX_ST_POLL_ON_INTERVAL,
+                    ),
+                ),
+                vol.Required(
+                    CONF_IP_CONTROL_POLL_INTERVAL,
+                    default=options.get(
+                        CONF_IP_CONTROL_POLL_INTERVAL,
+                        DEFAULT_IP_CONTROL_POLL_INTERVAL,
+                    ),
+                ): vol.All(
+                    vol.Coerce(int),
+                    vol.Clamp(
+                        min=MIN_IP_CONTROL_POLL_INTERVAL,
+                        max=MAX_IP_CONTROL_POLL_INTERVAL,
                     ),
                 ),
             }

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -68,6 +68,20 @@ CONF_ST_POLL_ON_INTERVAL = "st_poll_on_interval"
 DEFAULT_ST_POLL_ON_INTERVAL = 30
 MIN_ST_POLL_ON_INTERVAL = 5
 MAX_ST_POLL_ON_INTERVAL = 600
+# IP Control (local JSON-RPC) poll cadence (seconds) for the read-only state
+# sensors: speaker, volume, mute, picture size/mode, sound mode, input source
+# and — when the tuner is the active input — the local channel number. This is
+# a LAN call to the TV with no cloud quota behind it, which is why it is a
+# separate setting from CONF_ST_POLL_ON_INTERVAL rather than sharing it: the
+# reason to slow SmartThings down (cloud rate limits) does not apply here.
+# The floor is deliberately low but not zero — old panels (e.g. the 2018 set of
+# issue #206) are slow to answer, and below ~5 s the requests start to overlap
+# the responses rather than making anything more responsive.
+CONF_IP_CONTROL_POLL_INTERVAL = "ip_control_poll_interval"
+DEFAULT_IP_CONTROL_POLL_INTERVAL = 10
+MIN_IP_CONTROL_POLL_INTERVAL = 5
+MAX_IP_CONTROL_POLL_INTERVAL = 600
+
 # Fixed SmartThings poll cadence (seconds) while the TV is OFF. A short
 # keepalive so a power-on is still picked up from the cloud as a backup to
 # the local WebSocket, without hammering the API during standby.

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.6.17"
+  "version": "8.6.18"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -1917,7 +1917,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         if not isinstance(data, dict) or data.get("powered_off"):
             return None
 
-        # The snapshot is refreshed every IP_CONTROL_STATE_SCAN_INTERVAL, so
+        # The snapshot is refreshed at the configured IP Control poll cadence, so
         # after switching the TV away from its tuner the previous poll's channel
         # is still in `data` until the next one. Cross-check the input recorded
         # in the same snapshot, or media_channel would keep reporting a channel

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -56,6 +56,7 @@ from .const import (
     CONF_ART_IDENTIFY_ENABLE,
     CONF_DEVICE_ID,
     CONF_ENABLE_IP_CONTROL,
+    CONF_IP_CONTROL_POLL_INTERVAL,
     CONF_IP_CONTROL_TOKEN,
     CONF_IS_FRAME_TV,
     CONF_OAUTH_TOKEN,
@@ -65,6 +66,7 @@ from .const import (
     DATA_ART_API,
     DATA_CFG,
     DATA_IP_CONTROL_STATE_COORDINATOR,
+    DEFAULT_IP_CONTROL_POLL_INTERVAL,
     DEFAULT_PORT,
     DEFAULT_ST_POLL_ON_INTERVAL,
     DOMAIN,
@@ -82,6 +84,13 @@ def _ip_control_active(entry: ConfigEntry) -> bool:
     """True when IP Control is paired AND enabled in the options."""
     return bool(entry.data.get(CONF_IP_CONTROL_TOKEN)) and entry.options.get(
         CONF_ENABLE_IP_CONTROL, True
+    )
+
+
+def _ip_control_poll_interval(entry: ConfigEntry) -> int:
+    """Configured IP Control poll cadence (seconds) for the state sensors."""
+    return entry.options.get(
+        CONF_IP_CONTROL_POLL_INTERVAL, DEFAULT_IP_CONTROL_POLL_INTERVAL
     )
 
 
@@ -167,10 +176,6 @@ def _st_child_gate(entity) -> bool:
     entity._st_last_poll = now
     return True
 
-
-# Update interval for the read-only IP Control state sensors. Picture/sound
-# settings change slowly, so a relaxed cadence keeps JSON-RPC traffic light.
-IP_CONTROL_STATE_SCAN_INTERVAL = timedelta(seconds=30)
 
 # How long to wait before re-fetching the thumbnail of an Art Store (SAM-*)
 # artwork the TV has not cached locally yet. The TV materializes the thumbnail
@@ -2648,7 +2653,7 @@ class IPControlStateCoordinator(DataUpdateCoordinator):
             hass,
             self._log,
             name=f"IP Control state {entry.title}",
-            update_interval=IP_CONTROL_STATE_SCAN_INTERVAL,
+            update_interval=timedelta(seconds=_ip_control_poll_interval(entry)),
         )
         self._entry = entry
         self._host = host

--- a/custom_components/samsungtv_smart/strings.json
+++ b/custom_components/samsungtv_smart/strings.json
@@ -208,7 +208,8 @@
           "use_mute_check": "Use Mute State for Power Detection",
           "dump_apps": "Debug: Dump Applications",
           "toggle_art_mode": "Toggle Art Mode on Power",
-          "st_poll_on_interval": "SmartThings poll interval when on (seconds)"
+          "st_poll_on_interval": "SmartThings poll interval when on (seconds)",
+          "ip_control_poll_interval": "IP Control poll interval (seconds)"
         }
       },
       "save_exit": {

--- a/custom_components/samsungtv_smart/translations/en.json
+++ b/custom_components/samsungtv_smart/translations/en.json
@@ -208,7 +208,8 @@
           "use_mute_check": "Use Mute State for Power Detection",
           "dump_apps": "Debug: Dump Applications",
           "toggle_art_mode": "Toggle Art Mode on Power",
-          "st_poll_on_interval": "SmartThings poll interval when on (seconds)"
+          "st_poll_on_interval": "SmartThings poll interval when on (seconds)",
+          "ip_control_poll_interval": "IP Control poll interval (seconds)"
         }
       },
       "save_exit": {

--- a/custom_components/samsungtv_smart/translations/fr.json
+++ b/custom_components/samsungtv_smart/translations/fr.json
@@ -207,7 +207,8 @@
           "use_mute_check": "Utiliser l'état muet pour détecter l'alimentation",
           "dump_apps": "Debug : exporter la liste des applications",
           "toggle_art_mode": "Bouton d'alimentation bascule vers le mode Art",
-          "st_poll_on_interval": "Intervalle d'interrogation SmartThings quand la TV est allumée (secondes)"
+          "st_poll_on_interval": "Intervalle d'interrogation SmartThings quand la TV est allumée (secondes)",
+          "ip_control_poll_interval": "Intervalle d'interrogation IP Control (secondes)"
         }
       },
       "save_exit": {

--- a/tests/test_media_channel.py
+++ b/tests/test_media_channel.py
@@ -105,7 +105,7 @@ def test_channel_is_read_while_the_snapshot_says_tuner():
 def test_stale_channel_is_dropped_once_the_input_left_the_tuner():
     """A channel left over from the previous poll is not reported on HDMI.
 
-    The snapshot is only refreshed every IP_CONTROL_STATE_SCAN_INTERVAL, so
+    The snapshot is only refreshed at the IP Control poll cadence, so
     right after switching to HDMI it still carries the tuner channel.
     """
     device = _device()


### PR DESCRIPTION
Follow-up to #233 / #235.

## Why

`IPControlStateCoordinator` ran at a hard-coded `timedelta(seconds=30)`. That snapshot carries the input source — and with it the tuner channel added in #233 — so this constant, not any user setting, was what made `media_channel` and the reported input take up to 30 s to follow a change made with the remote. The contributor measured 18–21 s and assumed a setting was involved; there wasn't one.

## Why a dedicated option rather than reusing the SmartThings one

`CONF_ST_POLL_ON_INTERVAL` exists to arbitrate the **SmartThings cloud quota** — it is the knob that keeps installs under the rate limit. This coordinator makes a **LAN call to the TV** with no quota behind it. The two have no reason to move together: someone slowing the cloud down to avoid a 429 has no reason to slow their local sensors down as well.

The pattern is already established in the repo — `CONF_ST_POLL_ON_INTERVAL` (5–600 s) and `CONF_CONTENT_LIST_INTERVAL` (30–3600 s) are both per-coordinator options.

## The change

- `CONF_IP_CONTROL_POLL_INTERVAL`, **5–600 s, default 10**, in advanced options.
- `_ip_control_poll_interval(entry)` in `sensor.py`, next to the existing `_st_poll_on_interval`.
- The key joins `_RELOAD_OPTIONS`: the coordinator fixes `update_interval` at creation, exactly the case already documented there for the SmartThings option, so a reload re-creates it at the new cadence.
- `IP_CONTROL_STATE_SCAN_INTERVAL` is removed (it had no remaining user); the two comments referring to it are reworded.
- `strings.json` + `en` / `fr` translations, and a README row describing what the cadence actually governs.

The default moves from 30 s to 10 s, so existing installs get three times the local poll rate — deliberate, and the reason the floor is 5 s rather than lower: below that the requests start overlapping the responses on slower panels (the 2018 set of #206), which buys nothing.

`number.py`'s video-slider coordinator keeps its own interval — a calibration slider has no reason to follow the input source.

## Verification

- Config-flow code, so checked structurally rather than by eye: an AST pass confirms every `vol.Required` / `vol.Optional` in `config_flow.py` still takes exactly one positional argument (an earlier edit of mine had injected the new key as a second positional into the SmartThings field, which would have silently turned it into the voluptuous `msg` argument), the key is present in `_RELOAD_OPTIONS`, and the three JSON files still parse.
- Constants confirmed as `ip_control_poll_interval` / 10 / 5 / 600.
- black / flake8 / isort pass on `custom_components`; the unittest suite passes.

Not verified: the options form has not been opened in a running HA. Worth a look at **Configure → advanced** before publishing, since that is the screen this touches.

Version `8.6.18`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_