### PR TITLE
docs: bring the README introduction up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,22 @@ If this project is useful to you, you can support its development:
 
 <a href="https://buymeacoffee.com/thefab21" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-black.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
-This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode support, picture mode and source selection fixes for 2024 Frame TVs, and OAuth2 authentication for SmartThings.
+**What this fork adds.** It began as a handful of Frame TV fixes and grew a
+second control channel. Next to the WebSocket and SmartThings paths it now
+speaks Samsung's local **IP Control** (JSON-RPC), so power, input, volume,
+picture calibration, speaker output and a reboot button work without the
+cloud — on 2020+ sets and on older ones, which use a different port that is
+tried automatically.
+
+On a **Frame** it adds Art Mode proper: browse and upload artwork, mattes,
+slideshow, brightness and colour temperature, a gallery card and an upload
+card, uploads re-encoded to suit the panel — and optional **artwork
+identification**, which tells you the title, artist and date of what is on
+your wall, in five languages.
+
+Everywhere: **OAuth2** for SmartThings (or a token, or your existing
+SmartThings integration), a self-healing art WebSocket, and per-TV polling
+you can tune.
 
 ---
 


### PR DESCRIPTION
README only, one paragraph replaced.

## What was stale

The fork was still summarised in a single sentence:

> This fork brings improved WebSocket stability, full Samsung Frame TV Art Mode support, picture mode and source selection fixes for 2024 Frame TVs, and OAuth2 authentication for SmartThings.

Accurate several versions ago, and silent on everything since — the whole IP Control channel, artwork identification, the bundled cards, the pre-2020 support, the tunable polling.

## What it says now

Three short paragraphs: the local IP Control channel alongside WebSocket and SmartThings (power, input, volume, picture calibration, speaker output, reboot — no cloud); the Frame Art Mode feature set with the two cards, panel-aware upload re-encoding and optional artwork identification; and the cross-cutting items — three SmartThings authentication methods, self-healing art WebSocket, per-TV polling.

## Two deliberate restraints

- **No model-year range invented.** It says "2020+ sets and older ones, which use a different port that is tried automatically", not "since 2017" or "since 2013". We have one measurement on a 2018 set (#206), one on a 2013 set (#238) and a 2017 driver profile — enough to try both ports, not enough to promise a range to strangers. That class of claim is exactly what needed retracting three times in `IP_Control_Protocol_Reference.md` recently (#235, #239, #240).
- **Nothing broader than the body of the README.** Every item named has its own documented section further down.

The ollo69 credit and the support button are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_