### PR TITLE
fix(art): stop reporting a thumbnail as failed while it is still being retried

### DIFF
--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.8.2"
+  "version": "8.8.3"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -750,6 +750,10 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         # Current physical input reported by the shared getTVStates coordinator.
         # Also updated optimistically after a successful local source change.
         self._ip_input_source: str | None = None
+        # Content ids whose thumbnail is still being retried in the
+        # background after an upload; a failed fetch for one of these is an
+        # expected step, not a fault. See _retry_new_thumbnail.
+        self._thumbnail_retry_pending: set[str] = set()
         # Last SmartThings input that matched nothing in the source list,
         # so the warning above is logged once per change, not per poll.
         self._last_unmapped_source: str | None = None
@@ -4520,26 +4524,34 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         """
         # ~6.5 min total: covers the multi-minute generation delay seen in logs.
         retry_delays = [15, 30, 60, 120, 180]
-        for delay in retry_delays:
-            await asyncio.sleep(delay)
-            try:
-                result = await self.async_art_get_thumbnail(content_id)
-            except Exception as ex:  # noqa: BLE001 - best-effort background retry
-                self._log.debug(
-                    "Frame Art: delayed thumbnail retry for %s errored: %s",
-                    content_id,
-                    ex,
-                )
-                continue
-            if result and not result.get("error"):
-                self._log.info(
-                    "Frame Art: thumbnail for %s is now available (delayed retry)",
-                    content_id,
-                )
-                return
-        self._log.debug(
-            "Frame Art: thumbnail for %s still unavailable after delayed retries",
+        self._thumbnail_retry_pending.add(content_id)
+        try:
+            for delay in retry_delays:
+                await asyncio.sleep(delay)
+                try:
+                    result = await self.async_art_get_thumbnail(content_id)
+                except Exception as ex:  # noqa: BLE001 - best-effort retry
+                    self._log.debug(
+                        "Frame Art: delayed thumbnail retry for %s errored: %s",
+                        content_id,
+                        ex,
+                    )
+                    continue
+                if result and not result.get("error"):
+                    self._log.info(
+                        "Frame Art: thumbnail for %s is now available (delayed retry)",
+                        content_id,
+                    )
+                    return
+        finally:
+            self._thumbnail_retry_pending.discard(content_id)
+        # Only now has the TV genuinely failed to produce it.
+        self._log.warning(
+            "Frame Art: thumbnail for %s still unavailable after %d delayed "
+            "retries over ~%d minutes — the TV never generated it",
             content_id,
+            len(retry_delays),
+            sum(retry_delays) // 60,
         )
 
     async def async_art_delete(self, content_id: str) -> dict:
@@ -4697,11 +4709,19 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 self._store_art_result(result)
                 return result
 
-            # All retries failed
+            # All retries failed. For a just-uploaded image this is an
+            # expected step, not a fault: the TV takes 30 s to several minutes
+            # to generate the thumbnail, and _retry_new_thumbnail is already
+            # waiting it out — 11 such WARNINGs in one hour on a maintainer's
+            # install, every one of which ended with the thumbnail arriving.
+            # Warn only when nothing is going to try again.
             error_msg = f"Failed after {max_retries} attempts: {last_error}"
-            self._log.warning(
-                "Could not download thumbnail for %s: %s", content_id, error_msg
+            log = (
+                self._log.debug
+                if content_id in self._thumbnail_retry_pending
+                else self._log.warning
             )
+            log("Could not download thumbnail for %s: %s", content_id, error_msg)
             result = {"error": error_msg, "content_id": content_id}
             self._store_art_result(result)
             return result

--- a/tests/test_thumbnail_retry_logging.py
+++ b/tests/test_thumbnail_retry_logging.py
@@ -1,0 +1,108 @@
+"""A thumbnail that is still being retried is not a failure yet.
+
+After an upload the TV takes 30 s to several minutes to generate the
+thumbnail, and _retry_new_thumbnail waits it out with a back-off. Every fetch
+that lands too early used to log "Could not download thumbnail … Failed after
+3 attempts" at WARNING — 11 of them in one hour on a maintainer's install,
+and all five images involved ended up with their thumbnail.
+
+The warning now belongs to the retry chain, which is the only place that
+knows nothing further will be tried.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+ROOT = Path(__file__).parents[1] / "custom_components" / "samsungtv_smart"
+MEDIA_PLAYER = (ROOT / "media_player.py").read_text()
+
+
+def _block(source: str, start: str, end: str) -> str:
+    begin = source.index(start)
+    return source[begin : source.index(end, begin)]
+
+
+class RetryChainTest(unittest.TestCase):
+    """_retry_new_thumbnail owns the in-flight marker and the final verdict."""
+
+    def setUp(self):
+        self.block = _block(
+            MEDIA_PLAYER,
+            "    async def _retry_new_thumbnail",
+            "    async def async_art_delete",
+        )
+
+    def test_the_content_id_is_marked_before_the_first_sleep(self):
+        marked = self.block.index("self._thumbnail_retry_pending.add(content_id)")
+        slept = self.block.index("await asyncio.sleep(delay)")
+        self.assertLess(marked, slept)
+
+    def test_the_marker_is_cleared_in_a_finally(self):
+        # An exception or an early return must not leave the id marked, or its
+        # later failures would be silently downgraded forever.
+        self.assertIn("finally:", self.block)
+        finally_body = self.block[self.block.index("finally:") :]
+        self.assertIn("self._thumbnail_retry_pending.discard(content_id)", finally_body)
+
+    def test_success_still_returns_early_and_logs_info(self):
+        success = self.block[: self.block.index("finally:")]
+        self.assertIn("is now available (delayed retry)", success)
+        self.assertIn("return", success)
+
+    def test_giving_up_warns_and_says_how_long_it_waited(self):
+        tail = self.block[self.block.index("finally:") :]
+        self.assertIn("self._log.warning(", tail)
+        self.assertIn("never generated it", tail)
+        self.assertIn("len(retry_delays)", tail)
+
+    def test_the_final_warning_is_outside_the_finally_block(self):
+        # It must not fire on the success path, which returns from inside try.
+        discard = self.block.index("self._thumbnail_retry_pending.discard")
+        warn = self.block.index("self._log.warning(")
+        self.assertLess(discard, warn)
+
+
+class FetchSiteTest(unittest.TestCase):
+    """The per-attempt failure defers to the retry chain."""
+
+    def setUp(self):
+        self.block = _block(
+            MEDIA_PLAYER,
+            "            # All retries failed.",
+            "        except Exception as ex:",
+        )
+
+    def test_it_chooses_debug_while_a_retry_is_pending(self):
+        self.assertIn("content_id in self._thumbnail_retry_pending", self.block)
+        self.assertIn("self._log.debug", self.block)
+
+    def test_it_still_warns_when_nothing_will_retry(self):
+        self.assertIn("else self._log.warning", self.block)
+
+    def test_the_message_is_unchanged(self):
+        self.assertIn(
+            'log("Could not download thumbnail for %s: %s", content_id, error_msg)',
+            self.block,
+        )
+
+    def test_the_result_is_still_an_error_for_callers(self):
+        # Only the log level is conditional; the returned value must not be.
+        self.assertIn(
+            'result = {"error": error_msg, "content_id": content_id}', self.block
+        )
+
+
+class InitTest(unittest.TestCase):
+    def test_the_pending_set_is_initialised(self):
+        self.assertIn("self._thumbnail_retry_pending: set[str] = set()", MEDIA_PLAYER)
+
+    def test_it_is_only_mutated_by_the_retry_chain(self):
+        mutations = re.findall(
+            r"_thumbnail_retry_pending\.(add|discard|clear|pop)", MEDIA_PLAYER
+        )
+        self.assertEqual(sorted(mutations), ["add", "discard"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Third of the same kind, after #249 and #253: a normal condition reported as a fault.

## What the log shows

An hour of a maintainer's install, five personal uploads:

| image | WARNINGs logged | outcome |
|---|---:|---|
| `MY_F0004` | 1 | ✅ available 10:33:51 |
| `MY_F0007` | **4** | ✅ available 10:38:12 |
| `MY_F0009` | 1 | ✅ available 10:37:48 |
| `MY_F0010` | 1 | ✅ available 10:37:39 |
| `MY_F0011` | **3** | ✅ available 10:43:10 |

Eleven `Could not download thumbnail … Failed after 3 attempts` — and **every one of the five images ended up with its thumbnail**. `MY_F0011` failed at 10:38:27, 10:39:32 and 10:41:08, then arrived at 10:43:10.

The TV takes 30 s to several minutes to generate a thumbnail after an upload. `_retry_new_thumbnail` already waits that out with a back-off over ~6.5 minutes. Each fetch that landed too early was an expected step of a process that was working, announced as a failure.

## The change

The verdict moves to the retry chain — the only place that knows whether anything further will be tried:

- content ids with a chain in flight are held in a set for its duration, cleared in a `finally` so an early return or an exception cannot leave one marked;
- a failed fetch for one of those logs at **debug**;
- **giving up** after the last delay is what warns now, saying how many retries over how long. That is the case worth looking at, and it did not exist as a warning before — it was a debug line.

The returned value is unchanged; only the log level is conditional, so callers still receive the error dict.

## Not changed, but worth knowing

The same log shows the maintainer's own automation, *Frame Art: Rafraîchir thumbnails après upload*, firing `Already running` three times — it duplicates what `_retry_new_thumbnail` does after every upload, which is why `MY_F0007` was attempted four times instead of once. Deleting that automation removes most of the remaining traffic. That is a user-side change, not one for this PR.

## Tests

`tests/test_thumbnail_retry_logging.py` — 11 cases: the id is marked before the first sleep and discarded in a `finally`; success still returns early and logs INFO; giving up warns and reports how long it waited; the final warning sits outside the `finally` so it cannot fire on the success path; the fetch site picks debug only while a retry is pending and still warns otherwise; the message and the returned error dict are unchanged; and the set is mutated nowhere but by the retry chain.

109 unittest tests pass. black / flake8 / isort clean on `custom_components`. Version `8.8.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_