### PR TITLE
fix(browser): log which URL the IP Control launch asked for

### DIFF
--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.7.3"
+  "version": "8.7.4"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -3259,8 +3259,14 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         if ip_client is not None:
             try:
                 await ip_client.async_open_browser(url)
+                # Name the URL we asked for: the TV confirms only that the
+                # browser was launched (its getter returns applicationName and
+                # never the current page), so a "it opened the wrong page"
+                # report is only diagnosable if the log says what we requested.
                 self._log.info(
-                    "Browser launched using IP Control; the opened URL cannot be confirmed"
+                    "Browser launched via IP Control at %s; the TV does not "
+                    "report which URL it actually opened",
+                    url,
                 )
                 return True
 


### PR DESCRIPTION
Follow-up to #242, which is otherwise complete — this is the one-line refinement left over from the review rather than a defect in the contribution.

## The change

The INFO line added in #242 said the opened URL could not be confirmed, but did not say **which URL had been requested**:

```
Browser launched using IP Control; the opened URL cannot be confirmed
```

That is the one fact that makes an "it opened the wrong page" report diagnosable. The TV's `directAccessControl` getter returns only `applicationName` and never the current page (measured by the contributor on a QE65Q80TATXZT), so the requested URL is the only side of the comparison we can ever record. Now:

```
Browser launched via IP Control at https://example.com/; the TV does not
report which URL it actually opened
```

A comment above it explains why the line exists, so it does not get "simplified" back later.

## Incidentally

The original line was 91 characters and passed lint only because `E501` is disabled in our `.flake8` and black does not re-wrap string literals. The rewrite is back under 88.

## Not touched

The contributor's addition to `IP_Control_Protocol_Reference.md` is left exactly as written. It is scoped to the QE65Q80TATXZT he measured rather than generalised to all models — which is the discipline that three corrections to that same file this week (#235, #239, #240) were needed to restore.

Version `8.7.4`; black / flake8 / isort pass, and the browser and matte test suites pass (9 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_