### PR TITLE
8.7.9 — art-mode writes: option gates writes, panel truth first, read-back, cooldown; one picture-mode write

### DIFF
--- a/README.md
+++ b/README.md
@@ -1191,7 +1191,9 @@ This typically appears **after a TV factory reset and re-pairing** of the IP Con
 
 **Workarounds, in order of preference:**
 
-1. **Disable Art Mode over IP Control.** Under **Reconfigure → IP Control**, turn **Enable IP Control Art Mode** off (this is the default). Art Mode detection and switching then fall back to the WebSocket / Frame Art channel, which is unaffected. Power on/off over IP Control (**Enable IP Control** / the *IP Control* power-on method) keeps working — only the Art Mode path is disabled.
+1. **Disable Art Mode over IP Control.** Under **Reconfigure → IP Control**, turn **Enable IP Control Art Mode** off (this is the default). Art Mode detection **and switching** then fall back to the WebSocket / Frame Art channel, which is unaffected, and no `artModeControl` request — read or write — is sent to the TV. Power on/off over IP Control (**Enable IP Control** / the *IP Control* power-on method) keeps working — only the Art Mode path is disabled.
+
+   > **Before 8.7.7 this was only half true.** The option disabled the `artModeControl` *getter*, but art-mode switching still sent `artModeOn`/`artModeOff` over JSON-RPC. If you disabled the option on the advice above and still saw Art Mode misbehave, that is why — update to 8.7.7 or later, where "off" means no `artModeControl` traffic at all. To stop **every** IP Control write to a TV you suspect, turn off **Enable IP Control** itself.
 2. **Factory reset the TV.** If you need IP Control for Art Mode and the flag is wedged, the only known way to clear the stuck `artModeControl` flag on the TV side is a **factory reset of the TV** (Settings → General → Reset), followed by re-pairing. There is no remote/API command that unsticks it.
 
 Once a firmware update reports `artModeControl` correctly again, you can re-enable **Enable IP Control Art Mode** under **Reconfigure → IP Control**.

--- a/custom_components/samsungtv_smart/api/ipcontrol.py
+++ b/custom_components/samsungtv_smart/api/ipcontrol.py
@@ -590,6 +590,23 @@ class SamsungIPControl:
             raise SamsungIPControlError(f"invalid inputSource response: {result!r}")
         return response_value
 
+    async def async_panel_shows_art(self) -> bool | None:
+        """Whether the PANEL is displaying art right now, or None if unknown.
+
+        Read from ``getTVStates.pictureMode``, which is ``"Ambient"`` exactly
+        while art is on screen. This is the signal to consult before WRITING
+        art mode: it is independent of the ``artModeControl`` flag, which can
+        wedge "on" on some firmware (the wedge this integration documents on a
+        QE55LS03D), and of the WebSocket art channel, which can go stale. A
+        plain getter, safe on any TV state and cheap enough to call once per
+        write.
+        """
+        states = await self._async_request("getTVStates")
+        mode = states.get("pictureMode")
+        if not isinstance(mode, str) or not mode:
+            return None
+        return mode == "Ambient"
+
     async def async_get_tv_states(self) -> dict[str, Any]:
         """Return the TV's general state snapshot (read-only).
 

--- a/custom_components/samsungtv_smart/api/smartthings.py
+++ b/custom_components/samsungtv_smart/api/smartthings.py
@@ -1052,8 +1052,14 @@ class SmartThingsTV:
             self._log.error("Error setting sound mode: %s", err)
             raise
 
-    async def async_set_picture_mode(self, mode: str):
+    async def async_set_picture_mode(self, mode: str) -> bool | None:
         """Select picture mode using direct REST API.
+
+        Returns True when the panel was READ BACK as having applied the mode,
+        None when a send was accepted but could not be verified, and False when
+        nothing was applied (no attempt, every attempt rejected, or accepted
+        and demonstrably not applied). The caller uses this to decide whether
+        the WebSocket key is still needed — see async_select_picture_mode.
 
         Tries both capability variants: some Samsung TVs accept commands
         on custom.picturemode but not samsungvd.pictureMode, or vice versa.
@@ -1071,7 +1077,7 @@ class SmartThingsTV:
             self._log.debug(
                 "Cannot set picture mode: TV state is %s (not ON)", self._state
             )
-            return
+            return False
 
         # Resolve display name -> internal API id using the map.
         mode_id = self._picture_mode_map.get(mode, mode)
@@ -1194,9 +1200,9 @@ class SmartThingsTV:
                 # Confirmed on the panel: remember this (capability, form) so
                 # later changes go straight through (persisted across restarts).
                 self._remember_picture_mode_capability(f"{capability}|{form}")
-                return
+                return True
             if applied is None:
-                return
+                return None
             self._log.warning(
                 "setPictureMode via %s (%s form) was accepted (COMPLETED) but "
                 "the TV still reports another mode — trying the next variant",
@@ -1211,6 +1217,7 @@ class SmartThingsTV:
                 mode,
                 "; ".join(failures) or "no attempt was made",
             )
+            return False
         else:
             # All accepted-but-unapplied (or the last one unverifiable).
             # Keep the optimistic value: the select entity holds the pending
@@ -1221,6 +1228,7 @@ class SmartThingsTV:
                 "command channel likely cannot actuate this panel (see #116)",
                 mode,
             )
+            return False
 
     def _remember_picture_mode_capability(self, capability: str) -> None:
         """Memorize (and persist) the capability confirmed to actuate the panel.

--- a/custom_components/samsungtv_smart/art_mode_guard.py
+++ b/custom_components/samsungtv_smart/art_mode_guard.py
@@ -1,0 +1,111 @@
+"""Guard against re-issuing art-mode writes that did not take.
+
+Every path that puts a Frame into (or out of) Art Mode used to trust a derived
+``art_mode_status`` and then write — ``artModeOn`` over IP Control, or
+``set_artmode`` / ``KEY_POWER`` over the WebSocket — with no check of what the
+panel actually shows, no read-back afterwards, and no memory of having just
+done the same thing. A wrong reading therefore turned every periodic
+automation into a periodic write against the TV, indefinitely: one
+``artModeOn`` per run at a panel already showing art, or a full
+power-toggle-and-back when the fallback path ran instead.
+
+This module is the memory part. The panel check (``getTVStates.pictureMode``,
+which is ``Ambient`` exactly while art is displayed and is independent of the
+``artModeControl`` flag that can wedge on some firmware) lives with the
+callers; they consult this guard right before writing and report the outcome
+right after.
+
+Only writes that were NOT verified to take are remembered: a write that was
+read back as applied clears the record, so a user toggling art on, off with
+the remote, and on again within a minute is never blocked. What is blocked
+is the second unverified write of the same intent inside the cooldown — the
+exact shape of the loop above — and blocking it raises, so a retry loop that
+would otherwise thrash exits with one warning instead of N writes.
+
+Pure Python, no Home Assistant imports: shared between the media player and
+the Art Mode switch through the entry's ``hass.data`` dict, and unit-tested
+without either.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import time
+
+# Seconds during which a second, unverified write of the same intent is
+# refused. Long enough that an automation firing every 30-60 s cannot turn
+# into a write loop; short enough that a genuine retry after a transient
+# failure is not held for long.
+ART_MODE_WRITE_COOLDOWN = 60.0
+
+# Key under which the per-entry guard is stored in hass.data[DOMAIN][entry_id].
+DATA_ART_MODE_GUARD = "art_mode_write_guard"
+
+
+class ArtModeWriteSuppressed(Exception):
+    """A same-intent art-mode write was refused inside the cooldown.
+
+    Carries the seconds since the write it repeats, for the caller's warning.
+    """
+
+    def __init__(self, turn_on: bool, since: float) -> None:
+        self.turn_on = turn_on
+        self.since = since
+        intent = "on" if turn_on else "off"
+        super().__init__(
+            f"art mode '{intent}' was already written {since:.0f}s ago and did not "
+            f"take; not writing it again within {ART_MODE_WRITE_COOLDOWN:.0f}s"
+        )
+
+
+class ArtModeWriteGuard:
+    """Remember unverified art-mode writes, per intent, for a cooldown."""
+
+    def __init__(
+        self,
+        cooldown: float = ART_MODE_WRITE_COOLDOWN,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._cooldown = cooldown
+        self._clock = clock
+        # intent (True = art on, False = art off) -> monotonic time of the last
+        # write of that intent that was not verified to have taken.
+        self._unverified: dict[bool, float] = {}
+
+    def check(self, turn_on: bool) -> None:
+        """Raise ArtModeWriteSuppressed if this intent was just written in vain."""
+        last = self._unverified.get(turn_on)
+        if last is None:
+            return
+        since = self._clock() - last
+        if since < self._cooldown:
+            raise ArtModeWriteSuppressed(turn_on, since)
+        # Cooldown elapsed: the earlier attempt is history, allow one more.
+        del self._unverified[turn_on]
+
+    def record_unverified(self, turn_on: bool) -> None:
+        """A write was sent and either failed to take or could not be read back."""
+        self._unverified[turn_on] = self._clock()
+
+    def record_verified(self, turn_on: bool) -> None:
+        """A write was read back as applied: nothing to hold against it."""
+        self._unverified.pop(turn_on, None)
+
+    def pending(self, turn_on: bool) -> float | None:
+        """Seconds since the last unverified write of this intent, if any."""
+        last = self._unverified.get(turn_on)
+        return None if last is None else self._clock() - last
+
+
+def guard_for(entry_store: dict) -> ArtModeWriteGuard:
+    """Return the entry's shared guard, creating it on first use.
+
+    ``entry_store`` is ``hass.data[DOMAIN][entry_id]`` — the same dict the
+    shared art API lives in — so the switch and the media player, which both
+    write art mode, share one memory of what was just written.
+    """
+    guard = entry_store.get(DATA_ART_MODE_GUARD)
+    if guard is None:
+        guard = ArtModeWriteGuard()
+        entry_store[DATA_ART_MODE_GUARD] = guard
+    return guard

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -196,6 +196,13 @@ CONF_ENABLE_IP_CONTROL = "enable_ip_control"
 # Control (CONF_ENABLE_IP_CONTROL / CONF_POWER_ON_METHOD) is unaffected by
 # this setting. Re-enable once the TV's firmware reports artModeControl
 # correctly again.
+#
+# OFF MEANS NO artModeControl TRAFFIC AT ALL — reads and writes. Until 8.7.7
+# this gated only the getter, so a user who disabled it on our own advice (the
+# path "can break Art Mode entirely and may need a factory reset", seen on a
+# QE55LS03D) still had every art-mode toggle sent to the TV over JSON-RPC.
+# Art mode then uses the WebSocket art channel for both reading and switching,
+# which is what the documentation always said it did.
 CONF_IP_CONTROL_ART_MODE = "ip_control_art_mode"
 
 # Device identity, learned once via IP Control's getDeviceInformation right

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.7.7"
+  "version": "8.7.8"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.7.6"
+  "version": "8.7.7"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.7.8"
+  "version": "8.7.9"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -3758,22 +3758,37 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         await self._st.async_set_sound_mode(sound_mode)
 
     async def async_select_picture_mode(self, picture_mode):
-        """Select picture mode.
+        """Select picture mode: SmartThings first, WS key when it is needed.
 
-        Uses SmartThings API first, then sends a WS key command as well.
-        The WS key bypasses HDMI content protection restrictions that cause
-        the SmartThings API to return COMPLETED but the TV to show
-        "function not available".
+        The WS key exists because SmartThings can answer COMPLETED while the
+        TV shows "function not available" — HDMI content protection blocks the
+        cloud command on some inputs. It used to be sent on EVERY change, even
+        when the cloud write had been read back as applied, so one user action
+        wrote the same setting twice over two channels within a second.
+
+        It is now sent only when SmartThings did not demonstrably apply the
+        mode: no SmartThings at all, an exception, an outright failure, or a
+        send that could not be verified. A verified apply sends nothing more.
+        The ambiguous case still sends the key, so nothing that used to work
+        stops working — this only removes the provably redundant write.
         """
-        # 1. Try SmartThings API (works for native TV sources)
+        applied = False
         if self._st:
             try:
-                await self._st.async_set_picture_mode(picture_mode)
+                applied = await self._st.async_set_picture_mode(picture_mode) is True
             except Exception:
-                pass
+                applied = False
 
-        # 2. Also send WS key as fallback (bypasses HDMI restrictions, and is
-        # the only path left when the cloud refuses the command entirely).
+        if applied:
+            self._log.debug(
+                "Picture mode '%s' verified applied via SmartThings; "
+                "not sending the WS key as well",
+                picture_mode,
+            )
+            return
+
+        # SmartThings could not be confirmed to have applied it — send the key,
+        # which also covers the HDMI-restricted case above.
         mode_id = ""
         if self._st:
             mode_id = self._st.picture_mode_map.get(picture_mode, "")
@@ -3781,7 +3796,8 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         if ws_key:
             await self.async_send_command(ws_key)
             self._log.debug(
-                "Picture mode '%s' also sent via WS key %s",
+                "Picture mode '%s' sent via WS key %s (SmartThings did not "
+                "confirm it applied)",
                 picture_mode,
                 ws_key,
             )

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -86,6 +86,7 @@ from .api.samsungcast import SamsungCastTube
 from .api.samsungws import ArtModeStatus, SamsungTVAsyncRest, SamsungTVWS
 from .api.smartthings import SmartThingsCapabilityUnsupported, SmartThingsTV, STStatus
 from .api.upnp import SamsungUPnP
+from .art_mode_guard import ArtModeWriteSuppressed, guard_for
 from .const import (
     ATTR_BRIGHTNESS,
     ATTR_CATEGORY_ID,
@@ -207,6 +208,11 @@ ATTR_IP_ADDRESS = "ip_address"
 ATTR_PICTURE_MODE = "picture_mode"
 ATTR_PICTURE_MODE_LIST = "picture_mode_list"
 ATTR_CONFIG_ENTRY_ID = "config_entry_id"
+
+
+class _SkipPowerOn(Exception):
+    """Internal: leave the power-on block without sending the power key."""
+
 
 CMD_OPEN_BROWSER = "open_browser"
 CMD_RUN_APP = "run_app"
@@ -3981,6 +3987,20 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             resolution = device.get("resolution")
         return panel_size(resolution)
 
+    async def _panel_shows_art(self) -> bool | None:
+        """getTVStates.pictureMode == "Ambient", or None when it cannot be read.
+
+        Needs only IP Control to be paired: this is a plain state getter, not
+        the artModeControl flag the art-mode option guards.
+        """
+        client = self._get_ip_control_client()
+        if client is None:
+            return None
+        try:
+            return await client.async_panel_shows_art()
+        except SamsungIPControlError:
+            return None
+
     async def _ensure_tv_awake_for_art(self) -> bool:
         """Ensure the TV is powered, WITHOUT forcing it into Art Mode.
 
@@ -4070,6 +4090,33 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             self._log.debug("Frame Art: already in Art Mode, ready")
             return True
 
+        guard = guard_for(
+            self.hass.data.setdefault(DOMAIN, {}).setdefault(self._entry_id, {})
+        )
+
+        # Panel truth before anything is written or toggled. art_mode_status
+        # is a derived reading (IP flag, WebSocket art channel, SmartThings)
+        # and every one of those sources can be stale or wedged; the panel's
+        # own pictureMode cannot. If it shows Ambient, the TV IS in Art Mode
+        # and the only wrong move is to act on the stale reading — which used
+        # to mean an artModeOn at a panel already showing art on every
+        # automation run, or a KEY_POWER that toggled it out of art and back.
+        panel = await self._panel_shows_art()
+        if panel:
+            self._log.warning(
+                "Frame Art: art_mode_status reads off but the panel shows Ambient "
+                "— the reading is stale; treating the TV as in Art Mode and NOT "
+                "writing"
+            )
+            guard.record_verified(True)
+            return True
+
+        try:
+            guard.check(True)
+        except ArtModeWriteSuppressed as ex:
+            self._log.warning("Frame Art: %s", ex)
+            return False
+
         # Prefer the reliable IP Control path to enter Art Mode when paired:
         # the explicit artModeOn command moves the panel even on TVs whose
         # WebSocket art channel is unresponsive ("zombie") or whose
@@ -4092,21 +4139,49 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                         await ip_client.async_power_on()
                         await asyncio.sleep(3)
                 await ip_client.async_set_art_mode_on()
-                await asyncio.sleep(2)
-                self._log.debug("Frame Art: Art Mode activated via IP Control")
-                return True
             except SamsungIPControlError as ex:
                 self._log.debug(
                     "Frame Art: IP Control art-mode activation failed (%s); "
                     "falling back to WebSocket",
                     ex,
                 )
+            else:
+                # Read the panel back rather than trusting the accepted command.
+                await asyncio.sleep(2)
+                after = await self._panel_shows_art()
+                if after:
+                    guard.record_verified(True)
+                    self._log.debug("Frame Art: Art Mode activated via IP Control")
+                    return True
+                guard.record_unverified(True)
+                if after is None:
+                    self._log.debug(
+                        "Frame Art: artModeOn accepted but the panel could not be "
+                        "read back"
+                    )
+                    return True
+                self._log.warning(
+                    "Frame Art: artModeOn was accepted but the panel did not "
+                    "switch to Ambient — not retrying within the cooldown"
+                )
+                return False
 
         # Check if TV is off, turn it on if needed
         if self.state == MediaPlayerState.OFF:
             self._log.info("Frame Art: TV is off, turning it on first...")
 
             try:
+                # Never send the power key at a Frame whose art channel says
+                # art is on: on a Frame that key TOGGLES the panel out of Art
+                # Mode onto the last input. The panel read above already
+                # returned for a confirmed Ambient; this covers the case where
+                # the panel could not be read.
+                if self._ws.artmode_status == ArtModeStatus.On:
+                    self._log.debug(
+                        "Frame Art: art channel reports art on; not sending "
+                        "the power key"
+                    )
+                    raise _SkipPowerOn
                 # Try normal WebSocket turn on first
                 await self.async_turn_on()
 
@@ -4116,6 +4191,8 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
                 self._log.info("Frame Art: TV should now be on")
 
+            except _SkipPowerOn:
+                pass
             except Exception as ex:
                 # WebSocket failed, try SmartThings fallback
                 if (
@@ -4166,6 +4243,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
 
             if art_mode_status == "on":
                 self._log.debug("Frame Art: Art Mode already active")
+                guard.record_verified(True)
                 return True
 
             # Art Mode is not active, activate it
@@ -4173,14 +4251,33 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             async with asyncio.timeout(10):
                 result = await self._art_api.set_artmode(True)
 
-            if result:
-                self._log.info("Frame Art: Art Mode successfully activated")
-                # Wait a bit for Art Mode to fully activate
-                await asyncio.sleep(2)
-                return True
-            else:
+            if not result:
                 self._log.error("Frame Art: Failed to activate Art Mode")
+                guard.record_unverified(True)
                 return False
+
+            # Wait a bit, then read back rather than trust the return value —
+            # set_artmode can report success without moving the panel.
+            await asyncio.sleep(2)
+            try:
+                async with asyncio.timeout(8):
+                    confirmed = await self._art_api.get_artmode()
+            except Exception:  # noqa: BLE001 - read-back is best effort
+                confirmed = None
+            if confirmed == "on":
+                guard.record_verified(True)
+                self._log.info("Frame Art: Art Mode successfully activated")
+                return True
+            guard.record_unverified(True)
+            if confirmed is None:
+                self._log.info("Frame Art: Art Mode activated (not read back)")
+                return True
+            self._log.warning(
+                "Frame Art: set_artmode reported success but the TV still reports "
+                "art mode %s — not retrying within the cooldown",
+                confirmed,
+            )
+            return False
 
         except asyncio.TimeoutError:
             self._log.error("Frame Art: Timeout checking/activating Art Mode")

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -4059,7 +4059,16 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         # WebSocket art channel is unresponsive ("zombie") or whose
         # set_artmode times out. Power on first (returns into the last state)
         # then force Art Mode on.
-        ip_client = self._get_ip_control_client()
+        #
+        # Gated on CONF_IP_CONTROL_ART_MODE like every other art-mode use of
+        # IP Control: with that option off, no artModeControl request is sent
+        # at all, read or write. See the switch's _set_artmode for why the
+        # write path used to escape the setting, and why that was wrong.
+        ip_client = (
+            self._get_ip_control_client()
+            if self._get_option(CONF_IP_CONTROL_ART_MODE, False)
+            else None
+        )
         if ip_client is not None:
             try:
                 if self.state == MediaPlayerState.OFF:

--- a/custom_components/samsungtv_smart/switch.py
+++ b/custom_components/samsungtv_smart/switch.py
@@ -34,6 +34,7 @@ from .api.ipcontrol import (
     SamsungIPControlAuthError,
     SamsungIPControlError,
 )
+from .art_mode_guard import ArtModeWriteSuppressed, guard_for
 from .const import (
     AUTH_METHOD_OAUTH,
     CONF_AUTH_METHOD,
@@ -278,6 +279,28 @@ class FrameArtModeSwitch(SwitchEntity):
         switching then falls back to the WebSocket art channel, as the
         documentation already claims it does.
         """
+        guard = guard_for(self._hass.data[DOMAIN][self._entry.entry_id])
+
+        # 1. Panel truth before writing. getTVStates.pictureMode is a plain
+        # getter that needs only IP Control to be paired — not the art-mode
+        # option — and it is independent of the artModeControl flag (which can
+        # wedge) and of the WebSocket art channel (which can go stale). If the
+        # panel already shows what was asked for, the request is satisfied and
+        # writing again is exactly the loop we are guarding against.
+        panel = await self._panel_shows_art()
+        if panel is turn_on:
+            self._log.warning(
+                "Art Mode %s requested for %s but the panel already shows it — "
+                "the art-mode reading was stale; not writing",
+                "ON" if turn_on else "OFF",
+                self._device_name,
+            )
+            guard.record_verified(turn_on)
+            return True
+
+        # 2. Cooldown: refuse to repeat a same-intent write that did not take.
+        guard.check(turn_on)  # raises ArtModeWriteSuppressed
+
         client = self._get_ip_control() if self._ip_control_art_mode() else None
         if client is not None:
             try:
@@ -290,7 +313,6 @@ class FrameArtModeSwitch(SwitchEntity):
                     turn_on,
                     self._device_name,
                 )
-                return True
             except SamsungIPControlError as ex:
                 self._log.debug(
                     "IP Control art-mode set failed (%s); falling back to "
@@ -298,7 +320,47 @@ class FrameArtModeSwitch(SwitchEntity):
                     ex,
                     self._device_name,
                 )
-        return await self._art_api.set_artmode(turn_on)
+            else:
+                # 4. Read the panel back instead of trusting the accepted
+                # command: "COMPLETED" does not move a panel.
+                await asyncio.sleep(2)
+                after = await self._panel_shows_art()
+                if after is turn_on:
+                    guard.record_verified(turn_on)
+                    return True
+                guard.record_unverified(turn_on)
+                if after is None:
+                    self._log.debug(
+                        "Art Mode %s for %s accepted via IP Control but the panel "
+                        "could not be read back",
+                        turn_on,
+                        self._device_name,
+                    )
+                    return True
+                self._log.warning(
+                    "Art Mode %s for %s was accepted via IP Control but the panel "
+                    "did not change — not retrying within the cooldown",
+                    "ON" if turn_on else "OFF",
+                    self._device_name,
+                )
+                return False
+
+        result = await self._art_api.set_artmode(turn_on)
+        if result:
+            # The WebSocket path has no panel read-back here; the caller's
+            # get_artmode() check verifies it and clears this.
+            guard.record_unverified(turn_on)
+        return result
+
+    async def _panel_shows_art(self) -> bool | None:
+        """getTVStates.pictureMode == "Ambient", or None when unreadable."""
+        client = self._get_ip_control()
+        if client is None:
+            return None
+        try:
+            return await client.async_panel_shows_art()
+        except SamsungIPControlError:
+            return None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -533,6 +595,9 @@ class FrameArtModeSwitch(SwitchEntity):
                                     " (confirmed by get_artmode)",
                                     self._device_name,
                                 )
+                                guard_for(
+                                    self._hass.data[DOMAIN][self._entry.entry_id]
+                                ).record_verified(True)
                                 self._attr_is_on = True
                                 self._available = True
                                 self.async_write_ha_state()
@@ -545,6 +610,12 @@ class FrameArtModeSwitch(SwitchEntity):
                             await asyncio.sleep(retry_delay)
                             retry_delay *= 2  # Exponential backoff
 
+            except ArtModeWriteSuppressed as ex:
+                # The same write was just made and did not take. Retrying is
+                # the loop this guard exists to stop; say so once and stop.
+                self._log.warning("Art Mode for %s: %s", self._device_name, ex)
+                self.async_write_ha_state()
+                return
             except asyncio.TimeoutError:
                 self._log.debug("Timeout on attempt %d/%d", attempt + 1, max_retries)
                 if attempt < max_retries - 1:
@@ -620,6 +691,12 @@ class FrameArtModeSwitch(SwitchEntity):
                             await asyncio.sleep(retry_delay)
                             retry_delay *= 2
 
+            except ArtModeWriteSuppressed as ex:
+                # The same write was just made and did not take. Retrying is
+                # the loop this guard exists to stop; say so once and stop.
+                self._log.warning("Art Mode for %s: %s", self._device_name, ex)
+                self.async_write_ha_state()
+                return
             except asyncio.TimeoutError:
                 self._log.debug("Timeout on attempt %d/%d", attempt + 1, max_retries)
                 if attempt < max_retries - 1:

--- a/custom_components/samsungtv_smart/switch.py
+++ b/custom_components/samsungtv_smart/switch.py
@@ -38,6 +38,7 @@ from .const import (
     AUTH_METHOD_OAUTH,
     CONF_AUTH_METHOD,
     CONF_ENABLE_IP_CONTROL,
+    CONF_IP_CONTROL_ART_MODE,
     CONF_IP_CONTROL_TOKEN,
     CONF_IS_FRAME_TV,
     CONF_WS_NAME,
@@ -249,6 +250,10 @@ class FrameArtModeSwitch(SwitchEntity):
             self._ip_control_token = token
         return self._ip_control
 
+    def _ip_control_art_mode(self) -> bool:
+        """True when art mode may use IP Control at all (default: off)."""
+        return self._entry.options.get(CONF_IP_CONTROL_ART_MODE, False)
+
     async def _set_artmode(self, turn_on: bool):
         """Set Art Mode via IP Control (primary), WebSocket as fallback.
 
@@ -261,14 +266,19 @@ class FrameArtModeSwitch(SwitchEntity):
         WebSocket so behaviour is never worse than before. The caller verifies
         the resulting state afterwards.
 
-        Note: this writing path is gated only by ``CONF_ENABLE_IP_CONTROL``
-        (inside ``_get_ip_control``), NOT by ``CONF_IP_CONTROL_ART_MODE``. The
-        latter only disables the *read* path (the ``artModeControl`` getter,
-        which can wedge "on" on some firmwares). Issuing the explicit
-        ``artModeOn``/``artModeOff`` command is reliable even on those TVs, so
-        we keep using it for switching.
+        ``CONF_IP_CONTROL_ART_MODE`` gates this path, reads AND writes. It
+        used to gate only the ``artModeControl`` getter, on the reasoning that
+        the explicit artModeOn/artModeOff command stays reliable even on a TV
+        whose getter has wedged. That left the setting dishonest: our own
+        documentation tells users to disable it because the IP Control art-mode
+        path "can break Art Mode entirely and may need a factory reset (seen on
+        QE55LS03D fw 2123)", yet a user who did exactly that still had every
+        art-mode toggle sent to the TV over JSON-RPC. Whatever that firmware
+        fault really is, "off" must mean no artModeControl traffic at all —
+        switching then falls back to the WebSocket art channel, as the
+        documentation already claims it does.
         """
-        client = self._get_ip_control()
+        client = self._get_ip_control() if self._ip_control_art_mode() else None
         if client is not None:
             try:
                 if turn_on:

--- a/tests/test_art_mode_ip_gating.py
+++ b/tests/test_art_mode_ip_gating.py
@@ -1,0 +1,85 @@
+"""The IP Control art-mode option must gate writes, not only reads.
+
+Our documentation tells users to disable "Enable IP Control Art Mode" because
+that path "can break Art Mode entirely and may need a factory reset" on some
+firmware. Until 8.7.7 the option gated only the artModeControl *getter*, so a
+user following that advice still had every art-mode toggle sent to the TV over
+JSON-RPC. These tests pin the fix: with the option off, no artModeControl
+request is issued at all.
+"""
+
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).parents[1] / "custom_components" / "samsungtv_smart"
+SWITCH = (ROOT / "switch.py").read_text()
+MEDIA_PLAYER = (ROOT / "media_player.py").read_text()
+
+
+def _block(source: str, start: str, end: str) -> str:
+    begin = source.index(start)
+    return source[begin : source.index(end, begin)]
+
+
+class SwitchWritePathTest(unittest.TestCase):
+    """The Art Mode switch must respect the option before writing."""
+
+    def setUp(self):
+        self.block = _block(
+            SWITCH, "    async def _set_artmode", "    @property\n    def device_info"
+        )
+
+    def test_the_client_is_only_obtained_when_the_option_is_on(self):
+        self.assertIn(
+            "self._get_ip_control() if self._ip_control_art_mode() else None",
+            self.block,
+        )
+
+    def test_the_websocket_fallback_is_still_reachable(self):
+        self.assertIn("return await self._art_api.set_artmode(turn_on)", self.block)
+
+    def test_the_option_defaults_to_off(self):
+        helper = _block(
+            SWITCH, "    def _ip_control_art_mode", "    async def _set_artmode"
+        )
+        self.assertIn("CONF_IP_CONTROL_ART_MODE, False", helper)
+
+
+class MediaPlayerWritePathTest(unittest.TestCase):
+    """Entering Art Mode from the media player must respect it too."""
+
+    def setUp(self):
+        self.block = _block(
+            MEDIA_PLAYER,
+            "        # Prefer the reliable IP Control path to enter Art Mode",
+            "    async def async_art_upload",
+        )
+
+    def test_the_client_is_gated_on_the_option(self):
+        self.assertIn("CONF_IP_CONTROL_ART_MODE, False", self.block)
+        gate = self.block[: self.block.index("async_set_art_mode_on")]
+        self.assertIn("else None", gate)
+
+
+class NoUngatedSetterTest(unittest.TestCase):
+    """No art-mode setter anywhere may escape the option."""
+
+    def test_every_art_mode_write_site_is_gated(self):
+        for name, source in (("switch.py", SWITCH), ("media_player.py", MEDIA_PLAYER)):
+            for setter in ("async_set_art_mode_on", "async_set_art_mode_off"):
+                for line_no, line in enumerate(source.splitlines(), 1):
+                    if setter + "()" not in line:
+                        continue
+                    # The nearest 40 lines above the call must mention the option.
+                    context = "\n".join(
+                        source.splitlines()[max(0, line_no - 40) : line_no]
+                    )
+                    self.assertIn(
+                        "CONF_IP_CONTROL_ART_MODE",
+                        context,
+                        f"{name}:{line_no} calls {setter} with no visible gate",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_art_mode_ip_gating.py
+++ b/tests/test_art_mode_ip_gating.py
@@ -36,7 +36,7 @@ class SwitchWritePathTest(unittest.TestCase):
         )
 
     def test_the_websocket_fallback_is_still_reachable(self):
-        self.assertIn("return await self._art_api.set_artmode(turn_on)", self.block)
+        self.assertIn("await self._art_api.set_artmode(turn_on)", self.block)
 
     def test_the_option_defaults_to_off(self):
         helper = _block(
@@ -70,13 +70,14 @@ class NoUngatedSetterTest(unittest.TestCase):
                 for line_no, line in enumerate(source.splitlines(), 1):
                     if setter + "()" not in line:
                         continue
-                    # The nearest 40 lines above the call must mention the option.
+                    # The nearest 60 lines above the call must show the gate —
+                    # the option itself, or the switch's helper that reads it.
                     context = "\n".join(
-                        source.splitlines()[max(0, line_no - 40) : line_no]
+                        source.splitlines()[max(0, line_no - 60) : line_no]
                     )
-                    self.assertIn(
-                        "CONF_IP_CONTROL_ART_MODE",
-                        context,
+                    self.assertTrue(
+                        "CONF_IP_CONTROL_ART_MODE" in context
+                        or "self._ip_control_art_mode()" in context,
                         f"{name}:{line_no} calls {setter} with no visible gate",
                     )
 

--- a/tests/test_art_mode_write_guard.py
+++ b/tests/test_art_mode_write_guard.py
@@ -1,0 +1,196 @@
+"""Art-mode writes: panel truth first, no repeat of a write that did not take.
+
+Two layers. The pure guard is exercised directly with a fake clock; the
+integration points are checked structurally, since media_player.py and
+switch.py cannot be imported without Home Assistant.
+"""
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).parents[1] / "custom_components" / "samsungtv_smart"
+
+
+def _load_guard_module():
+    spec = importlib.util.spec_from_file_location(
+        "art_mode_guard_under_test", ROOT / "art_mode_guard.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+guard_mod = _load_guard_module()
+ArtModeWriteGuard = guard_mod.ArtModeWriteGuard
+ArtModeWriteSuppressed = guard_mod.ArtModeWriteSuppressed
+
+
+class _Clock:
+    def __init__(self):
+        self.now = 1000.0
+
+    def __call__(self):
+        return self.now
+
+
+class GuardTest(unittest.TestCase):
+    """The memory of unverified writes."""
+
+    def setUp(self):
+        self.clock = _Clock()
+        self.guard = ArtModeWriteGuard(cooldown=60.0, clock=self.clock)
+
+    def test_first_write_is_always_allowed(self):
+        self.guard.check(True)
+        self.guard.check(False)
+
+    def test_a_verified_write_never_blocks_the_next_one(self):
+        self.guard.record_verified(True)
+        self.clock.now += 1
+        self.guard.check(True)
+
+    def test_an_unverified_write_blocks_the_same_intent_inside_the_cooldown(self):
+        self.guard.record_unverified(True)
+        self.clock.now += 30
+        with self.assertRaises(ArtModeWriteSuppressed) as ctx:
+            self.guard.check(True)
+        self.assertEqual(ctx.exception.turn_on, True)
+        self.assertAlmostEqual(ctx.exception.since, 30.0)
+
+    def test_the_other_intent_is_not_blocked(self):
+        # art on failed; the user asking for art OFF is a different request.
+        self.guard.record_unverified(True)
+        self.clock.now += 5
+        self.guard.check(False)
+
+    def test_the_block_lifts_when_the_cooldown_elapses(self):
+        self.guard.record_unverified(True)
+        self.clock.now += 61
+        self.guard.check(True)
+        # ...and the stale record is gone, not merely ignored.
+        self.assertIsNone(self.guard.pending(True))
+
+    def test_a_later_verified_write_clears_an_earlier_unverified_one(self):
+        self.guard.record_unverified(True)
+        self.guard.record_verified(True)
+        self.guard.check(True)
+
+    def test_pending_reports_age(self):
+        self.assertIsNone(self.guard.pending(True))
+        self.guard.record_unverified(True)
+        self.clock.now += 12
+        self.assertAlmostEqual(self.guard.pending(True), 12.0)
+
+    def test_the_exception_message_names_intent_and_age(self):
+        message = str(ArtModeWriteSuppressed(True, 42.0))
+        self.assertIn("'on'", message)
+        self.assertIn("42s", message)
+
+    def test_guard_for_is_shared_per_entry_store(self):
+        store: dict = {}
+        first = guard_mod.guard_for(store)
+        second = guard_mod.guard_for(store)
+        self.assertIs(first, second)
+        self.assertIsNot(first, guard_mod.guard_for({}))
+
+
+SWITCH = (ROOT / "switch.py").read_text()
+MEDIA_PLAYER = (ROOT / "media_player.py").read_text()
+IPCONTROL = (ROOT / "api" / "ipcontrol.py").read_text()
+
+
+def _block(source: str, start: str, end: str) -> str:
+    begin = source.index(start)
+    return source[begin : source.index(end, begin)]
+
+
+class PanelTruthTest(unittest.TestCase):
+    """Both writers ask the panel before writing, and read it back after."""
+
+    def test_the_getter_reads_pictureMode_not_the_art_flag(self):
+        block = _block(
+            IPCONTROL,
+            "    async def async_panel_shows_art",
+            "    async def async_get_tv_states",
+        )
+        self.assertIn('self._async_request("getTVStates")', block)
+        self.assertIn('== "Ambient"', block)
+        self.assertNotIn('_async_request("artModeControl")', block)
+
+    def test_switch_checks_the_panel_before_the_cooldown_and_the_write(self):
+        block = _block(
+            SWITCH, "    async def _set_artmode", "    async def _panel_shows_art"
+        )
+        panel = block.index("await self._panel_shows_art()")
+        cooldown = block.index("guard.check(turn_on)")
+        write = block.index("async_set_art_mode_on()")
+        self.assertLess(panel, cooldown)
+        self.assertLess(cooldown, write)
+
+    def test_switch_reads_the_panel_back_after_an_ip_write(self):
+        block = _block(
+            SWITCH, "    async def _set_artmode", "    async def _panel_shows_art"
+        )
+        write = block.index("async_set_art_mode_on()")
+        self.assertIn("after = await self._panel_shows_art()", block[write:])
+        self.assertIn("guard.record_verified(turn_on)", block[write:])
+        self.assertIn("guard.record_unverified(turn_on)", block[write:])
+
+    def test_media_player_checks_the_panel_before_any_write_or_toggle(self):
+        block = _block(
+            MEDIA_PLAYER,
+            "    async def _ensure_art_mode_ready",
+            "    async def async_art_select_image",
+        )
+        panel = block.index("await self._panel_shows_art()")
+        cooldown = block.index("guard.check(True)")
+        ip_write = block.index("async_set_art_mode_on()")
+        power = block.index("await self.async_turn_on()")
+        self.assertLess(panel, cooldown)
+        self.assertLess(cooldown, ip_write)
+        self.assertLess(ip_write, power)
+
+    def test_media_player_reads_back_after_both_write_paths(self):
+        block = _block(
+            MEDIA_PLAYER,
+            "    async def _ensure_art_mode_ready",
+            "    async def async_art_select_image",
+        )
+        self.assertIn("after = await self._panel_shows_art()", block)
+        self.assertIn("confirmed = await self._art_api.get_artmode()", block)
+
+
+class NoPowerKeyAtArtTest(unittest.TestCase):
+    """The fallback must not toggle a Frame out of Art Mode with the power key."""
+
+    def test_power_on_is_skipped_when_the_art_channel_says_art_is_on(self):
+        block = _block(
+            MEDIA_PLAYER,
+            "    async def _ensure_art_mode_ready",
+            "    async def async_art_select_image",
+        )
+        guard = block.index("self._ws.artmode_status == ArtModeStatus.On")
+        power = block.index("await self.async_turn_on()")
+        self.assertLess(guard, power)
+        self.assertIn("raise _SkipPowerOn", block[guard:power])
+
+
+class RetryLoopsStopTest(unittest.TestCase):
+    """A suppressed write ends the switch's retry loops with one warning."""
+
+    def test_both_loops_handle_the_suppression_before_the_generic_except(self):
+        for name in ("async_turn_on", "async_turn_off"):
+            block = _block(
+                SWITCH,
+                f"    async def {name}(self, **kwargs",
+                "        # All retries failed",
+            )
+            suppressed = block.index("except ArtModeWriteSuppressed")
+            generic = block.index("except Exception as ex")
+            self.assertLess(suppressed, generic, name)
+            self.assertIn("return", block[suppressed:generic])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_picture_mode_single_write.py
+++ b/tests/test_picture_mode_single_write.py
@@ -1,0 +1,83 @@
+"""One picture-mode change must not write twice on two channels.
+
+async_select_picture_mode used to send the SmartThings command AND the
+WebSocket key on every change, even when the cloud write had been read back
+as applied. The WS key is a workaround for HDMI content protection, so it
+must still be sent whenever SmartThings cannot be confirmed — but not when it
+demonstrably worked.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+ROOT = Path(__file__).parents[1] / "custom_components" / "samsungtv_smart"
+MEDIA_PLAYER = (ROOT / "media_player.py").read_text()
+SMARTTHINGS = (ROOT / "api" / "smartthings.py").read_text()
+
+
+def _block(source: str, start: str, end: str) -> str:
+    begin = source.index(start)
+    return source[begin : source.index(end, begin)]
+
+
+class SmartThingsContractTest(unittest.TestCase):
+    """The setter must report whether the panel applied the mode."""
+
+    def setUp(self):
+        self.block = _block(
+            SMARTTHINGS,
+            "    async def async_set_picture_mode",
+            "    def _remember_picture_mode_capability",
+        )
+
+    def test_the_signature_announces_a_tri_state_result(self):
+        self.assertIn(
+            "async def async_set_picture_mode(self, mode: str) -> bool | None:",
+            SMARTTHINGS,
+        )
+
+    def test_a_verified_apply_returns_true(self):
+        verified = self.block[self.block.index("if applied:") :]
+        self.assertIn("return True", verified[: verified.index("if applied is None")])
+
+    def test_an_unverifiable_send_returns_none(self):
+        self.assertIn("if applied is None:\n                return None", self.block)
+
+    def test_every_failure_path_returns_false(self):
+        # "not ON", "every attempt rejected", "accepted but never applied".
+        self.assertEqual(len(re.findall(r"\n            return False", self.block)), 3)
+
+    def test_the_nested_attempt_builder_still_returns_nothing(self):
+        helper = _block(self.block, "        def _add(", "        for capability in")
+        self.assertNotIn("return False", helper)
+
+
+class CallerTest(unittest.TestCase):
+    """The WS key is a fallback, not a companion."""
+
+    def setUp(self):
+        self.block = _block(
+            MEDIA_PLAYER,
+            "    async def async_select_picture_mode",
+            "    async def _async_set_hue_sync",
+        )
+
+    def test_a_verified_apply_stops_before_the_ws_key(self):
+        head = self.block[: self.block.index("mode_id = ")]
+        self.assertIn("if applied:", head)
+        self.assertIn("return", head)
+
+    def test_only_an_exact_true_counts_as_applied(self):
+        # None (unverifiable) must NOT suppress the key.
+        self.assertIn("async_set_picture_mode(picture_mode) is True", self.block)
+
+    def test_an_exception_does_not_suppress_the_key(self):
+        self.assertIn("except Exception:\n                applied = False", self.block)
+
+    def test_the_ws_key_is_still_sent_on_the_fallback_path(self):
+        self.assertIn("await self.async_send_command(ws_key)", self.block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three commits from auditing what this integration actually writes to a TV, after a report of repeated hardware failures on one QE55LS03D. The third is the substantive one.

## 1. "Enable IP Control Art Mode" off now means off

`switch.py` gated only the `artModeControl` *getter* on that option, by design, and said so. The README meanwhile tells users to disable the option because the path "can break Art Mode entirely and may need a factory reset (seen on QE55LS03D fw 2123)" and that switching then falls back to the WebSocket. Both cannot be true: a user who followed the warning still sent `artModeControl` writes on every toggle. The option now gates reads and writes at both call sites.

## 2. One picture-mode change no longer writes twice on two channels

`async_select_picture_mode` sent the SmartThings command **and** the WebSocket key, always — even when the cloud write had been read back as applied. `async_set_picture_mode` now returns `True` / `None` / `False` and the key is sent unless the answer is `True`. (Not implicated in the reported TV: its automations touched art mode only.)

## 3. Art-mode writes: panel truth first, read-back after, no repeat of a write that did not take

This is the unbounded write pattern the audit found. Every path that puts a Frame into or out of Art Mode — the switch, and `_ensure_art_mode_ready`, which `art_select_image` and six other services go through — trusted a derived `art_mode_status` and then wrote, with **no check of what the panel shows, no read-back, and no memory of having just done the same thing**. `art_mode_status` comes from the IP flag (which can wedge — documented on this exact model), the WebSocket art channel (which can go stale — #153) or SmartThings. When it reads *off* while the panel shows art:

- before commit 1: an `artModeOn` at a panel already showing art, **on every automation run, forever**;
- after commit 1 (IP path off): the fallback sent `KEY_POWER` — which on a Frame **toggles the panel out of Art Mode onto HDMI** — then `set_artmode` ten seconds later to put it back. A full flap per run.

Four changes, applied to both writers:

1. **Panel truth before writing.** `getTVStates.pictureMode` is `"Ambient"` exactly while art is displayed, is a plain getter that needs only IP Control paired (not the art-mode option), and is independent of both the wedgeable flag and the WebSocket channel. If it already shows what was asked for, nothing is written and the stale reading is logged at WARNING.
2. **No power key at a Frame whose art channel says art is on.**
3. **A cooldown per intent**, shared per TV between the switch and the media player (`art_mode_guard.py`, pure Python). Only writes **not** read back as applied are remembered, so a user toggling art on, off with the remote, and on again is never blocked. A second unverified write of the same intent inside 60 s raises `ArtModeWriteSuppressed`; the switch's retry loops exit on it with one warning instead of N writes.
4. **Read-back after every write** — `pictureMode` after IP, `get_artmode()` after WebSocket — instead of `return True` on an accepted command.

## What this does not claim

None of it establishes that the integration caused hardware damage, and it is not offered as that. Nothing writes during polling; power, volume, mute and source are strict either/or. What the audit did find is that a wrong art-mode reading became a periodic, unverified, unbounded write against a firmware already in a bad state — and that is what commit 3 removes.

## Tests — 48 pass locally

- `tests/test_art_mode_write_guard.py` (16): the guard with a fake clock (first write allowed, verified never blocks, unverified blocks same intent only, lifts after cooldown, shared per entry); and structural checks that both writers check the panel **before** the cooldown **before** the write, read back after both write paths, skip the power key when the art channel says on, and that both retry loops handle the suppression before their generic `except`.
- `tests/test_art_mode_ip_gating.py` (5), `tests/test_picture_mode_single_write.py` (9), plus the existing suites.

black / flake8 / isort clean on `custom_components`. Version `8.7.9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2
