### PR TITLE
Add capability-based IP Control absolute volume support

### DIFF
--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -488,8 +488,54 @@ class SamsungIPControl:
             raise SamsungIPControlError(f"unexpected mute response: {result!r}")
         return value == "muteOn"
 
+    async def async_get_volume(self) -> int:
+        """Return the absolute volume (0-100) when supported."""
+        result = await self._async_request("directVolumeControl")
+        value = result.get("volume")
+
+        try:
+            volume = int(value)
+        except (TypeError, ValueError) as ex:
+            raise SamsungIPControlError(
+                f"invalid directVolumeControl response: {result!r}"
+            ) from ex
+
+        if not 0 <= volume <= 100:
+            raise SamsungIPControlError(
+                f"volume out of range in directVolumeControl response: {result!r}"
+            )
+
+        return volume
+
+    async def async_set_volume(self, value: int) -> int:
+        """Set and return the absolute volume (0-100) when supported."""
+        volume = int(value)
+
+        if not 0 <= volume <= 100:
+            raise SamsungIPControlError("volume must be between 0 and 100")
+
+        result = await self._async_request(
+            "directVolumeControl",
+            {"volume": volume},
+        )
+        response_value = result.get("volume", volume)
+
+        try:
+            response_volume = int(response_value)
+        except (TypeError, ValueError) as ex:
+            raise SamsungIPControlError(
+                f"invalid directVolumeControl response: {result!r}"
+            ) from ex
+
+        if not 0 <= response_volume <= 100:
+            raise SamsungIPControlError(
+                f"volume out of range in directVolumeControl response: {result!r}"
+            )
+
+        return response_volume
+
     async def async_volume_up(self) -> None:
-        """Step the volume up by one (relative — no absolute level over IP Control).
+        """Step the volume up by one using relative IP Control.
 
         ``volumeUpDnControl`` is the only volume setter that works via IP
         Control on a Frame 2024/2025 — ``directVolumeControl`` (absolute

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -1595,11 +1595,18 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             try:
                 volume = await client.async_get_volume()
             except SamsungIPControlUnsupportedError as ex:
-                self._ip_absolute_volume_supported = False
-                self._log.debug(
-                    "IP Control absolute volume is not available on this TV: %s",
-                    ex,
-                )
+                if self._ip_control_ambient_mode_active():
+                    self._log.debug(
+                        "IP Control absolute volume unavailable while Ambient mode "
+                        "is active; not treating it as unsupported: %s",
+                        ex,
+                    )
+                else:
+                    self._ip_absolute_volume_supported = False
+                    self._log.debug(
+                        "IP Control absolute volume is not available on this TV: %s",
+                        ex,
+                    )
             except SamsungIPControlError as ex:
                 # Network/state errors must not be mistaken for a missing
                 # capability. We can retry on the next normal update.
@@ -1610,9 +1617,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 )
             else:
                 if self._ip_absolute_volume_supported is not True:
-                    self._log.info(
-                        "IP Control absolute volume detected for this TV"
-                    )
+                    self._log.info("IP Control absolute volume detected for this TV")
 
                 self._ip_absolute_volume_supported = True
                 self._attr_volume_level = volume / 100
@@ -1928,6 +1933,16 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             .get(self._entry_id, {})
             .get(DATA_IP_CONTROL_STATE_COORDINATOR)
         )
+
+    def _ip_control_ambient_mode_active(self) -> bool:
+        """Return whether the shared IP Control snapshot reports Ambient mode."""
+        coordinator = self._get_ip_control_state_coordinator()
+        data = getattr(coordinator, "data", None)
+        if not isinstance(data, dict) or data.get("powered_off"):
+            return False
+
+        tv_states = data.get("tv")
+        return isinstance(tv_states, dict) and tv_states.get("pictureMode") == "Ambient"
 
     def _get_ip_control_input_source(self) -> str | None:
         """Return the latest physical input from the shared IP Control snapshot."""
@@ -3139,11 +3154,18 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             try:
                 applied = await client.async_set_volume(target)
             except SamsungIPControlUnsupportedError as ex:
-                self._ip_absolute_volume_supported = False
-                self._log.debug(
-                    "IP Control absolute volume is not available on this TV: %s",
-                    ex,
-                )
+                if self._ip_control_ambient_mode_active():
+                    self._log.debug(
+                        "IP Control absolute volume unavailable while Ambient mode "
+                        "is active; not treating it as unsupported: %s",
+                        ex,
+                    )
+                else:
+                    self._ip_absolute_volume_supported = False
+                    self._log.debug(
+                        "IP Control absolute volume is not available on this TV: %s",
+                        ex,
+                    )
             except SamsungIPControlError as ex:
                 self._log.debug(
                     "IP Control absolute-volume set failed (%s); "

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -80,6 +80,7 @@ from .api.ipcontrol import (
     SamsungIPControl,
     SamsungIPControlAuthError,
     SamsungIPControlError,
+    SamsungIPControlUnsupportedError,
 )
 from .api.samsungcast import SamsungCastTube
 from .api.samsungws import ArtModeStatus, SamsungTVAsyncRest, SamsungTVWS
@@ -700,6 +701,10 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         # PowerState='standby' override or the potentially-stale art_api cache.
         self._ip_control_client: SamsungIPControl | None = None
         self._ip_control_token_cached: str | None = None
+        # directVolumeControl is model-dependent. Some Samsung TVs support
+        # absolute volume locally, including with an external HDMI/eARC audio
+        # device, while others do not. None means "not probed yet".
+        self._ip_absolute_volume_supported: bool | None = None
         # Current physical input reported by the shared getTVStates coordinator.
         # Also updated optimistically after a successful local source change.
         self._ip_input_source: str | None = None
@@ -1145,14 +1150,17 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         """
         entry = self.hass.config_entries.async_get_entry(self._entry_id)
         token = entry.data.get(CONF_IP_CONTROL_TOKEN) if entry else None
+
         if not token or not self._get_option(CONF_ENABLE_IP_CONTROL, True):
-            # Un-paired, or the IP Control channel was disabled in options —
-            # drop any cached client/value and behave as if not paired.
+            # Unpaired, or IP Control disabled.
             if self._ip_control_client is not None:
                 self._ip_control_client = None
                 self._ip_control_token_cached = None
+            self._ip_absolute_volume_supported = None
             return None
+
         port = ip_control_port(entry.data)
+
         if (
             self._ip_control_client is None
             or self._ip_control_token_cached != token
@@ -1162,6 +1170,8 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 self.hass, self._host, port=port, token=token
             )
             self._ip_control_token_cached = token
+            self._ip_absolute_volume_supported = None
+
         return self._ip_control_client
 
     def _on_art_transition(self) -> None:
@@ -1574,17 +1584,48 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
     async def _update_volume_info(self):
         """Update the volume info."""
-        if self._state == MediaPlayerState.ON:
-            # if self._st and self._setvolumebyst:
-            #     self._attr_volume_level = self._st.volume
-            #     self._attr_is_volume_muted = self._st.muted
-            #     return
+        if self._state != MediaPlayerState.ON:
+            return
 
-            if (volume := await self._upnp.async_get_volume()) is not None:
-                self._attr_volume_level = int(volume) / 100
+        # Prefer local IP Control when this TV implements directVolumeControl.
+        # This is discovered per device rather than inferred from model/year.
+        client = self._get_ip_control_client()
+
+        if client is not None and self._ip_absolute_volume_supported is not False:
+            try:
+                volume = await client.async_get_volume()
+            except SamsungIPControlUnsupportedError as ex:
+                self._ip_absolute_volume_supported = False
+                self._log.debug(
+                    "IP Control absolute volume is not available on this TV: %s",
+                    ex,
+                )
+            except SamsungIPControlError as ex:
+                # Network/state errors must not be mistaken for a missing
+                # capability. We can retry on the next normal update.
+                self._log.debug(
+                    "IP Control absolute-volume read failed (%s); "
+                    "falling back to UPnP",
+                    ex,
+                )
             else:
-                self._attr_volume_level = None
-            self._attr_is_volume_muted = await self._upnp.async_get_mute()
+                if self._ip_absolute_volume_supported is not True:
+                    self._log.info(
+                        "IP Control absolute volume detected for this TV"
+                    )
+
+                self._ip_absolute_volume_supported = True
+                self._attr_volume_level = volume / 100
+                self._attr_is_volume_muted = await self._upnp.async_get_mute()
+                return
+
+        # Existing behaviour for TVs without local absolute-volume support.
+        if (volume := await self._upnp.async_get_volume()) is not None:
+            self._attr_volume_level = int(volume) / 100
+        else:
+            self._attr_volume_level = None
+
+        self._attr_is_volume_muted = await self._upnp.async_get_mute()
 
     def _get_external_entity_status(self):
         """Get status from external binary sensor."""
@@ -2592,18 +2633,21 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
     def supported_features(self) -> int:
         """Flag media player features that are supported."""
         features = SUPPORT_SAMSUNGTV_SMART
+
         if self.state == MediaPlayerState.ON:
             features |= MediaPlayerEntityFeature.BROWSE_MEDIA
+
         if self._st:
             features |= MediaPlayerEntityFeature.SELECT_SOUND_MODE
-        # Absolute volume (the slider) only targets the TV's internal volume:
-        # with an external output (HDMI-eARC receiver, optical, BT soundbar)
-        # UPnP/SmartThings setvolume is a no-op, so drop VOLUME_SET to hide the
-        # dead slider. VOLUME_STEP and VOLUME_MUTE are KEPT: the TV relays the
-        # up/down/mute keys to the external device over CEC/ARC (confirmed by a
-        # user with an eARC AVR), and the same relay applies to BT soundbars.
-        if self._speaker_output_is_internal() is False:
+
+        # Preserve the 8.7.0 protection for external receivers/soundbars unless
+        # this specific TV has positively demonstrated directVolumeControl.
+        if (
+            self._speaker_output_is_internal() is False
+            and self._ip_absolute_volume_supported is not True
+        ):
             features &= ~MediaPlayerEntityFeature.VOLUME_SET
+
         return features
 
     def _smartthings_reports_art(self) -> bool:
@@ -3035,23 +3079,44 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             return False
 
     async def async_mute_volume(self, mute):
-        """Send mute command."""
+        """Set mute state."""
         if self._state != MediaPlayerState.ON:
             return
+
         if self.is_volume_muted is not None and mute == self.is_volume_muted:
             return
+
+        # With an external receiver/soundbar, the TV remote's KEY_MUTE is
+        # relayed to the external audio device over HDMI-CEC/ARC/eARC.
+        # An explicit IP Control muteControl state is not equally reliable
+        # with external audio, so use the same toggle path as the physical
+        # remote. The state guard above ensures we only toggle when needed.
+        if self._speaker_output_is_internal() is False:
+            await self.async_send_command("KEY_MUTE")
+
+            if self.is_volume_muted is not None:
+                self._attr_is_volume_muted = mute
+
+            return
+
+        # Internal speakers retain the existing IP Control behaviour, with
+        # WebSocket KEY_MUTE as fallback.
         client = self._get_ip_control_client()
         sent_via_ip_control = False
+
         if client is not None:
             try:
                 await client.async_set_mute(mute)
                 sent_via_ip_control = True
             except SamsungIPControlError as ex:
                 self._log.debug(
-                    "IP Control mute failed (%s); falling back to WebSocket", ex
+                    "IP Control mute failed (%s); falling back to WebSocket",
+                    ex,
                 )
+
         if not sent_via_ip_control:
             await self.async_send_command("KEY_MUTE")
+
         if self.is_volume_muted is not None:
             self._attr_is_volume_muted = mute
 
@@ -3059,25 +3124,54 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         """Set the volume level."""
         if self._state != MediaPlayerState.ON:
             return
+
         if self.volume_level is None:
             return
-        # Absolute volume only reaches the TV's internal speakers; with an
-        # external output the command is silently ignored by the TV. Warn
-        # (rather than raise, to keep legacy automations from erroring) and
-        # skip the pointless call. Use volume_up/down instead — the TV relays
-        # those to the external device over CEC/ARC.
-        if self._speaker_output_is_internal() is False:
+
+        target = int(volume * 100)
+        speaker_internal = self._speaker_output_is_internal()
+
+        # Prefer directVolumeControl whenever the capability has not already
+        # been ruled out for this IP Control client.
+        client = self._get_ip_control_client()
+
+        if client is not None and self._ip_absolute_volume_supported is not False:
+            try:
+                applied = await client.async_set_volume(target)
+            except SamsungIPControlUnsupportedError as ex:
+                self._ip_absolute_volume_supported = False
+                self._log.debug(
+                    "IP Control absolute volume is not available on this TV: %s",
+                    ex,
+                )
+            except SamsungIPControlError as ex:
+                self._log.debug(
+                    "IP Control absolute-volume set failed (%s); "
+                    "using the existing fallback when possible",
+                    ex,
+                )
+            else:
+                self._ip_absolute_volume_supported = True
+                self._attr_volume_level = applied / 100
+                return
+
+        # Without confirmed local absolute-volume support, retain the 8.7.0
+        # protection for external receivers/soundbars.
+        if speaker_internal is False:
             self._log.warning(
                 "volume_set ignored: the TV's speaker output is external "
-                "(receiver/soundbar) and absolute volume only targets the "
-                "internal speakers — use volume_up/volume_down instead"
+                "(receiver/soundbar) and IP Control absolute volume is not "
+                "available — use volume_up/volume_down instead"
             )
             return
+
+        # Internal speakers retain the existing SmartThings/UPnP behaviour.
         if self._st and self._setvolumebyst:
-            await self._st.async_send_command("setvolume", int(volume * 100))
+            await self._st.async_send_command("setvolume", target)
         else:
-            await self._upnp.async_set_volume(int(volume * 100))
-        self._attr_volume_level = volume
+            await self._upnp.async_set_volume(target)
+
+        self._attr_volume_level = target / 100
 
     def media_play_pause(self):
         """Simulate play pause media player."""

--- a/tests/api/test_ipcontrol_volume.py
+++ b/tests/api/test_ipcontrol_volume.py
@@ -1,0 +1,234 @@
+"""Tests for Samsung IP Control absolute volume."""
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+def _load_ipcontrol_module():
+    """Load ipcontrol.py with a minimal Home Assistant type stub."""
+    homeassistant = types.ModuleType("homeassistant")
+    homeassistant_core = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:
+        """Type stub used only while importing the module."""
+
+    homeassistant_core.HomeAssistant = HomeAssistant
+    sys.modules.setdefault("homeassistant", homeassistant)
+    sys.modules.setdefault("homeassistant.core", homeassistant_core)
+
+    module_path = (
+        Path(__file__).parents[2]
+        / "custom_components"
+        / "samsungtv_smart"
+        / "api"
+        / "ipcontrol.py"
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "ipcontrol_volume_under_test",
+        module_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return module
+
+
+ipcontrol = _load_ipcontrol_module()
+
+
+class _FakeHass:
+    """Minimal executor bridge used by the async client."""
+
+    async def async_add_executor_job(self, func, *args):
+        """Run executor work inline for the unit test."""
+        return func(*args)
+
+
+class AbsoluteVolumeControlTest(unittest.IsolatedAsyncioTestCase):
+    """Verify directVolumeControl getter and setter."""
+
+    def _client(self):
+        """Return a paired client with a fake Home Assistant instance."""
+        ipcontrol._HOST_LOCKS.clear()
+
+        return ipcontrol.SamsungIPControl(
+            _FakeHass(),
+            "192.0.2.1",
+            token="test-token",
+        )
+
+    async def test_get_volume_emits_expected_payload_and_returns_value(self):
+        """Getter sends only AccessToken and returns the absolute volume."""
+        client = self._client()
+        sent = {}
+
+        def fake_post(payload, timeout):
+            sent.update(json.loads(payload))
+
+            return json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "volume": 30,
+                    },
+                }
+            )
+
+        client._sync_post = fake_post
+
+        result = await client.async_get_volume()
+
+        self.assertEqual(sent["method"], "directVolumeControl")
+        self.assertEqual(
+            sent["params"],
+            {
+                "AccessToken": "test-token",
+            },
+        )
+        self.assertEqual(result, 30)
+
+    async def test_set_volume_emits_expected_payload_and_returns_value(self):
+        """Setter includes volume and returns the TV-reported value."""
+        client = self._client()
+        sent = {}
+
+        def fake_post(payload, timeout):
+            sent.update(json.loads(payload))
+
+            return json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "volume": 30,
+                    },
+                }
+            )
+
+        client._sync_post = fake_post
+
+        result = await client.async_set_volume(30)
+
+        self.assertEqual(sent["method"], "directVolumeControl")
+        self.assertEqual(
+            sent["params"],
+            {
+                "AccessToken": "test-token",
+                "volume": 30,
+            },
+        )
+        self.assertEqual(result, 30)
+
+    async def test_set_volume_uses_requested_value_when_response_omits_volume(self):
+        """Some TVs may acknowledge SET without echoing the volume."""
+        client = self._client()
+
+        async def fake_request(method, params=None):
+            self.assertEqual(method, "directVolumeControl")
+            self.assertEqual(params, {"volume": 30})
+            return {}
+
+        client._async_request = fake_request
+
+        self.assertEqual(
+            await client.async_set_volume(30),
+            30,
+        )
+
+    async def test_get_volume_missing_value_is_error(self):
+        """A getter response without volume is invalid."""
+        client = self._client()
+
+        async def fake_request(method, params=None):
+            self.assertEqual(method, "directVolumeControl")
+            return {}
+
+        client._async_request = fake_request
+
+        with self.assertRaises(ipcontrol.SamsungIPControlError):
+            await client.async_get_volume()
+
+    async def test_get_volume_non_numeric_value_is_error(self):
+        """A non-numeric volume response is invalid."""
+        client = self._client()
+
+        async def fake_request(method, params=None):
+            return {
+                "volume": "not-a-number",
+            }
+
+        client._async_request = fake_request
+
+        with self.assertRaises(ipcontrol.SamsungIPControlError):
+            await client.async_get_volume()
+
+    async def test_get_volume_out_of_range_is_error(self):
+        """Getter rejects values outside the Home Assistant 0-100 range."""
+        client = self._client()
+
+        async def fake_request(method, params=None):
+            return {
+                "volume": 101,
+            }
+
+        client._async_request = fake_request
+
+        with self.assertRaises(ipcontrol.SamsungIPControlError):
+            await client.async_get_volume()
+
+    async def test_set_volume_below_range_is_error(self):
+        """Setter rejects values below zero without sending a request."""
+        client = self._client()
+
+        async def fake_request(method, params=None):
+            self.fail("RPC request must not be sent for invalid volume")
+
+        client._async_request = fake_request
+
+        with self.assertRaises(ipcontrol.SamsungIPControlError):
+            await client.async_set_volume(-1)
+
+    async def test_set_volume_above_range_is_error(self):
+        """Setter rejects values above 100 without sending a request."""
+        client = self._client()
+
+        async def fake_request(method, params=None):
+            self.fail("RPC request must not be sent for invalid volume")
+
+        client._async_request = fake_request
+
+        with self.assertRaises(ipcontrol.SamsungIPControlError):
+            await client.async_set_volume(101)
+
+    async def test_method_not_found_surfaces_as_unsupported(self):
+        """JSON-RPC -32601 identifies a TV without directVolumeControl."""
+        client = self._client()
+
+        def fake_post(payload, timeout):
+            return json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {
+                        "code": -32601,
+                        "message": "Method not found",
+                    },
+                }
+            )
+
+        client._sync_post = fake_post
+
+        with self.assertRaises(
+            ipcontrol.SamsungIPControlUnsupportedError
+        ):
+            await client.async_get_volume()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ipcontrol_volume_media_player.py
+++ b/tests/test_ipcontrol_volume_media_player.py
@@ -1,0 +1,247 @@
+"""Tests for IP Control volume integration in the media player."""
+
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.media_player import (
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+)
+
+# The repository test requirements do not install pysmartthings.
+# Provide the symbols needed while importing media_player.py.
+if "pysmartthings" not in sys.modules:
+    pysmartthings = ModuleType("pysmartthings")
+
+    class _Names:
+        """Return arbitrary SmartThings enum-like attributes."""
+
+        def __getattr__(self, name):
+            return name
+
+    pysmartthings.Attribute = _Names()
+    pysmartthings.Capability = _Names()
+    pysmartthings.SmartThings = object
+    sys.modules["pysmartthings"] = pysmartthings
+
+
+from custom_components.samsungtv_smart.api.ipcontrol import (  # noqa: E402
+    SamsungIPControlUnsupportedError,
+)
+from custom_components.samsungtv_smart.media_player import (  # noqa: E402
+    SamsungTVDevice,
+)
+
+
+def _device(*, external=True, muted=False, volume=0.20):
+    """Create the minimum SamsungTVDevice needed by these unit tests."""
+    device = object.__new__(SamsungTVDevice)
+
+    device._state = MediaPlayerState.ON
+    device._attr_is_volume_muted = muted
+    device._attr_volume_level = volume
+
+    device._st = None
+    device._setvolumebyst = False
+
+    device._ip_absolute_volume_supported = None
+
+    device._log = MagicMock()
+    device._upnp = AsyncMock()
+
+    device.async_send_command = AsyncMock()
+
+    device._speaker_output_is_internal = MagicMock(
+        return_value=not external
+    )
+
+    device._power_off_in_progress = MagicMock(
+        return_value=False
+    )
+
+    return device
+
+
+async def test_volume_poll_detects_direct_volume_control_support():
+    """A successful local getter enables absolute-volume capability."""
+    device = _device(external=True)
+
+    client = AsyncMock()
+    client.async_get_volume.return_value = 30
+
+    device._get_ip_control_client = MagicMock(
+        return_value=client
+    )
+    device._upnp.async_get_mute.return_value = False
+
+    await device._update_volume_info()
+
+    client.async_get_volume.assert_awaited_once_with()
+
+    assert device._ip_absolute_volume_supported is True
+    assert device._attr_volume_level == 0.30
+    assert device._attr_is_volume_muted is False
+
+
+async def test_unsupported_direct_volume_control_is_probed_only_once():
+    """A confirmed -32601 disables future absolute-volume probes."""
+    device = _device(external=True)
+
+    client = AsyncMock()
+    client.async_get_volume.side_effect = (
+        SamsungIPControlUnsupportedError("Method not found")
+    )
+
+    device._get_ip_control_client = MagicMock(
+        return_value=client
+    )
+
+    device._upnp.async_get_volume.return_value = 20
+    device._upnp.async_get_mute.return_value = False
+
+    await device._update_volume_info()
+    await device._update_volume_info()
+
+    assert device._ip_absolute_volume_supported is False
+
+    # The optional capability is only probed once.
+    assert client.async_get_volume.await_count == 1
+
+    # Existing UPnP behaviour remains available.
+    assert device._upnp.async_get_volume.await_count == 2
+    assert device._attr_volume_level == 0.20
+
+
+async def test_external_supported_volume_keeps_volume_set_feature():
+    """External audio keeps the slider after local support is confirmed."""
+    device = _device(external=True)
+
+    device._ip_absolute_volume_supported = True
+
+    features = device.supported_features
+
+    assert features & MediaPlayerEntityFeature.VOLUME_SET
+
+
+async def test_external_unsupported_volume_hides_volume_set_feature():
+    """External audio retains the 8.7.0 slider protection if unsupported."""
+    device = _device(external=True)
+
+    device._ip_absolute_volume_supported = False
+
+    features = device.supported_features
+
+    assert not (
+        features & MediaPlayerEntityFeature.VOLUME_SET
+    )
+
+
+async def test_external_absolute_volume_uses_ip_control():
+    """Absolute volume for external audio is sent through IP Control."""
+    device = _device(external=True, volume=0.20)
+
+    client = AsyncMock()
+    client.async_set_volume.return_value = 30
+
+    device._get_ip_control_client = MagicMock(
+        return_value=client
+    )
+
+    await device.async_set_volume_level(0.30)
+
+    client.async_set_volume.assert_awaited_once_with(30)
+
+    assert device._ip_absolute_volume_supported is True
+    assert device._attr_volume_level == 0.30
+
+    device._upnp.async_set_volume.assert_not_awaited()
+
+
+async def test_external_unsupported_absolute_volume_is_not_sent_to_upnp():
+    """External audio keeps the old protection after a -32601 response."""
+    device = _device(external=True, volume=0.20)
+
+    client = AsyncMock()
+    client.async_set_volume.side_effect = (
+        SamsungIPControlUnsupportedError("Method not found")
+    )
+
+    device._get_ip_control_client = MagicMock(
+        return_value=client
+    )
+
+    await device.async_set_volume_level(0.30)
+
+    client.async_set_volume.assert_awaited_once_with(30)
+
+    assert device._ip_absolute_volume_supported is False
+
+    # Never fall through to the ineffective external-speaker UPnP path.
+    device._upnp.async_set_volume.assert_not_awaited()
+
+
+async def test_external_speaker_mute_uses_key_mute_toggle():
+    """External receiver/soundbar mute is relayed through KEY_MUTE."""
+    device = _device(
+        external=True,
+        muted=False,
+    )
+
+    device._get_ip_control_client = MagicMock()
+
+    await device.async_mute_volume(True)
+
+    device.async_send_command.assert_awaited_once_with(
+        "KEY_MUTE"
+    )
+
+    assert device._attr_is_volume_muted is True
+
+    # Pressing the same HA mute button again requests unmute.
+    await device.async_mute_volume(False)
+
+    assert device.async_send_command.await_count == 2
+    assert (
+        device.async_send_command.await_args_list[1].args
+        == ("KEY_MUTE",)
+    )
+
+    assert device._attr_is_volume_muted is False
+
+    # External audio must not use IP Control muteControl.
+    device._get_ip_control_client.assert_not_called()
+
+
+async def test_internal_speaker_mute_uses_ip_control():
+    """Internal speakers retain explicit IP Control mute state."""
+    device = _device(
+        external=False,
+        muted=False,
+    )
+
+    client = AsyncMock()
+
+    device._get_ip_control_client = MagicMock(
+        return_value=client
+    )
+
+    await device.async_mute_volume(True)
+
+    client.async_set_mute.assert_awaited_once_with(True)
+
+    device.async_send_command.assert_not_awaited()
+
+    assert device._attr_is_volume_muted is True
+
+
+async def test_mute_does_nothing_when_state_already_matches():
+    """No toggle is emitted when HA already has the requested mute state."""
+    device = _device(
+        external=True,
+        muted=True,
+    )
+
+    await device.async_mute_volume(True)
+
+    device.async_send_command.assert_not_awaited()

--- a/tests/test_ipcontrol_volume_media_player.py
+++ b/tests/test_ipcontrol_volume_media_player.py
@@ -46,6 +46,7 @@ def _device(*, external=True, muted=False, volume=0.20):
     device._setvolumebyst = False
 
     device._ip_absolute_volume_supported = None
+    device._ip_control_ambient_mode_active = MagicMock(return_value=False)
 
     device._log = MagicMock()
     device._upnp = AsyncMock()
@@ -245,3 +246,71 @@ async def test_mute_does_nothing_when_state_already_matches():
     await device.async_mute_volume(True)
 
     device.async_send_command.assert_not_awaited()
+
+
+async def test_unsupported_volume_probe_in_ambient_mode_is_not_latched():
+    """A -32601 in Ambient mode must not permanently disable volume control."""
+    device = _device(external=True)
+
+    client = AsyncMock()
+    client.async_get_volume.side_effect = [
+        SamsungIPControlUnsupportedError("Method not found"),
+        30,
+    ]
+
+    device._get_ip_control_client = MagicMock(
+        return_value=client
+    )
+    device._ip_control_ambient_mode_active.return_value = True
+
+    device._upnp.async_get_volume.return_value = 20
+    device._upnp.async_get_mute.return_value = False
+
+    await device._update_volume_info()
+
+    assert device._ip_absolute_volume_supported is None
+    assert device._attr_volume_level == 0.20
+    assert client.async_get_volume.await_count == 1
+
+    # After leaving Ambient mode the method must be probed again and can
+    # successfully establish support without reloading the integration.
+    device._ip_control_ambient_mode_active.return_value = False
+
+    await device._update_volume_info()
+
+    assert device._ip_absolute_volume_supported is True
+    assert device._attr_volume_level == 0.30
+    assert client.async_get_volume.await_count == 2
+
+
+async def test_unsupported_volume_set_in_ambient_mode_is_not_latched():
+    """A setter -32601 in Ambient mode must remain retryable."""
+    device = _device(external=True, volume=0.20)
+
+    client = AsyncMock()
+    client.async_set_volume.side_effect = [
+        SamsungIPControlUnsupportedError("Method not found"),
+        30,
+    ]
+
+    device._get_ip_control_client = MagicMock(
+        return_value=client
+    )
+    device._ip_control_ambient_mode_active.return_value = True
+
+    await device.async_set_volume_level(0.30)
+
+    assert device._ip_absolute_volume_supported is None
+    assert device._attr_volume_level == 0.20
+    assert client.async_set_volume.await_count == 1
+    device._upnp.async_set_volume.assert_not_awaited()
+
+    # Leaving Ambient mode must allow the same operation to succeed later.
+    device._ip_control_ambient_mode_active.return_value = False
+
+    await device.async_set_volume_level(0.30)
+
+    assert device._ip_absolute_volume_supported is True
+    assert device._attr_volume_level == 0.30
+    assert client.async_set_volume.await_count == 2
+    device._upnp.async_set_volume.assert_not_awaited()


### PR DESCRIPTION
## Summary

Add support for Samsung IP Control `directVolumeControl` and use it for
absolute volume when the TV actually implements the method.

This preserves the external-speaker protection introduced in 8.7.0, but
makes it capability-based instead of assuming that absolute volume cannot
work whenever an external receiver or soundbar is selected.

## Behaviour

- Probe `directVolumeControl` per TV.
- When supported:
  - expose `VOLUME_SET`;
  - read absolute volume through IP Control;
  - set absolute volume through IP Control;
  - allow the Home Assistant volume slider with an external HDMI/eARC
    audio device.
- When `directVolumeControl` returns JSON-RPC `-32601`:
  - mark the capability unsupported;
  - avoid probing it again for the current IP Control client;
  - retain the existing 8.7.0 external-speaker protection and hide
    `VOLUME_SET`.
- Transient IP Control errors do not permanently disable the capability.
- With an external receiver/soundbar, mute/unmute uses `KEY_MUTE`,
  matching the physical remote / HDMI-CEC behaviour.
- Internal speakers retain the existing explicit IP Control mute handling
  with WebSocket fallback.

## Hardware validation

Tested on a Samsung UE27F6000FUXZT with a Samsung S5B-Series Soundbar
connected through HDMI/eARC.

`directVolumeControl` was verified to change both the actual soundbar
volume and the Samsung on-screen volume indication.

Absolute volume was tested with:

- 20 → 10
- 10 → 30
- 30 → 20

with the resulting state correctly reported back to Home Assistant.

The standard Home Assistant media-player card now exposes a working
absolute volume slider while the external soundbar is selected.

Mute and unmute from the same card were also verified to work correctly
using the `KEY_MUTE` path.

The changes were additionally regression-tested on a second Samsung TV
with no observed regressions.

## Tests

Added API tests covering:

- `directVolumeControl` GET and SET payloads/responses;
- missing, invalid and out-of-range responses;
- setter range validation;
- JSON-RPC `-32601` capability detection.

Added media-player tests covering:

- successful capability detection;
- unsupported capability caching after `-32601`;
- `VOLUME_SET` exposure only when appropriate;
- external absolute volume through IP Control instead of UPnP;
- preservation of the 8.7.0 protection when unsupported;
- external-speaker mute through `KEY_MUTE`;
- internal-speaker mute through IP Control;
- no-op when the requested mute state already matches.

Test results:

- 18/18 related IP Control unittest tests pass.
- 15/15 related Home Assistant pytest tests pass.

## AI assistance disclosure

The implementation and tests in this pull request were developed with
assistance from ChatGPT (OpenAI).

The proposed changes were manually reviewed, tested against the repository's
test suite, and validated on real Samsung TV / HDMI-eARC soundbar hardware
before submission.