### PR TITLE
docs: show how to drive the TV like a remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode su
   - [Detecting Art Mode vs. watching TV](#detecting-art-mode-vs-watching-tv)
 - [Services](#services)
   - [Standard TV Services](#standard-tv-services)
+  - [Driving the TV like a remote (D-pad, Home, Back…)](#driving-the-tv-like-a-remote-d-pad-home-back)
   - [Frame Art Services](#frame-art-services)
 - [Frame Art Mode](#frame-art-mode)
   - [What happens to your image](#what-happens-to-your-image)
@@ -559,6 +560,62 @@ data:
   media_content_type: send_key
   media_content_id: KEY_MUTE
 ```
+
+### Driving the TV like a remote (D-pad, Home, Back…)
+
+Everything the on-screen Samsung remote does is available as a service call, so
+you can build a remote dashboard, bind keys to physical buttons, or script a
+navigation sequence. Use the `remote.<tv_name>` entity — it takes a **list** of
+keys and a repeat count:
+
+```yaml
+action: remote.send_command
+target:
+  entity_id: remote.samsung_tv
+data:
+  command:
+    - KEY_HOME
+    - KEY_RIGHT
+    - KEY_ENTER
+  num_repeats: 1
+```
+
+The keys for the navigation cluster:
+
+| Button | Key |
+|---|---|
+| Up / Down / Left / Right | `KEY_UP` / `KEY_DOWN` / `KEY_LEFT` / `KEY_RIGHT` |
+| Select / OK | `KEY_ENTER` |
+| Back / Return | `KEY_RETURN` |
+| Home | `KEY_HOME` |
+| Info | `KEY_INFO` |
+| Menu | `KEY_MENU` |
+| Guide | `KEY_GUIDE` |
+| Exit | `KEY_EXIT` |
+| Channel list | `KEY_CH_LIST` |
+
+The full key list is in
+[Key_codes.md](https://github.com/jaruba/ha-samsungtv-tizen/blob/master/Key_codes.md).
+Not every key exists on every model — a key the TV does not know is simply
+ignored.
+
+**Timing.** Keys in a sequence are sent 0.5 s apart. When a menu needs longer
+to appear, insert a delay in milliseconds as its own step (clamped to
+0.2–2 s) — this works in the `media_player.play_media` form, where the sequence
+is one `+`-joined string:
+
+```yaml
+action: media_player.play_media
+target:
+  entity_id: media_player.samsung_tv
+data:
+  media_content_type: send_key
+  media_content_id: KEY_HOME+1500+KEY_RIGHT+KEY_ENTER
+```
+
+The same string also accepts `ST_` source keys (routed through SmartThings) and
+`IP_` source keys (routed through IP Control), so a single sequence can mix
+input switching with remote keys.
 
 **Typing text into a native Tizen text field:**
 

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.7.4"
+  "version": "8.7.5"
 }


### PR DESCRIPTION
Prompted by #246, which asks for "full d-pad, enter, back/return, home, and info exposed as a programmable interface". All of that has shipped for a long time — `remote.<tv_name>` with `remote.send_command`, plus `media_player.play_media` with `media_content_type: send_key`. The request exists because none of it is findable.

## What the README had

- one table row: `remote.send_command` — *Send raw key commands (via remote entity)*
- one entity row: `remote.<tv_name>` — *Send remote key sequences*
- one example, `KEY_MUTE` through `play_media`

Nothing showed a navigation cluster, a key sequence, or the entity a remote dashboard would bind to. Someone looking for "how do I press Up" does not find it.

## What is added

A section under the existing key example, in the TOC:

- the `remote.send_command` form, with a **list** of keys and `num_repeats` — the shape a dashboard actually uses
- a table of the navigation keys (D-pad, Enter, Return, Home, Info, Menu, Guide, Exit, channel list), plus the link to the full key list and the note that unknown keys are ignored rather than fatal
- the timing rules: 0.5 s between keys, and the **millisecond delay step** inside a `+`-joined sequence (`KEY_HOME+1500+KEY_RIGHT+KEY_ENTER`)
- that such a sequence can mix `ST_` and `IP_` source keys with remote keys

The delay step is worth calling out: it is implemented in `_async_send_keys` (a numeric element is slept on, clamped to 0.2–2 s) and was documented nowhere. Same for mixing source keys into a sequence.

Docs only — no code change. Version `8.7.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_