### PR TITLE
8.8.0 — stop polling sleeping TVs from two more entities, release notes

### DIFF
--- a/RELEASE_NOTES_8.8.0.md
+++ b/RELEASE_NOTES_8.8.0.md
@@ -50,6 +50,8 @@ writes. To stop *every* IP Control write to a TV you suspect, turn off
   nothing — contributed by [@alienpoop03](https://github.com/alienpoop03).
 - **Driving the TV like a remote is documented** — it always worked, nobody
   could find it.
+- **Two more entities stop reading sleeping TVs**, removing what became the
+  largest log producer once the poll overrun was fixed.
 
 ---
 
@@ -133,6 +135,26 @@ have achieved. The warning is kept where it still means something: a
 genuinely slow *reachable* TV warns at most once per five minutes, with the
 count it stands for.
 
+## Sleeping TVs, part two: the colour tone and backlight entities
+
+The same shape as above, one platform over, found by the same reporter on the
+same fleet. Five of the seven IP Control picture entities read through a
+shared coordinator that returns early when the TV is off or in Art Mode.
+**The colour-tone select and the backlight number polled independently and
+had no such gate**, so they kept opening a connection to a sleeping TV every
+30 s. Measured: 7.8 s for one such read, against 0.15 s awake — and because
+each takes the per-host lock on its own, two of them queued behind each other
+cross Home Assistant's 10 s per-entity threshold.
+
+That produced **6 019 `Update of <entity> is taking over 10 seconds` lines in
+21.4 hours** on a 13-TV install, the largest single log producer there once
+the sleeping-TV overrun was fixed. Correlation with time asleep: 0.81.
+
+Both now use the same gate as their five siblings, which is also why those
+five never produced a single warning. As a side effect, the speaker select's
+private copy of that gate is now the shared one — three definitions became
+one.
+
 ## Services that answer
 
 19 of the 26 services computed a result and were registered without
@@ -193,6 +215,11 @@ sequence can mix `ST_` and `IP_` source keys with remote keys.
   when the same action was just sent and did not take. Before, it was sent
   again silently. If you see that warning, the TV — not the automation —
   is the thing to look at.
+- **`Art Mode ON aborted …` is reworded.** It claimed more than it did: the
+  power-on request *had* been sent, and only the art-mode part was deferred.
+  It now says so, and repeats while a deferral is already outstanding drop to
+  INFO — a TV that simply wakes late used to produce one WARNING per attempt
+  all morning.
 
 ---
 

--- a/RELEASE_NOTES_8.8.0.md
+++ b/RELEASE_NOTES_8.8.0.md
@@ -1,0 +1,205 @@
+# Release notes — 8.8.0
+
+If this project is useful to you, you can support its development:
+
+# <a href="https://buymeacoffee.com/thefab21" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-black.png" alt="Buy Me A Coffee" height="41" width="174"></a>
+
+> **Status: stable release.** This note covers everything since **8.7.1**
+> (8.7.2 → 8.7.9 plus this release). Nothing to reconfigure. Two things may
+> change what you see in the log or in an automation — both are called out
+> below under [What may look different](#what-may-look-different).
+
+## ⚠️ If you disabled "Enable IP Control Art Mode" on our advice, read this
+
+Our README has long said: do not enable *Enable IP Control Art Mode* unless
+you know your firmware handles it — it can break Art Mode entirely and may
+need a factory reset (seen on a QE55LS03D). And it said that with the option
+off, Art Mode switching falls back to the WebSocket channel.
+
+**Until 8.7.7 that was only half true.** The option disabled the
+`artModeControl` *read*. Every Art Mode *write* — the Art Mode switch,
+`art_select_image`, and the six other services that put the TV into Art Mode
+first — still went to the TV over IP Control's JSON-RPC, on every toggle,
+including from automations. If you set the option off believing it protected
+you, it did not stop the traffic it was meant to stop.
+
+This was not hypothetical. One user with 11 Frames, every one with the option
+off precisely because of the warning, counted **237 Art Mode transitions in
+seven hours** that all took the IP Control write path anyway
+([#248](https://github.com/TheFab21/ha-samsungtv-smart/issues/248)).
+
+From 8.7.7, **off means no `artModeControl` traffic at all**, reads and
+writes. To stop *every* IP Control write to a TV you suspect, turn off
+**Enable IP Control** itself. Sorry — this was our gap, not yours.
+
+## Highlights
+
+- **Art Mode writes are now checked against the panel**, read back
+  afterwards, and never repeated blindly when they did not take. This closes
+  the one unbounded write pattern found in an audit of everything this
+  integration sends to a TV.
+- **Sleeping TVs no longer flood the log** — the two warnings per poll
+  (ours and Home Assistant core's) are gone at the source, measured
+  705/725 → 0/0.
+- **19 services can finally return data** — `art_get_current`,
+  `art_get_thumbnail`, `art_get_matte_list` and the rest computed a result
+  that Home Assistant threw away.
+- **`matte_id` is validated** before an upload, instead of letting the TV
+  store artwork it then cannot render.
+- **Browser launch over IP Control**, for TVs where the WebSocket path opens
+  nothing — contributed by [@alienpoop03](https://github.com/alienpoop03).
+- **Driving the TV like a remote is documented** — it always worked, nobody
+  could find it.
+
+---
+
+## Art Mode writes: panel truth first, read-back after, no blind repeats
+
+Every path that puts a Frame into or out of Art Mode trusted a *derived*
+`art_mode_status` — the IP Control flag (which can wedge, as the README
+documents), the WebSocket art channel (which can go stale), or
+SmartThings — and then wrote, with no check of what the panel showed, no
+read-back, and no memory of having just done the same thing.
+
+When that reading was wrong while the panel was in fact showing art, a
+periodic automation became a periodic write, indefinitely: an `artModeOn`
+sent to a panel already in Art Mode on every run — or, on the fallback path,
+a `KEY_POWER` that toggled the panel **out** of Art Mode onto HDMI and a
+`set_artmode` ten seconds later to put it back.
+
+Four changes, applied to both the Art Mode switch and the media player:
+
+1. **The panel is asked first.** `getTVStates.pictureMode` is `Ambient`
+   exactly while art is on screen. It is a plain getter that needs only IP
+   Control to be paired (not the Art Mode option) and is independent of both
+   the wedgeable flag and the WebSocket channel. If it already shows what
+   was asked for, nothing is written and the stale reading is logged.
+2. **No power key at a Frame whose art channel says art is on.**
+3. **A cooldown per intent**, shared per TV. Only writes that were *not*
+   read back as applied are remembered, so toggling art on, off with the
+   remote, and on again within a minute is never blocked. A second
+   unverified write of the same intent inside 60 s is refused with one
+   warning, and the retry loops stop instead of thrashing.
+4. **Every write is read back** — the panel after IP Control,
+   `get_artmode()` after the WebSocket — instead of trusting an accepted
+   command.
+
+Two new log lines are worth knowing, because they are the first measurement
+of something nobody had measured:
+
+```
+… art_mode_status reads off but the panel shows Ambient — the reading is stale; … NOT writing
+… art mode 'on' was already written 42s ago and did not take; not writing it again within 60s
+```
+
+The first means the Art Mode reading was wrong and the integration did *not*
+act on it. The second means the TV accepted a write and did not apply it. If
+you see either regularly, please say which model in
+[#248](https://github.com/TheFab21/ha-samsungtv-smart/issues/248) — it tells
+us how common the stale-reading case is in the wild.
+
+## One picture-mode change writes once
+
+`select_picture_mode` sent the SmartThings command **and** the WebSocket key,
+always — even when the cloud write had been read back as applied. The
+SmartThings side is itself a matrix of up to four verified sends, so one
+change could put five writes on the same subsystem within a second or two.
+
+The WebSocket key exists for a real reason: SmartThings answers COMPLETED
+while the TV shows "function not available" when HDMI content protection
+blocks the cloud command. It is still sent in every case where SmartThings
+could not be confirmed — no SmartThings, a failure, an unverifiable send. It
+is no longer sent when the cloud write was read back as applied.
+
+## Sleeping TVs and the slow-update warning
+
+A Frame in standby leaves the network entirely, so its power probe can only
+end in a timeout — and that timeout (6 s) was longer than the scan interval
+(5 s) it was racing. A sleeping TV therefore overran **every single poll**,
+by construction, and both this integration and Home Assistant core logged a
+warning each time: about 5 000 lines per day per sleeping TV, doubled.
+
+A TV already believed to be off now gets a 3 s probe, which finishes inside
+the interval. Polling cadence is unchanged, so nothing is detected later.
+Measured on a 13-TV install with the same two TVs asleep in both windows:
+
+| | 8.7.4 | 8.7.9 |
+|---|---:|---:|
+| `samsungtv_smart.media_player` warnings | 705 | **0** |
+| Home Assistant core warnings | 725 | **0** |
+
+Core's line went with ours, which is the part a log-level change could never
+have achieved. The warning is kept where it still means something: a
+genuinely slow *reachable* TV warns at most once per five minutes, with the
+count it stands for.
+
+## Services that answer
+
+19 of the 26 services computed a result and were registered without
+`supports_response`, so Home Assistant discarded it. Only `art_identify`,
+`art_upload` and `art_upload_batch` could ever answer. All 19 now can —
+`art_get_current`, `art_get_thumbnail`, `art_get_brightness`,
+`art_get_matte_list`, `art_available` and the rest. Existing calls that
+ignore the response are unaffected. Use a response variable, or run them
+from Developer Tools → Actions to see the result.
+
+`art_upload` also gains `show: true`, so upload-then-display is one call.
+
+## `matte_id` is validated
+
+A matte is `<type>_<color>` and both halves must exist on *your* TV — the
+lists differ by model, and the TV also has to pair them. An id built from a
+type and a colour the panel does not know used to be sent anyway; on a
+QN55LS03HEFXZA the TV stored the artwork and then crashed rendering it, which
+looked like a TV fault ([#243](https://github.com/TheFab21/ha-samsungtv-smart/issues/243)).
+
+`art_upload` now checks both halves against the TV's own lists first and
+refuses with a message naming what is wrong and what the TV offers.
+(`art_upload_batch` does not validate yet — it takes the same `matte_id`, and
+that gap is on the list.) If the lists cannot be read, the upload proceeds as before —
+validation never blocks something that would have worked. Call
+`art_get_matte_list` (which now returns its lists) to see what your TV
+accepts.
+
+## Browser launch over IP Control
+
+`media_player.play_media` with `media_content_type: browser` uses
+`directAccessControl` with `applicationName: "webBrowser"` when IP Control is
+paired, and falls back to the WebSocket launch otherwise. On a QE65Q80TATXZT
+the WebSocket path opened nothing; the IP Control path opens the browser at
+the URL. The TV never reports which page it actually opened, so the INFO
+line names the URL that was requested — that is the one fact that makes a
+"wrong page" report diagnosable. Contributed by
+[@alienpoop03](https://github.com/alienpoop03).
+
+## Driving the TV like a remote
+
+Asked for as a feature in
+[#246](https://github.com/TheFab21/ha-samsungtv-smart/issues/246); it has
+existed for years. The README now has a section on `remote.send_command`
+with a key list and repeat count, a table of the navigation keys (D-pad,
+Enter, Return, Home, Info, Menu, Guide, Exit…), and the two things that were
+implemented but documented nowhere: a **millisecond delay step** inside a
+`+`-joined sequence (`KEY_HOME+1500+KEY_RIGHT+KEY_ENTER`), and that such a
+sequence can mix `ST_` and `IP_` source keys with remote keys.
+
+## What may look different
+
+- **An `art_upload` with a `matte_id` your TV does not list now fails**
+  with a clear error instead of succeeding and producing artwork the TV
+  cannot show. If an automation used such an id, it will start reporting
+  an error — that is the TV telling you the truth earlier.
+- **An Art Mode action can now be refused for up to 60 s**, with a WARNING,
+  when the same action was just sent and did not take. Before, it was sent
+  again silently. If you see that warning, the TV — not the automation —
+  is the thing to look at.
+
+---
+
+## Upgrading
+
+HACS → update → restart Home Assistant. Nothing to reconfigure.
+
+If you disabled **Enable IP Control Art Mode** believing it stopped IP
+Control Art Mode writes: it does now. If you want to stop every IP Control
+write to a particular TV, turn off **Enable IP Control** on that entry.

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.7.9"
+  "version": "8.8.0"
 }

--- a/custom_components/samsungtv_smart/number.py
+++ b/custom_components/samsungtv_smart/number.py
@@ -292,6 +292,22 @@ class SamsungTVIPControlBacklightNumber(NumberEntity):
 
     async def async_update(self) -> None:
         """Read current picture backlight from IP Control."""
+        # Guardrail, same as the coordinator-backed picture sliders: backlight
+        # applies to normal viewing only and answers -32601 in Art Mode, so a
+        # read while the TV is off or showing art is pointless. It is also
+        # expensive: on a TV that has left the network the connection attempt
+        # costs CMD_TIMEOUT plus the weak-DH retry (~7.8 s measured), and this
+        # entity polls independently of the video coordinator, taking the
+        # per-host lock on its own. Two such entities per TV queued behind each
+        # other is what pushed single updates past Home Assistant's 10 s
+        # per-entity threshold — 1 626 core warnings in 21 h on a 13-TV install
+        # (#248). The coordinator-backed sliders never produced one, because
+        # the coordinator returns early on exactly this condition.
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None or not _tv_normal_viewing(self.hass, entry):
+            self._mark_unavailable()
+            return
+
         client = self._get_ip_control()
         if client is None:
             self._mark_unavailable()

--- a/custom_components/samsungtv_smart/select.py
+++ b/custom_components/samsungtv_smart/select.py
@@ -471,6 +471,28 @@ async def _load_motion_options(
 # ══════════════════════════════════════════════════════════════════════════
 
 
+def _tv_normal_viewing(hass: HomeAssistant, entry_id: str) -> bool:
+    """True when the TV is on for normal viewing (not off, not Art Mode).
+
+    The IP Control picture and speaker methods answer -32601 outside normal
+    viewing, so polling them while the TV is off or showing art is pointless —
+    and on a TV that has left the network it is expensive: the connection
+    attempt costs CMD_TIMEOUT plus the weak-DH retry, ~7.8 s measured, against
+    0.15 s awake. Entities that poll independently take the per-host lock one
+    after another, so two of them are enough to push a single update past Home
+    Assistant's 10 s per-entity threshold (#248).
+    """
+    registry = er.async_get(hass)
+    for entity in registry.entities.get_entries_for_config_entry_id(entry_id):
+        if entity.domain != "media_player":
+            continue
+        state = hass.states.get(entity.entity_id)
+        if state is None or state.state in (STATE_OFF, "unavailable", "unknown"):
+            return False
+        return state.attributes.get("art_mode_status") != "on"
+    return False
+
+
 class SamsungTVIPControlColorToneSelect(SelectEntity):
     """Select entity for the IP Control picture color tone."""
 
@@ -578,6 +600,14 @@ class SamsungTVIPControlColorToneSelect(SelectEntity):
 
     async def async_update(self) -> None:
         """Read current picture color tone from IP Control."""
+        # See _tv_normal_viewing: this entity polls on its own rather than
+        # through IPControlVideoCoordinator, so without this gate it kept
+        # reading a sleeping TV every 30 s at ~7.8 s a time — 4 392 core
+        # warnings in 21 h on a 13-TV install (#248).
+        if not _tv_normal_viewing(self.hass, self._entry_id):
+            self._mark_unavailable()
+            return
+
         client = self._get_ip_control()
         if client is None:
             self._mark_unavailable()
@@ -703,15 +733,7 @@ class SamsungTVIPControlSpeakerSelect(SelectEntity):
         and only allow switching — during normal viewing. Field-observed: 50
         pointless -32601 reads per art session before this gate.
         """
-        registry = er.async_get(self.hass)
-        for entity in registry.entities.get_entries_for_config_entry_id(self._entry_id):
-            if entity.domain != "media_player":
-                continue
-            state = self.hass.states.get(entity.entity_id)
-            if state is None or state.state in (STATE_OFF, "unavailable", "unknown"):
-                return False
-            return state.attributes.get("art_mode_status") != "on"
-        return False
+        return _tv_normal_viewing(self.hass, self._entry_id)
 
     def _rebuild_options(self) -> None:
         """Options = fixed public targets + currently listed external devices."""

--- a/custom_components/samsungtv_smart/switch.py
+++ b/custom_components/samsungtv_smart/switch.py
@@ -477,7 +477,10 @@ class FrameArtModeSwitch(SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn Art Mode on."""
         self._log.debug("Turning Art Mode ON for %s", self._device_name)
-        # A fresh explicit attempt supersedes any earlier deferred one.
+        # A fresh explicit attempt supersedes any earlier deferred one. Keep
+        # whether one was outstanding: it distinguishes the first failure to
+        # reach a TV from the repeats of a caller that keeps asking.
+        was_pending = self._pending_art_on
         self._pending_art_on = False
 
         # Short-circuit: if already in Art Mode, nothing to do.
@@ -519,10 +522,24 @@ class FrameArtModeSwitch(SwitchEntity):
             # command on an off Salon TV — issue #116 follow-up).
             tv_was_off = True
             if not await self._wait_for_tv_ready(max_wait=20):
-                self._log.warning(
-                    "Art Mode ON aborted for %s: TV did not become reachable "
-                    "after power-on (likely off the network) — will re-apply "
-                    "when the TV comes back online",
+                # Say what actually happened: the power-on WAS sent (WOL, or
+                # KEY_POWER / IP Control powerOn depending on the configured
+                # method) and the TV did not answer within 20 s. Only the art
+                # mode part is deferred.
+                #
+                # Repeat calls are logged at INFO. An automation that asks
+                # every few minutes re-enters here each time — and because the
+                # top of this method clears _pending_art_on, each call also
+                # cancels the previous deferral — so a TV that wakes late
+                # produced one WARNING per attempt for an entirely normal
+                # morning (11 in 50 minutes on a TV whose usual wake time is
+                # 05:51-08:10, #248). The first is worth a warning; the rest
+                # are the deferral working.
+                log = self._log.info if was_pending else self._log.warning
+                log(
+                    "Art Mode ON for %s: the TV did not answer within 20s of "
+                    "the power-on request (likely in deep standby / off the "
+                    "network) — art mode deferred until it is back online",
                     self._device_name,
                 )
                 # Defer instead of hammering: re-apply once the media_player

--- a/tests/test_ip_control_poll_gating.py
+++ b/tests/test_ip_control_poll_gating.py
@@ -1,0 +1,140 @@
+"""Independently-polling IP Control entities must not read a sleeping TV.
+
+The picture sliders that go through IPControlVideoCoordinator never read a TV
+that is off or in Art Mode: the coordinator returns early. The colour-tone
+select and the backlight number poll on their own and had no such gate, so
+they kept opening connections to sleeping TVs every 30 s — ~7.8 s each,
+against 0.15 s awake — and, queued behind each other on the per-host lock,
+crossed Home Assistant's 10 s per-entity threshold: 6 019 core warnings in
+21.4 hours on a 13-TV install (#248).
+"""
+
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).parents[1] / "custom_components" / "samsungtv_smart"
+SELECT = (ROOT / "select.py").read_text()
+NUMBER = (ROOT / "number.py").read_text()
+
+
+def _block(source: str, start: str, end: str) -> str:
+    begin = source.index(start)
+    return source[begin : source.index(end, begin)]
+
+
+def _update_body(source: str, class_decl: str) -> str:
+    """The async_update body of the class beginning at class_decl."""
+    cls = source[source.index(class_decl) :]
+    body = cls[cls.index("    async def async_update") :]
+    end = body.index("\n    def ", 1) if "\n    def " in body[1:] else len(body)
+    return body[:end]
+
+
+class ColorToneSelectTest(unittest.TestCase):
+    """select.<tv>_color_tone — 4 392 of the warnings."""
+
+    def setUp(self):
+        self.body = _update_body(
+            SELECT, "class SamsungTVIPControlColorToneSelect(SelectEntity):"
+        )
+
+    def test_the_gate_runs_before_any_client_is_obtained(self):
+        gate = self.body.index("_tv_normal_viewing(self.hass, self._entry_id)")
+        client = self.body.index("self._get_ip_control()")
+        self.assertLess(gate, client)
+
+    def test_a_gated_poll_marks_the_entity_unavailable(self):
+        gate = self.body.index("_tv_normal_viewing")
+        client = self.body.index("self._get_ip_control()")
+        self.assertIn("self._mark_unavailable()", self.body[gate:client])
+
+    def test_the_entity_still_polls(self):
+        # The gate must not be achieved by simply disabling polling.
+        cls = SELECT[SELECT.index("class SamsungTVIPControlColorToneSelect") :]
+        self.assertIn("_attr_should_poll = True", cls[: cls.index("def __init__")])
+
+
+class BacklightNumberTest(unittest.TestCase):
+    """number.<tv>_backlight — the other 1 626."""
+
+    def setUp(self):
+        self.body = _update_body(
+            NUMBER, "class SamsungTVIPControlBacklightNumber(NumberEntity):"
+        )
+
+    def test_the_gate_runs_before_any_client_is_obtained(self):
+        gate = self.body.index("_tv_normal_viewing(self.hass, entry)")
+        client = self.body.index("self._get_ip_control()")
+        self.assertLess(gate, client)
+
+    def test_a_missing_config_entry_is_treated_as_not_viewing(self):
+        self.assertIn("entry is None or not _tv_normal_viewing", self.body)
+
+    def test_a_gated_poll_marks_the_entity_unavailable(self):
+        gate = self.body.index("_tv_normal_viewing")
+        client = self.body.index("self._get_ip_control()")
+        self.assertIn("self._mark_unavailable()", self.body[gate:client])
+
+
+class SharedHelperTest(unittest.TestCase):
+    """One definition of "normal viewing" per module, not three."""
+
+    def test_select_defines_the_gate_once_at_module_level(self):
+        self.assertIn(
+            "def _tv_normal_viewing(hass: HomeAssistant, entry_id: str)", SELECT
+        )
+        # The speaker select had its own copy; it must delegate now.
+        speaker_gate = _block(
+            SELECT,
+            "    def _tv_normal_viewing(self) -> bool:",
+            "    def _rebuild_options",
+        )
+        self.assertIn(
+            "return _tv_normal_viewing(self.hass, self._entry_id)", speaker_gate
+        )
+        self.assertNotIn("registry = er.async_get(self.hass)", speaker_gate)
+
+    def test_the_gate_excludes_off_unavailable_unknown_and_art(self):
+        helper = _block(
+            SELECT,
+            "def _tv_normal_viewing(hass: HomeAssistant, entry_id: str)",
+            "class SamsungTVIPControlColorToneSelect",
+        )
+        for token in ("STATE_OFF", '"unavailable"', '"unknown"', "art_mode_status"):
+            self.assertIn(token, helper)
+
+
+class ArtModeAbortMessageTest(unittest.TestCase):
+    """The deferral message must describe what actually happened."""
+
+    def setUp(self):
+        self.block = _block(
+            (ROOT / "switch.py").read_text(),
+            "            tv_was_off = True",
+            "            # Additional delay for TV Art subsystem",
+        )
+
+    def test_it_no_longer_claims_nothing_was_sent(self):
+        # The power-on WAS sent before this point; only art mode is deferred.
+        self.assertNotIn("Art Mode ON aborted", self.block)
+        self.assertIn("did not answer within 20s of", self.block)
+        self.assertIn("art mode deferred", self.block)
+
+    def test_repeats_drop_to_info_while_a_deferral_is_outstanding(self):
+        self.assertIn(
+            "log = self._log.info if was_pending else self._log.warning", self.block
+        )
+
+    def test_the_outstanding_deferral_is_captured_before_being_cleared(self):
+        turn_on = _block(
+            (ROOT / "switch.py").read_text(),
+            "    async def async_turn_on(self, **kwargs",
+            "        # Check if TV is on",
+        )
+        captured = turn_on.index("was_pending = self._pending_art_on")
+        cleared = turn_on.index("self._pending_art_on = False")
+        self.assertLess(captured, cleared)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two commits: the follow-up ajguerre1 found on his fleet after #249, and the 8.8.0 release notes covering everything since 8.7.1.

## 1. The colour-tone and backlight entities were reading sleeping TVs

Same shape as #248, one platform over. After #249 removed the poll overrun, the largest log producer on his 13-TV install became **6 019 `Update of <entity> is taking over 10 seconds` lines in 21.4 hours** — every one naming `select.*_color_tone` (4 392) or `number.*_backlight` (1 626). Correlation with time asleep: **0.81**. His measurements:

| entity | TV state | seconds |
|---|---|---:|
| `select.<tv>_color_tone` | on | 0.15 |
| `number.<tv>_backlight` | on | 0.15 |
| `select.<tv>_color_tone` | **off** | **7.79** |

**Why only these two.** Five of the seven IP Control picture entities go through `IPControlVideoCoordinator`, which returns `{}` without issuing a request when `_tv_normal_viewing()` is false. These two poll independently (`_attr_should_poll = True`, their own `async_update`) and had no such gate, so each opened its own connection to a sleeping TV every 30 s — `CMD_TIMEOUT` plus the weak-DH retry — and, taking the per-host lock separately, two of them queued behind each other cross core's 10 s per-entity threshold. That is precisely why the coordinator-backed siblings never produced one.

Both now use the same gate. The picture and speaker methods answer `-32601` outside normal viewing anyway, so nothing is lost. `select.py` also had **three copies** of that predicate; they become one module-level helper.

**A note on the two directions he proposed:** moving these onto `IPControlVideoCoordinator` (his option 1) would not have helped — `getVideoStates` carries neither `backlight` nor `colorTone`; they are separate getters (`backlightControl`, `colorToneControl`), so no request would be saved. The gate is the smaller and correct fix.

## 2. The art-mode deferral message claimed more than it did

He read his eleven `Art Mode ON aborted … TV did not become reachable` lines as eleven writes that did **not** happen, and credited 8.7.9. Both halves are wrong, and worth correcting in the log rather than in a reply he has to remember:

- that abort predates 8.7.9 — it is the `_wait_for_tv_ready` bail-out from the #116 follow-up;
- and `_turn_on_tv()` runs **before** it, so each of the eleven attempts *did* send a power-on (WOL, or `KEY_POWER` / IP Control `powerOn` per the configured method). Only the art-mode part was deferred.

The message now says that. And because the top of `async_turn_on` clears `_pending_art_on`, a caller that asks every few minutes cancels its own deferral each time and re-enters this path — so a TV whose normal wake window is 05:51–08:10 produced 11 WARNINGs in 50 minutes for behaving normally. Repeats while a deferral is outstanding now log at INFO; the first still warns.

## 3. Release notes for 8.8.0

`RELEASE_NOTES_8.8.0.md`, covering 8.7.2 → 8.7.9 plus this. Top item is the one he asked for: until 8.7.7, disabling **Enable IP Control Art Mode** stopped only the reads, so anyone who set it off on the README's advice was not protected — with his field count (237 art-mode transitions across 11 Frames in seven hours, all on the write path). A **What may look different** section names the three user-visible changes.

## Tests

`tests/test_ip_control_poll_gating.py` — 11 cases: the gate runs before any client is obtained in both entities, a gated poll marks the entity unavailable, the entities still poll (the gate must not be achieved by disabling polling), the shared helper is defined once and still excludes off/unavailable/unknown/art, and the reworded message with its INFO-on-repeat behaviour, including that `was_pending` is captured before `_pending_art_on` is cleared.

59 tests pass; black / flake8 / isort clean. Version `8.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2
