### PR TITLE
fix(polling): stop a sleeping TV overrunning its own scan interval

### DIFF
--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.7.5"
+  "version": "8.7.6"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -216,6 +216,18 @@ CMD_SEND_KEY = "send_key"
 CMD_SEND_TEXT = "send_text"
 
 DELAYED_SOURCE_TIMEOUT = 80
+# Timeout for the periodic power probe of a TV we ALREADY believe is off.
+# DEFAULT_TIMEOUT (6 s) is longer than SCAN_INTERVAL (5 s), so a TV that has
+# left the network cannot possibly be polled within its own interval: every
+# single poll overran, and both this integration and Home Assistant core
+# logged a warning for it (#248 measured ~5 000 lines/day per sleeping TV).
+# A probe that fails in 3 s finishes inside the interval, which removes the
+# cause rather than hiding the symptom. The generous timeout is kept for a
+# TV believed to be ON, where a slow answer is worth waiting for.
+POWER_PROBE_OFF_TIMEOUT = 3.0
+# Minimum gap between two slow-update warnings for one entity, and the
+# suppressed count is reported with the next one.
+SLOW_UPDATE_WARN_INTERVAL = 300.0
 KEYHOLD_MAX_DELAY = 5.0
 KEYPRESS_DEFAULT_DELAY = 0.5
 KEYPRESS_MAX_DELAY = 2.0
@@ -720,6 +732,10 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         # to populate art_mode_status without falling back to the device_info
         # PowerState='standby' override or the potentially-stale art_api cache.
         self._ip_control_client: SamsungIPControl | None = None
+        # Slow-update warning throttle: last warning time and how many
+        # overruns it has stood for since (#248).
+        self._slow_update_last_warn: float = 0.0
+        self._slow_update_suppressed: int = 0
         self._ip_control_token_cached: str | None = None
         # directVolumeControl is model-dependent. Some Samsung TVs support
         # absolute volume locally, including with an external HDMI/eARC audio
@@ -1663,8 +1679,13 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
         if self._get_device_spec("PowerState") is not None:
             self._log.debug("Checking if TV %s is on using device info", self._host)
-            # Ensure we get an updated value
-            info = await self._async_load_device_info(force=True)
+            # Ensure we get an updated value. A TV we already believe to be off
+            # gets the short probe timeout so this poll still fits inside the
+            # scan interval; one believed on keeps the full timeout.
+            probe_timeout = (
+                None if self._state == MediaPlayerState.ON else POWER_PROBE_OFF_TIMEOUT
+            )
+            info = await self._async_load_device_info(force=True, timeout=probe_timeout)
             return info is not None and info["device"]["PowerState"] == "on"
 
         result = self._ws.is_connected
@@ -2156,14 +2177,23 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         self._st_error_count = 0
 
     async def _async_load_device_info(
-        self, force: bool = False
+        self, force: bool = False, timeout: float | None = None
     ) -> dict[str, Any] | None:
-        """Try to gather infos of this TV."""
+        """Try to gather infos of this TV.
+
+        ``timeout`` overrides the REST client's own (longer) timeout for this
+        one call — see POWER_PROBE_OFF_TIMEOUT. A timeout is indistinguishable
+        from any other failure here: both mean "no answer", and both return
+        None.
+        """
         if self._device_info is not None and not force:
             return self._device_info
 
         try:
-            device_info: dict[str, Any] = await self._rest_api.async_rest_device_info()
+            request = self._rest_api.async_rest_device_info()
+            if timeout is not None:
+                request = asyncio.wait_for(request, timeout=timeout)
+            device_info: dict[str, Any] = await request
             # This payload is ~40 mostly-immutable fields (model, MAC, codec
             # support...) refetched every poll cycle, so dumping it whole each
             # time buried real events under tens of MB of noise — 21% of a 26h
@@ -2311,12 +2341,51 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         finally:
             elapsed = time.monotonic() - start_time
             if elapsed > SCAN_INTERVAL.total_seconds():
-                self._log.warning(
-                    "%s - Update took %.1fs, longer than the %.0fs scan interval",
-                    self.entity_id,
-                    elapsed,
-                    SCAN_INTERVAL.total_seconds(),
-                )
+                self._note_slow_update(elapsed)
+
+    def _note_slow_update(self, elapsed: float) -> None:
+        """Report an update that overran the scan interval, without flooding.
+
+        An update of a TV that turned out to be OFF is slow *because* the TV is
+        off — the probe has to time out before we can say so — and warning about
+        the expected consequence of a known state is noise. That case goes to
+        debug. A reachable TV that is genuinely slow still warns, but at most
+        once per SLOW_UPDATE_WARN_INTERVAL, carrying the count it stands for
+        (#248: 13 TVs produced 557 warnings in 84 minutes, 96% of them from the
+        two that were asleep).
+        """
+        if self._state != MediaPlayerState.ON:
+            self._log.debug(
+                "%s - Update took %.1fs (TV is off; the power probe has to time "
+                "out before that is known)",
+                self.entity_id,
+                elapsed,
+            )
+            return
+
+        now = time.monotonic()
+        if now - self._slow_update_last_warn < SLOW_UPDATE_WARN_INTERVAL:
+            self._slow_update_suppressed += 1
+            return
+
+        if self._slow_update_suppressed:
+            self._log.warning(
+                "%s - Update took %.1fs, longer than the %.0fs scan interval "
+                "(%d further slow updates since the last warning)",
+                self.entity_id,
+                elapsed,
+                SCAN_INTERVAL.total_seconds(),
+                self._slow_update_suppressed,
+            )
+        else:
+            self._log.warning(
+                "%s - Update took %.1fs, longer than the %.0fs scan interval",
+                self.entity_id,
+                elapsed,
+                SCAN_INTERVAL.total_seconds(),
+            )
+        self._slow_update_last_warn = now
+        self._slow_update_suppressed = 0
 
     async def _async_update(self):
         """Perform the actual state update."""

--- a/tests/test_slow_update_warning.py
+++ b/tests/test_slow_update_warning.py
@@ -1,0 +1,87 @@
+"""Tests for the slow-update warning and the power probe timeout (#248).
+
+A TV in standby leaves the network entirely, so its power probe can only end
+in a timeout. DEFAULT_TIMEOUT was longer than SCAN_INTERVAL, which made every
+such poll overrun by construction.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+SOURCE = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "samsungtv_smart"
+    / "media_player.py"
+).read_text()
+CONST_SOURCE = (
+    Path(__file__).parents[1] / "custom_components" / "samsungtv_smart" / "const.py"
+).read_text()
+
+
+def _number(source: str, name: str) -> float:
+    match = re.search(rf"^{name} = ([0-9.]+)$", source, re.MULTILINE)
+    assert match, f"{name} not found"
+    return float(match.group(1))
+
+
+class ProbeTimeoutTest(unittest.TestCase):
+    """The probe must be able to finish inside one scan interval."""
+
+    def test_scan_interval_is_five_seconds(self):
+        match = re.search(r"^SCAN_INTERVAL = timedelta\(seconds=(\d+)\)$", SOURCE, re.M)
+        self.assertTrue(match)
+        self.assertEqual(int(match.group(1)), 5)
+
+    def test_the_default_rest_timeout_still_exceeds_the_interval(self):
+        """The condition that caused #248 — kept as the reason for the fix."""
+        self.assertGreater(_number(CONST_SOURCE, "DEFAULT_TIMEOUT"), 5)
+
+    def test_off_probe_timeout_fits_inside_the_scan_interval(self):
+        self.assertLess(_number(SOURCE, "POWER_PROBE_OFF_TIMEOUT"), 5)
+
+    def test_probe_timeout_is_applied_only_when_the_tv_is_not_on(self):
+        block = SOURCE[SOURCE.index("    async def _check_status") :]
+        block = block[: block.index("    @callback")]
+        self.assertIn("POWER_PROBE_OFF_TIMEOUT", block)
+        self.assertIn("if self._state == MediaPlayerState.ON", block)
+
+    def test_load_device_info_wraps_the_call_when_a_timeout_is_given(self):
+        block = SOURCE[SOURCE.index("    async def _async_load_device_info") :]
+        block = block[: block.index("    def _should_poll_st")]
+        self.assertIn("asyncio.wait_for(request, timeout=timeout)", block)
+        self.assertIn("if timeout is not None:", block)
+
+
+class SlowUpdateWarningTest(unittest.TestCase):
+    """An overrun explained by the TV being off must not warn."""
+
+    def setUp(self):
+        block = SOURCE[SOURCE.index("    def _note_slow_update") :]
+        self.block = block[: block.index("\n    async def _async_update")]
+
+    def test_an_off_tv_is_logged_at_debug(self):
+        head = self.block[: self.block.index("now = time.monotonic()")]
+        self.assertIn("if self._state != MediaPlayerState.ON:", head)
+        self.assertIn("self._log.debug(", head)
+        self.assertNotIn("self._log.warning(", head)
+
+    def test_a_reachable_tv_still_warns(self):
+        self.assertIn("self._log.warning(", self.block)
+
+    def test_warnings_are_throttled_and_report_what_they_stand_for(self):
+        self.assertIn("SLOW_UPDATE_WARN_INTERVAL", self.block)
+        self.assertIn("self._slow_update_suppressed += 1", self.block)
+        self.assertIn("further slow updates since the last warning", self.block)
+
+    def test_the_counter_resets_after_a_warning(self):
+        tail = self.block[self.block.rindex("self._slow_update_last_warn = now") :]
+        self.assertIn("self._slow_update_suppressed = 0", tail)
+
+    def test_throttle_interval_is_long_enough_to_matter(self):
+        self.assertGreaterEqual(_number(SOURCE, "SLOW_UPDATE_WARN_INTERVAL"), 60)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #248, where @ajguerre1 measured 557 slow-update warnings in 84 minutes across 13 TVs — 96% of them from the two in standby, projecting to 40 000–55 000 lines/day on his install.

## The cause is arithmetic

```
const.py:245        DEFAULT_TIMEOUT = 6          # REST client
media_player.py:267 SCAN_INTERVAL = timedelta(seconds=5)
```

A standby Frame leaves the network entirely, so `_check_status` can only learn it is off by letting the power probe **time out** — and that timeout is one second longer than the interval it is racing. Every poll of a sleeping TV overran, by construction, forever. His measured median overrun of 5.6 s is that 6 s timeout.

That also explains the shape of his data, which no amount of load would: the warning set and the unreachable set were *exactly* the same set.

## The fix

A TV **already believed to be off** gets a 3 s probe, which finishes inside the interval. A TV believed to be on keeps the full 6 s, where waiting for a slow answer is the right trade. Detection latency is unchanged — still probed every 5 s — and a TV that woke and needs longer than 3 s is caught on the next poll.

This matters more than a log-level change would, because it also removes **Home Assistant core's** line (`Updating samsungtv_smart media_player took longer than the scheduled update interval`). He counted 555 of those against our 557. We cannot silence core's warning; we can stop earning it. Nothing else in this PR could have addressed the doubling he reported.

## The warning itself

Kept, but only where it means something:

- an overrun on a TV that turned out to be **off** goes to `debug` — it is the expected consequence of a state we have just determined, which is his own first suggestion and the right one;
- a genuinely slow **reachable** TV still warns, now at most once per 5 minutes, carrying the number of overruns it stands for.

## Tests

`tests/test_slow_update_warning.py`, 10 cases. One of them asserts that `DEFAULT_TIMEOUT` still exceeds `SCAN_INTERVAL` — the condition that caused this — so the fix's reason stays pinned rather than becoming folklore, and the others cover the probe timeout being applied only when the TV is not on, the debug path, the throttle and its counter reset.

19 tests pass overall; black / flake8 / isort clean. Version `8.7.6`.

## On the report

Worth saying: it identified the right two lines of code, explained why a debug log would have added nothing (the warning is unconditional), and separated what predates this fork from what does not by reading #70. The projection was per-TV and measured. It is the reason this took one pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_