### PR TITLE
8.8.2 — tolerate an isolated -32002 on a state read (+ defensive sw_version coercion)

### DIFF
--- a/custom_components/samsungtv_smart/entity.py
+++ b/custom_components/samsungtv_smart/entity.py
@@ -42,8 +42,19 @@ class SamsungTVEntity(Entity):
         )
         if self.unique_id:
             self._attr_device_info[ATTR_IDENTIFIERS] = {(DOMAIN, self.unique_id)}
+        # CONF_DEVICE_OS is stored verbatim from the TV's REST payload
+        # (device.OS), so its type is whatever the firmware sent. The device
+        # registry accepts only a string, and passing anything else has been
+        # deprecated since Home Assistant 2026.x — it stops working in
+        # 2026.12.0. Some payloads carry a list; join it rather than dropping
+        # the information, and stringify anything else.
         if dev_os := config.get(CONF_DEVICE_OS):
-            self._attr_device_info[ATTR_SW_VERSION] = dev_os
+            if isinstance(dev_os, (list, tuple, set)):
+                dev_os = ", ".join(str(part) for part in dev_os)
+            elif not isinstance(dev_os, str):
+                dev_os = str(dev_os)
+            if dev_os:
+                self._attr_device_info[ATTR_SW_VERSION] = dev_os
         if self._mac:
             self._attr_device_info[ATTR_CONNECTIONS] = {
                 (CONNECTION_NETWORK_MAC, self._mac)

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.8.0"
+  "version": "8.8.1"
 }

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.8.1"
+  "version": "8.8.2"
 }

--- a/custom_components/samsungtv_smart/sensor.py
+++ b/custom_components/samsungtv_smart/sensor.py
@@ -47,6 +47,7 @@ from .api.ipcontrol import (
     SamsungIPControl,
     SamsungIPControlAuthError,
     SamsungIPControlError,
+    SamsungIPControlModeLockedError,
     SamsungIPControlTransportError,
     SamsungIPControlUnsupportedError,
 )
@@ -2628,6 +2629,17 @@ class SmartThingsPowerConsumptionSensor(CoordinatorEntity, SensorEntity):
             return None
 
 
+# Consecutive -32002 answers tolerated on a state READ before it is reported as
+# a coordinator failure. The TV returns this for a read it momentarily refuses;
+# our own message calls it "usually transient", and it is — measured as isolated
+# single occurrences a few times a day on healthy TVs, each recovering on the
+# next cycle. Raising UpdateFailed on the first one logs an ERROR for a normal
+# condition, the same mistake #248 fixed for the sleeping-TV overrun. A run of
+# them is different: that is a TV stuck in a state it will not read from, and
+# worth an ERROR.
+IP_CONTROL_READ_TRANSIENT_TOLERANCE = 3
+
+
 class IPControlStateCoordinator(DataUpdateCoordinator):
     """Polls getTVStates over IP Control for the read-only state sensors.
 
@@ -2660,6 +2672,8 @@ class IPControlStateCoordinator(DataUpdateCoordinator):
         self._ip_control: SamsungIPControl | None = None
         self._ip_control_token: str | None = None
         self._channel_control_supported: bool | None = None
+        # Consecutive -32002 answers on getTVStates; see the constant above.
+        self._transient_read_failures = 0
 
     def _device_title(self) -> str:
         entry = self.hass.config_entries.async_get_entry(self._entry.entry_id)
@@ -2780,9 +2794,31 @@ class IPControlStateCoordinator(DataUpdateCoordinator):
                 "IP Control state: transport failure (TV likely off): %s", ex
             )
             return {"tv": {}, "powered_off": True}
+        except SamsungIPControlModeLockedError as ex:
+            # -32002 on a READ: the TV refused it in its current state. Isolated
+            # occurrences are normal and recover on the next cycle, so hold the
+            # previous snapshot instead of failing the coordinator. Only a run
+            # of them means something is actually wrong.
+            self._transient_read_failures += 1
+            if self._transient_read_failures <= IP_CONTROL_READ_TRANSIENT_TOLERANCE:
+                self._log.debug(
+                    "IP Control state read refused (%s) — attempt %d of %d "
+                    "tolerated, keeping the previous snapshot",
+                    ex,
+                    self._transient_read_failures,
+                    IP_CONTROL_READ_TRANSIENT_TOLERANCE,
+                )
+                if self.data is not None:
+                    return self.data
+                return {"tv": {}, "channel": {}, "powered_off": False}
+            raise UpdateFailed(
+                f"IP Control state read refused {self._transient_read_failures} "
+                f"times in a row: {ex}"
+            ) from ex
         except SamsungIPControlError as ex:
             raise UpdateFailed(f"IP Control state read failed: {ex}") from ex
 
+        self._transient_read_failures = 0
         clear_token_problem(self.hass, self._entry.entry_id, METHOD_IP_CONTROL)
         return {
             "tv": tv_states,

--- a/tests/test_device_sw_version.py
+++ b/tests/test_device_sw_version.py
@@ -1,0 +1,88 @@
+"""sw_version must reach the device registry as a string.
+
+CONF_DEVICE_OS is stored verbatim from the TV's REST payload (`device.OS`),
+so its type is whatever the firmware sent. Home Assistant's device registry
+accepts only a string; anything else is deprecated and stops working in
+2026.12.0:
+
+    Detected code that passes a non-string value of type list as sw_version
+    to the device registry. This will stop working in Home Assistant 2026.12.0
+
+The entity is not importable without Home Assistant, so the coercion is
+exercised by compiling that block on its own.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+ROOT = Path(__file__).parents[1] / "custom_components" / "samsungtv_smart"
+ENTITY = (ROOT / "entity.py").read_text()
+
+
+def _coerce(value):
+    """Run the module's own coercion on one value.
+
+    Extracted from the source rather than reimplemented, so the test fails if
+    the real code changes shape.
+    """
+    block = ENTITY[ENTITY.index("        if dev_os := config.get(CONF_DEVICE_OS):") :]
+    block = block[: block.index("        if self._mac:")]
+    body = "\n".join(line[8:] for line in block.split("\n"))
+    body = body.replace(
+        "if dev_os := config.get(CONF_DEVICE_OS):", "if dev_os := config.get('x'):"
+    ).replace(
+        "self._attr_device_info[ATTR_SW_VERSION] = dev_os", "result['sw'] = dev_os"
+    )
+    namespace = {"config": {"x": value}, "result": {}}
+    exec(compile(body, "entity_sw_version", "exec"), namespace)
+    return namespace["result"].get("sw")
+
+
+class CoercionTest(unittest.TestCase):
+    """Whatever the firmware sent, the registry gets a string or nothing."""
+
+    def test_a_plain_string_is_unchanged(self):
+        self.assertEqual(_coerce("Tizen"), "Tizen")
+
+    def test_a_list_is_joined_not_dropped(self):
+        # The reported case. Keep the information rather than discarding it.
+        self.assertEqual(_coerce(["Tizen"]), "Tizen")
+        self.assertEqual(_coerce(["Tizen", "9.0"]), "Tizen, 9.0")
+
+    def test_a_tuple_is_joined_too(self):
+        self.assertEqual(_coerce(("Tizen", "9.0")), "Tizen, 9.0")
+
+    def test_a_number_becomes_a_string(self):
+        self.assertEqual(_coerce(9), "9")
+
+    def test_falsy_values_set_nothing(self):
+        for value in (None, "", [], 0):
+            self.assertIsNone(_coerce(value), value)
+
+    def test_the_result_is_always_a_string_or_absent(self):
+        for value in ("Tizen", ["a", "b"], ("a",), 9, 9.5, {"a"}):
+            out = _coerce(value)
+            self.assertIsInstance(out, str, value)
+
+
+class SourceTest(unittest.TestCase):
+    """The guard must stay in front of the only assignment."""
+
+    def test_sw_version_is_assigned_exactly_once(self):
+        self.assertEqual(
+            len(re.findall(r"ATTR_SW_VERSION\]\s*=", ENTITY)),
+            1,
+            "a second assignment would bypass the coercion",
+        )
+
+    def test_the_assignment_is_guarded_by_the_type_checks(self):
+        block = ENTITY[ENTITY.index("if dev_os := config.get(CONF_DEVICE_OS):") :]
+        block = block[: block.index("if self._mac:")]
+        coercion = block.index("isinstance(dev_os, (list, tuple, set))")
+        assignment = block.index("ATTR_SW_VERSION")
+        self.assertLess(coercion, assignment)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ip_control_read_tolerance.py
+++ b/tests/test_ip_control_read_tolerance.py
@@ -1,0 +1,113 @@
+"""A -32002 on a state read is transient until it repeats.
+
+The TV answers -32002 ("refused in its current state") to an occasional
+getTVStates. Our own message calls it "usually transient", and two maintainer
+logs bear that out: 6 isolated occurrences in 67.8 h, then 5 in 25.6 h across
+two TVs, each recovering on the next cycle. Raising UpdateFailed on the first
+one logs an ERROR for a normal condition — the mistake #248 fixed for the
+sleeping-TV overrun. A run of them is a different thing and still fails.
+
+Structural, like the other coordinator tests: sensor.py cannot be imported
+without Home Assistant.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+ROOT = Path(__file__).parents[1] / "custom_components" / "samsungtv_smart"
+SENSOR = (ROOT / "sensor.py").read_text()
+IPCONTROL = (ROOT / "api" / "ipcontrol.py").read_text()
+
+
+def _block(source: str, start: str, end: str) -> str:
+    begin = source.index(start)
+    return source[begin : source.index(end, begin)]
+
+
+class ExceptionContractTest(unittest.TestCase):
+    """The handler only works if -32002 really arrives as ModeLockedError."""
+
+    def test_minus_32002_raises_mode_locked_for_reads_too(self):
+        block = _block(
+            IPCONTROL,
+            "            if code == ERROR_SERVER:",
+            "            if code == ERROR_METHOD_NOT_FOUND:",
+        )
+        # Both the picture-write branch and the fallback raise the same class;
+        # only the message differs. If that ever changes, the coordinator's
+        # tolerance silently stops applying to reads.
+        self.assertEqual(block.count("raise SamsungIPControlModeLockedError("), 2)
+        self.assertIn("usually transient", block)
+
+    def test_the_coordinator_imports_that_exception(self):
+        self.assertIn("SamsungIPControlModeLockedError", SENSOR.split("class ")[0])
+
+
+class ToleranceTest(unittest.TestCase):
+    """The state coordinator holds its snapshot for a few refusals."""
+
+    def setUp(self):
+        self.block = _block(
+            SENSOR,
+            "        except SamsungIPControlModeLockedError as ex:",
+            "\n        clear_token_problem(",
+        )
+
+    def test_the_specific_handler_precedes_the_generic_one(self):
+        specific = SENSOR.index("except SamsungIPControlModeLockedError as ex:")
+        generic = SENSOR.index(
+            'except SamsungIPControlError as ex:\n            raise UpdateFailed(f"IP Control state read failed'
+        )
+        self.assertLess(specific, generic)
+
+    def test_a_tolerated_refusal_does_not_raise(self):
+        head = self.block[: self.block.index("raise UpdateFailed")]
+        self.assertIn("self._transient_read_failures += 1", head)
+        self.assertIn("<= IP_CONTROL_READ_TRANSIENT_TOLERANCE", head)
+        self.assertIn("self._log.debug(", head)
+        self.assertNotIn("self._log.error", head)
+
+    def test_it_keeps_the_previous_snapshot_when_there_is_one(self):
+        self.assertIn("if self.data is not None:", self.block)
+        self.assertIn("return self.data", self.block)
+
+    def test_it_has_a_first_refresh_fallback(self):
+        # self.data is None before the first successful update.
+        self.assertIn(
+            'return {"tv": {}, "channel": {}, "powered_off": False}', self.block
+        )
+
+    def test_a_run_of_refusals_still_fails_the_coordinator(self):
+        tail = self.block[self.block.index("raise UpdateFailed") :]
+        self.assertIn("times in a row", tail)
+
+    def test_the_counter_resets_after_a_successful_read(self):
+        after = SENSOR[
+            SENSOR.index(
+                '        except SamsungIPControlError as ex:\n            raise UpdateFailed(f"IP Control state read failed'
+            ) :
+        ]
+        reset = after.index("self._transient_read_failures = 0")
+        clear = after.index("clear_token_problem(")
+        self.assertLess(reset, clear)
+
+    def test_the_tolerance_is_small_and_declared_once(self):
+        value = re.search(
+            r"^IP_CONTROL_READ_TRANSIENT_TOLERANCE = (\d+)$", SENSOR, re.M
+        )
+        self.assertIsNotNone(value)
+        self.assertLessEqual(int(value.group(1)), 5)
+        self.assertEqual(SENSOR.count("IP_CONTROL_READ_TRANSIENT_TOLERANCE = "), 1)
+
+    def test_the_counter_is_initialised(self):
+        init = _block(
+            SENSOR,
+            "        self._channel_control_supported: bool | None = None",
+            "\n    def ",
+        )
+        self.assertIn("self._transient_read_failures = 0", init)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two changes. The first is a real fix from measured logs; the second is defensive hardening — see its note.

## 1. An isolated `-32002` on a state read is no longer an ERROR

`getTVStates` occasionally answers `-32002`, and the message we ship for it already says what it is:

> the TV refused it in its current state; **usually transient**

The coordinator nevertheless turned the first occurrence into `UpdateFailed`, which Home Assistant logs at ERROR.

**Measured**, two windows from the same install:

| window | duration | occurrences | pattern |
|---|---|---:|---|
| 8.8.0, one TV | 67.8 h | **6** | all isolated, each recovered next cycle |
| after a second TV was re-added | 25.6 h | **5** | isolated, now on both TVs |

Never a run, never a user-visible consequence — an ERROR per event for something that fixes itself in one poll. Same shape as #248: a normal condition logged as a fault.

`IPControlStateCoordinator` now catches `SamsungIPControlModeLockedError` before the generic handler and tolerates up to **3 consecutive** refusals, holding its previous snapshot and logging at debug, so sensors keep their last values instead of flickering unavailable. Any successful read resets the counter; a longer run still raises `UpdateFailed`, naming how many times in a row — that means a TV genuinely stuck, and is worth an ERROR.

**One dependency worth pinning:** this hinges on `-32002` arriving as `SamsungIPControlModeLockedError`. It does — `ipcontrol.py` raises that class in *both* branches of `if code == ERROR_SERVER:`, differing only in message. That is easy to "tidy" into a generic error later, at which point the tolerance would silently stop applying to reads with no test failing. A test asserts both raises are present.

## 2. `sw_version` reaches the device registry as a string — defensive only

**This does not fix the warning that prompted it.** That one was traced to a Home Assistant *core* integration:

```
Detected that integration 'ipp' passes a non-string value of type list as
sw_version to the device registry at homeassistant/components/ipp/sensor.py,
line 126
```

Nothing to do with this integration. Included here anyway on its own merits: `CONF_DEVICE_OS` is stored verbatim from the TV's REST payload (`device.OS`) and handed straight to `DeviceInfo`, so its type is whatever the firmware sent. From Home Assistant 2026.12 a non-string in that field raises rather than warns — a hard failure at device registration, on a value we do not control and have never validated.

Now coerced before assignment: a list/tuple/set is **joined** so the information is kept rather than dropped, anything else is stringified, an empty result sets nothing.

No Samsung payload is known to send a list here — every one observed sends a plain string such as `"Tizen"`. Reviewer's call whether four lines of guard against a future hard failure are worth keeping; happy to drop this commit if not.

## Tests

- `tests/test_ip_control_read_tolerance.py` — 10 cases: the exception contract, handler ordering, a tolerated refusal neither raising nor logging above debug, the previous snapshot kept (with a first-refresh fallback), a run still failing, the counter reset placed before `clear_token_problem`, and the tolerance small and declared once.
- `tests/test_device_sw_version.py` — 8 cases. The coercion is **extracted from the source and executed**, not reimplemented, so the test fails if the real block changes shape.

98 unittest tests pass. The 8 collection errors under `tests/` are pre-existing pytest files needing `aiohttp` / `pytest_homeassistant_custom_component`, which neither this container nor CI installs.

black / flake8 / isort clean on `custom_components`. Version `8.8.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2
