### PR TITLE
Add async browser opening methods in IP Control and media player

### DIFF
--- a/IP_Control_Protocol_Reference.md
+++ b/IP_Control_Protocol_Reference.md
@@ -119,7 +119,7 @@ when calling each method with only the `AccessToken` (no extra params):
 | `powerControl` | ✅ getter/setter | `power` ∈ `powerOn` / `powerOff` / `reboot` | `power` | Read returns `powerOn` in Art Mode (Art Mode = physically on). Read-and-set via the same method. |
 | `artModeControl` | ✅ getter/setter | `artMode` ∈ `artModeOn` / `artModeOff` | `artMode` | Case-sensitive: only `artModeControl` (capital M) works. `artmodeControl` / `ArtModeControl` → `-32601`. **Authoritative read-source for Art Mode state.** |
 | `muteControl` | ✅ getter/setter | `mute` ∈ `muteOn` / `muteOff` | `mute` | |
-| `directAccessControl` | ✅ getter/setter | `applicationName` (+ optional `url`) | `applicationName` | Launches an app. Read returns `"unknown"` when no app launched via this method. |
+| `directAccessControl` | ✅ getter/setter | `applicationName` (+ optional `url`) | `applicationName` | Launches an app. Read returns `"unknown"` when no app launched via this method. On a 2020 QE65Q80TATXZT, setting `applicationName: "webBrowser"` with `url` opens the Samsung browser at the requested URL; a subsequent getter returns `{"applicationName":"webBrowser"}` but does not expose the current URL. |
 | `remoteKeyControl` | ⚠️ needs param | `remoteKey` (see list below) | — | Virtual remote key sender. |
 | `volumeUpDnControl` | ⚠️ needs param | `control` ∈ `volumeUp` / `volumeDn` | `control` | Relative volume. |
 | `channelUpDnControl` | ⚠️ needs param | `control` ∈ `channelUp` / `channelDn` | `control` | Relative channel. |

--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -623,6 +623,21 @@ class SamsungIPControl:
         """
         return await self._async_request("getVideoStates")
 
+    async def async_open_browser(self, url: str) -> str:
+        """Open a URL in the Samsung web browser using IP Control."""
+        if not url:
+            raise SamsungIPControlError("browser URL must not be empty")
+    
+        result = await self._async_request(
+            "directAccessControl",
+            {
+                "applicationName": "webBrowser",
+                "url": url,
+            },
+        )
+
+        return result.get("applicationName", "")
+
     # -- transport -----------------------------------------------------------
 
     async def _async_request(

--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -623,20 +623,18 @@ class SamsungIPControl:
         """
         return await self._async_request("getVideoStates")
 
-    async def async_open_browser(self, url: str) -> str:
+    async def async_open_browser(self, url: str) -> None:
         """Open a URL in the Samsung web browser using IP Control."""
         if not url:
             raise SamsungIPControlError("browser URL must not be empty")
-    
-        result = await self._async_request(
+
+        await self._async_request(
             "directAccessControl",
             {
                 "applicationName": "webBrowser",
                 "url": url,
             },
         )
-
-        return result.get("applicationName", "")
 
     # -- transport -----------------------------------------------------------
 

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.7.2"
+  "version": "8.7.3"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -3253,25 +3253,24 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
     async def _async_open_browser(self, url: str) -> bool:
         """Open URL using IP Control, falling back to WebSocket."""
-    
+
         ip_client = self._get_ip_control_client()
-    
+
         if ip_client is not None:
             try:
                 await ip_client.async_open_browser(url)
-                self._log.debug(
-                    "Browser URL opened using IP Control directAccessControl: %s",
-                    url,
+                self._log.info(
+                    "Browser launched using IP Control; the opened URL cannot be confirmed"
                 )
                 return True
-    
+
             except SamsungIPControlError as ex:
                 self._log.debug(
                     "IP Control browser launch failed (%s); "
                     "falling back to WebSocket",
                     ex,
                 )
-    
+
         return await self.async_send_command(url, CMD_OPEN_BROWSER)
 
     async def _async_ip_control_source(self, source_key: str) -> bool:

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -3231,6 +3231,29 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         else:
             self.send_command("KEY_REWIND")
 
+    async def _async_open_browser(self, url: str) -> bool:
+        """Open URL using IP Control, falling back to WebSocket."""
+    
+        ip_client = self._get_ip_control_client()
+    
+        if ip_client is not None:
+            try:
+                await ip_client.async_open_browser(url)
+                self._log.debug(
+                    "Browser URL opened using IP Control directAccessControl: %s",
+                    url,
+                )
+                return True
+    
+            except SamsungIPControlError as ex:
+                self._log.debug(
+                    "IP Control browser launch failed (%s); "
+                    "falling back to WebSocket",
+                    ex,
+                )
+    
+        return await self.async_send_command(url, CMD_OPEN_BROWSER)
+
     async def _async_ip_control_source(self, source_key: str) -> bool:
         """Select an input source through local Samsung IP Control."""
         input_source = source_key.removeprefix("IP_")
@@ -3525,11 +3548,11 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 self._playing = True
                 return
 
-            await self.async_send_command(media_id, CMD_OPEN_BROWSER)
+            await self._async_open_browser(media_id)
 
         # Open url in browser
         elif media_type == MEDIA_TYPE_BROWSER:
-            await self.async_send_command(media_id, CMD_OPEN_BROWSER)
+            await self._async_open_browser(media_id)
 
         # Trying to make stream component work on TV
         elif media_type == "application/vnd.apple.mpegurl":

--- a/tests/api/test_ipcontrol_browser.py
+++ b/tests/api/test_ipcontrol_browser.py
@@ -1,0 +1,96 @@
+"""Tests for Samsung IP Control browser launch."""
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+def _load_ipcontrol_module():
+    """Load ipcontrol.py with a minimal Home Assistant type stub."""
+    homeassistant = types.ModuleType("homeassistant")
+    homeassistant_core = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:
+        """Type stub used only while importing the module."""
+
+    homeassistant_core.HomeAssistant = HomeAssistant
+    sys.modules.setdefault("homeassistant", homeassistant)
+    sys.modules.setdefault("homeassistant.core", homeassistant_core)
+
+    module_path = (
+        Path(__file__).parents[2]
+        / "custom_components"
+        / "samsungtv_smart"
+        / "api"
+        / "ipcontrol.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "ipcontrol_browser_under_test", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ipcontrol = _load_ipcontrol_module()
+
+
+class _FakeHass:
+    """Minimal executor bridge used by the async client."""
+
+    async def async_add_executor_job(self, func, *args):
+        """Run executor work inline for the unit test."""
+        return func(*args)
+
+
+class BrowserControlTest(unittest.IsolatedAsyncioTestCase):
+    """Verify browser launch without network access."""
+
+    def _client(self):
+        """Return a paired client with a fake Home Assistant instance."""
+        ipcontrol._HOST_LOCKS.clear()
+        return ipcontrol.SamsungIPControl(
+            _FakeHass(),
+            "192.0.2.1",
+            token="test-token",
+        )
+
+    async def test_open_browser_emits_expected_payload(self):
+        """directAccessControl sends the expected browser launch payload."""
+        client = self._client()
+        sent = {}
+
+        def fake_post(payload, timeout):
+            sent.update(json.loads(payload))
+            return json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "applicationName": "webBrowser",
+                        "url": "https://example.com/",
+                    },
+                }
+            )
+
+        client._sync_post = fake_post
+
+        result = await client.async_open_browser("https://example.com/")
+
+        self.assertIsNone(result)
+        self.assertEqual(sent["method"], "directAccessControl")
+        self.assertEqual(
+            sent["params"],
+            {
+                "AccessToken": "test-token",
+                "applicationName": "webBrowser",
+                "url": "https://example.com/",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ipcontrol_browser_media_player.py
+++ b/tests/test_ipcontrol_browser_media_player.py
@@ -1,0 +1,51 @@
+"""Tests for IP Control browser integration in the media player."""
+
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock
+
+# The repository test requirements do not install pysmartthings.
+# Provide the symbols needed while importing media_player.py.
+if "pysmartthings" not in sys.modules:
+    pysmartthings = ModuleType("pysmartthings")
+
+    class _Names:
+        """Return arbitrary SmartThings enum-like attributes."""
+
+        def __getattr__(self, name):
+            return name
+
+    pysmartthings.Attribute = _Names()
+    pysmartthings.Capability = _Names()
+    pysmartthings.SmartThings = object
+    sys.modules["pysmartthings"] = pysmartthings
+
+
+from custom_components.samsungtv_smart.api.ipcontrol import (  # noqa: E402
+    SamsungIPControlError,
+)
+from custom_components.samsungtv_smart.media_player import (  # noqa: E402
+    CMD_OPEN_BROWSER,
+    SamsungTVDevice,
+)
+
+
+async def test_browser_falls_back_to_websocket_when_ip_control_fails():
+    """A failed IP Control browser launch falls back to WebSocket."""
+    device = object.__new__(SamsungTVDevice)
+
+    client = AsyncMock()
+    client.async_open_browser.side_effect = SamsungIPControlError("test failure")
+
+    device._get_ip_control_client = MagicMock(return_value=client)
+    device._log = MagicMock()
+    device.async_send_command = AsyncMock(return_value=True)
+
+    url = "https://example.com/"
+
+    result = await device._async_open_browser(url)
+
+    client.async_open_browser.assert_awaited_once_with(url)
+    device.async_send_command.assert_awaited_once_with(url, CMD_OPEN_BROWSER)
+
+    assert result is True


### PR DESCRIPTION
# The problem
The existing browser URL launch uses the Samsung WebSocket ed.apps.launch mechanism with org.tizen.browser, NATIVE_LAUNCH, and the URL passed as metaTag. On at least some Samsung TVs, including my 2020 QE65Q80TATXZT, this path **does not navigate** the browser to the requested URL.

In Home Assistant, when performing this action:
```
action: media_player.play_media
target:
  entity_id: media_player.my_tv_entity
data:
  media_content_type: browser
  media_content_id: "https://www.google.com/"
```
it leads to nothing: no browser app opens and consequently the url doesn't show up.

# The solution
I tried using IP Control over the default WebSocket, with `directAccessControl` method, and the problem was finally resolved.

Sending this command to the TV successfully opens the browser app at the specified url:
```
curl -sk --http1.1 "https://$TV:1516/" \
  -H 'Accept: application/json' \
  -H 'Content-Type: application/json' \
  --data "{
    \"jsonrpc\":\"2.0\",
    \"id\":3,
    \"method\":\"directAccessControl\",
    \"params\":{
      \"AccessToken\":\"$TOKEN\",
      \"applicationName\":\"webBrowser\",
      \"url\":\"$URL\"
    }
  }"
```

The existing WebSocket behaviour is preserved as a fallback: the new code prefers IP Control when it is available to open the browser at the specified url, but it falls back to WebSocket if IP Control is not enabled or it returns an error.

If `media_content_type` is set to `url` instead, it primarily tries UPnP, then falls back to IP Control and eventually to WebSocket.

### Minor issue
If IP Control method successfully opens the browser but fails to open at the specified url, the WebSocket fallback never occurs. 

We can't reliably detect this condition after the command has been executed, since the getter response doesn't expose the URL currently opened in the browser:
```
curl -sk --http1.1 "https://$TV:1516/" \
  -H 'Accept: application/json' \
  -H 'Content-Type: application/json' \
  --data "{
    \"jsonrpc\":\"2.0\",
    \"id\":4,
    \"method\":\"directAccessControl\",
    \"params\":{
      \"AccessToken\":\"$TOKEN\"
    }
  }"
{"id":"4","jsonrpc":"2.0","result":{"applicationName":"webBrowser"}}
```

