### PR TITLE
fix(core): stop runtime-learned data writes from reloading the entry (#12)

### DIFF
--- a/custom_components/samsungtv_smart/__init__.py
+++ b/custom_components/samsungtv_smart/__init__.py
@@ -68,11 +68,17 @@ from .const import (
     CONF_DEVICE_NAME,
     CONF_ENABLE_IP_CONTROL,
     CONF_IP_CONTROL_ART_MODE,
+    CONF_IP_CONTROL_FW_VERSION,
+    CONF_IP_CONTROL_MODEL_ID,
     CONF_IP_CONTROL_POLL_INTERVAL,
+    CONF_IP_CONTROL_TOKEN,
+    CONF_IS_FRAME_TV,
     CONF_LOAD_ALL_APPS,
     CONF_OAUTH_TOKEN,
+    CONF_REST_PORT,
     CONF_SCAN_APP_HTTP,
     CONF_SHOW_CHANNEL_NR,
+    CONF_SLIDESHOW_API,
     CONF_SOURCE_LIST,
     CONF_ST_ENTRY_UNIQUE_ID,
     CONF_ST_PICTURE_MODE_CAPABILITY,
@@ -1335,6 +1341,25 @@ _NO_RELOAD_DATA_KEYS = (
     CONF_ART_LLM_PROVIDER,
     CONF_ART_LLM_API_KEY,
     CONF_ART_LLM_MODEL,
+    # Connection facts LEARNED and refreshed at runtime by the live clients,
+    # which have already adapted by the time these are persisted — the write
+    # only exists to survive a restart, so it must not reload (#12). The WS and
+    # OAuth tokens rotate, and on ~2020 Frames the Art/REST ports re-learn on
+    # reconnect; before this list, each such write reloaded the whole entry,
+    # which on an unstable connection looped every few minutes (entity flapping
+    # unavailable -> unknown -> restored). A reconfigure still reloads: it bumps
+    # CONF_RECONFIGURE_GENERATION, which is NOT excluded here.
+    CONF_TOKEN,
+    CONF_OAUTH_TOKEN,
+    CONF_PORT,
+    CONF_REST_PORT,
+    CONF_SUPPORTS_GET_BRIGHTNESS,
+    CONF_SUPPORTS_GET_COLOR_TEMPERATURE,
+    CONF_IS_FRAME_TV,
+    CONF_SLIDESHOW_API,
+    CONF_IP_CONTROL_TOKEN,
+    CONF_IP_CONTROL_MODEL_ID,
+    CONF_IP_CONTROL_FW_VERSION,
 )
 
 

--- a/custom_components/samsungtv_smart/config_flow.py
+++ b/custom_components/samsungtv_smart/config_flow.py
@@ -6,6 +6,7 @@ import logging
 from numbers import Number
 import socket
 from typing import Any, Dict
+import uuid
 
 import voluptuous as vol
 
@@ -89,6 +90,7 @@ from .const import (
     CONF_OAUTH_TOKEN,
     CONF_PING_PORT,
     CONF_POWER_ON_METHOD,
+    CONF_RECONFIGURE_GENERATION,
     CONF_REST_PORT,
     CONF_SHOW_CHANNEL_NR,
     CONF_SOURCE_LIST,
@@ -857,7 +859,10 @@ class SamsungTVSmartOAuth2FlowHandler(
         # client is rebuilt with the new id.
         return self.async_update_and_abort(
             entry,
-            data_updates={CONF_DEVICE_ID: device_id},
+            data_updates={
+                CONF_DEVICE_ID: device_id,
+                CONF_RECONFIGURE_GENERATION: uuid.uuid4().hex,
+            },
             reason="st_device_updated",
         )
 
@@ -997,6 +1002,9 @@ class SamsungTVSmartOAuth2FlowHandler(
                     data_updates: dict[str, Any] = {
                         CONF_IP_CONTROL_TOKEN: token,
                         CONF_IP_CONTROL_PORT: port,
+                        # Force the reload even though the token is excluded from
+                        # the fingerprint (#12).
+                        CONF_RECONFIGURE_GENERATION: uuid.uuid4().hex,
                     }
                     try:
                         device_info = await client.async_get_device_information()
@@ -1116,6 +1124,10 @@ class SamsungTVSmartOAuth2FlowHandler(
             updates[CONF_AUTH_METHOD] = self._auth_method
             if CONF_ST_ENTRY_UNIQUE_ID in entry.data or self._st_entry_unique_id:
                 updates[CONF_ST_ENTRY_UNIQUE_ID] = self._st_entry_unique_id
+
+        # Guarantee the reload even if every other changed key is excluded from
+        # the fingerprint (same-host re-pair, port re-detect): see #12.
+        updates[CONF_RECONFIGURE_GENERATION] = uuid.uuid4().hex
 
         # Update the entry data only; the update listener schedules the reload
         # (combining an in-flow reload with an update listener is deprecated).

--- a/custom_components/samsungtv_smart/const.py
+++ b/custom_components/samsungtv_smart/const.py
@@ -43,6 +43,13 @@ DATA_ART_API = "art_api"  # Shared Frame Art API instance
 DATA_ART_CACHE = "art_cache"  # Shared ArtIdentifyCache instance (per entry)
 DATA_IP_CONTROL_STATE_COORDINATOR = "ip_control_state_coordinator"
 CONF_IS_FRAME_TV = "is_frame_tv"  # Persisted flag: TV confirmed as Frame TV
+# Bumped to a fresh value on every reconfigure so a reconfigure always changes
+# the reload fingerprint — even a same-host re-pair or port re-detect that
+# only touches keys listed in _NO_RELOAD_DATA_KEYS. This lets those
+# runtime-learned keys be excluded from the fingerprint (so their automatic
+# refresh no longer reloads the integration, #12) without also blinding the
+# reconfigure-driven reload.
+CONF_RECONFIGURE_GENERATION = "reconfigure_generation"
 # V7: persisted capability flags for the dedicated brightness / colour-temp
 # WebSocket requests. On TVs that don't respond (e.g. Frame 2024) we learn
 # this at runtime and remember it across restarts so we don't pay the probe

--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.8.3"
+  "version": "8.8.4"
 }

--- a/tests/test_reload_fingerprint.py
+++ b/tests/test_reload_fingerprint.py
@@ -1,0 +1,164 @@
+"""Runtime-learned entry.data keys must not reload the integration (#12).
+
+_update_listener reloads the entry whenever _reload_fingerprint changes.
+Facts the live clients learn and refresh at runtime (WS/OAuth tokens, the
+Art/REST ports on 2020 Frames, capability flags) are persisted only to
+survive a restart — reloading on them made the entry flap
+unavailable -> unknown -> restored every few minutes on an unstable
+connection. They now sit in _NO_RELOAD_DATA_KEYS. A reconfigure still
+reloads: it bumps CONF_RECONFIGURE_GENERATION, which is deliberately not
+excluded.
+
+const.py imports cleanly without Home Assistant; __init__.py and
+config_flow.py do not, so those are checked structurally and the fingerprint
+behaviour is reproduced against the real exclusion set.
+"""
+
+import importlib.util
+from pathlib import Path
+import re
+import unittest
+
+ROOT = Path(__file__).parents[1] / "custom_components" / "samsungtv_smart"
+INIT = (ROOT / "__init__.py").read_text()
+CONFIG_FLOW = (ROOT / "config_flow.py").read_text()
+
+
+def _load_const():
+    spec = importlib.util.spec_from_file_location(
+        "samsungtv_const_under_test", ROOT / "const.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+const = _load_const()
+
+
+def _excluded_key_names() -> set[str]:
+    """The CONF_* names listed inside _NO_RELOAD_DATA_KEYS in __init__.py."""
+    block = INIT[INIT.index("_NO_RELOAD_DATA_KEYS = (") :]
+    # Slice to the closing paren at the start of a line — the block contains
+    # comments with parens ("(#12)"), so block.index(")") would truncate.
+    block = block[: block.index("\n)")]
+    # Only real tuple entries ("    CONF_X,"), never CONF_* names that appear
+    # inside the explanatory comments (which mention deliberately-excluded and
+    # deliberately-kept keys).
+    names = set()
+    for line in block.splitlines():
+        m = re.match(r"\s+(CONF_[A-Z_]+),\s*$", line)
+        if m:
+            names.add(m.group(1))
+    return names
+
+
+# CONF_TOKEN / CONF_PORT (and the identity keys used below) come from
+# homeassistant.const, not our const.py; their string values are stable HA
+# public constants.
+_HA_CONST = {
+    "CONF_TOKEN": "token",
+    "CONF_PORT": "port",
+    "CONF_HOST": "host",
+    "CONF_DEVICE_ID": "device_id",
+    "CONF_API_KEY": "api_key",
+}
+
+
+def _resolve(name: str) -> str:
+    return getattr(const, name, None) or _HA_CONST[name]
+
+
+def _excluded_values() -> set[str]:
+    """The excluded key NAMES resolved to their string values."""
+    return {_resolve(name) for name in _excluded_key_names()}
+
+
+class ExclusionSetTest(unittest.TestCase):
+    """The learned keys are excluded; identity/connection settings are not."""
+
+    def test_the_runtime_learned_keys_are_all_excluded(self):
+        excluded = _excluded_values()
+        for name in (
+            "CONF_TOKEN",
+            "CONF_OAUTH_TOKEN",
+            "CONF_PORT",
+            "CONF_REST_PORT",
+            "CONF_SUPPORTS_GET_BRIGHTNESS",
+            "CONF_SUPPORTS_GET_COLOR_TEMPERATURE",
+            "CONF_IS_FRAME_TV",
+            "CONF_SLIDESHOW_API",
+            "CONF_IP_CONTROL_TOKEN",
+            "CONF_IP_CONTROL_MODEL_ID",
+            "CONF_IP_CONTROL_FW_VERSION",
+            "CONF_ST_PICTURE_MODE_CAPABILITY",
+        ):
+            self.assertIn(_resolve(name), excluded, name)
+
+    def test_identity_and_connection_settings_still_reload(self):
+        excluded = _excluded_values()
+        # Changing these must still tear down and rebuild the clients.
+        for value in ("host", "device_id", "api_key"):
+            self.assertNotIn(value, excluded, value)
+
+    def test_the_reconfigure_nonce_is_not_excluded(self):
+        # It is the key that guarantees a reconfigure reloads.
+        self.assertNotIn(const.CONF_RECONFIGURE_GENERATION, _excluded_values())
+
+
+class FingerprintBehaviourTest(unittest.TestCase):
+    """Reproduce _reload_fingerprint against the real exclusion set."""
+
+    def setUp(self):
+        self.excluded = _excluded_values()
+
+    def _fingerprint(self, data):
+        # Mirrors _reload_fingerprint's data half (options omitted here).
+        return {k: v for k, v in data.items() if k not in self.excluded}
+
+    def test_a_rotated_token_does_not_change_the_fingerprint(self):
+        before = {"host": "1.2.3.4", _resolve("CONF_TOKEN"): "old"}
+        after = {"host": "1.2.3.4", _resolve("CONF_TOKEN"): "new"}
+        self.assertEqual(self._fingerprint(before), self._fingerprint(after))
+
+    def test_a_relearned_rest_port_does_not_change_the_fingerprint(self):
+        before = {"host": "1.2.3.4", const.CONF_REST_PORT: 8001}
+        after = {"host": "1.2.3.4", const.CONF_REST_PORT: 8002}
+        self.assertEqual(self._fingerprint(before), self._fingerprint(after))
+
+    def test_an_oauth_refresh_does_not_change_the_fingerprint(self):
+        before = {const.CONF_OAUTH_TOKEN: {"access_token": "a"}}
+        after = {const.CONF_OAUTH_TOKEN: {"access_token": "b"}}
+        self.assertEqual(self._fingerprint(before), self._fingerprint(after))
+
+    def test_a_host_change_does_change_the_fingerprint(self):
+        before = {"host": "1.2.3.4", _resolve("CONF_TOKEN"): "t"}
+        after = {"host": "5.6.7.8", _resolve("CONF_TOKEN"): "t"}
+        self.assertNotEqual(self._fingerprint(before), self._fingerprint(after))
+
+    def test_a_reconfigure_nonce_bump_does_change_the_fingerprint(self):
+        before = {_resolve("CONF_TOKEN"): "t", const.CONF_RECONFIGURE_GENERATION: "aaa"}
+        after = {_resolve("CONF_TOKEN"): "t2", const.CONF_RECONFIGURE_GENERATION: "bbb"}
+        # Token rotated (ignored) but the nonce moved -> reload.
+        self.assertNotEqual(self._fingerprint(before), self._fingerprint(after))
+
+
+class ReconfigureBumpsNonceTest(unittest.TestCase):
+    """Every reconfigure save path must set the nonce, or it won't reload."""
+
+    def test_all_three_reconfigure_saves_bump_the_generation(self):
+        # main reconfigure, ST device re-pick, IP Control pairing.
+        self.assertEqual(
+            CONFIG_FLOW.count("CONF_RECONFIGURE_GENERATION: uuid.uuid4().hex")
+            + CONFIG_FLOW.count(
+                "updates[CONF_RECONFIGURE_GENERATION] = uuid.uuid4().hex"
+            ),
+            3,
+        )
+
+    def test_uuid_is_imported(self):
+        self.assertIn("\nimport uuid\n", CONFIG_FLOW)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the regression @excprocess reports in #12 (8.3.3 fine, 8.6.0 onward broken): on his Frame 2020, `frame_art` and the TV entity flap `unavailable → unknown → restored` every few minutes, "as though performing a full periodic reload."

## It is a full periodic reload

`_update_listener` (`__init__.py`) reloads the entry whenever `_reload_fingerprint` changes. The fingerprint excludes only the keys in `_NO_RELOAD_DATA_KEYS` — which was **just `CONF_ST_PICTURE_MODE_CAPABILITY` plus the art-identification keys**. Every other `entry.data` key, on change, reloads the whole integration.

But eleven facts are persisted to `entry.data` **at runtime** by the live clients:

```
CONF_TOKEN          CONF_OAUTH_TOKEN     CONF_PORT           CONF_REST_PORT
CONF_SUPPORTS_GET_BRIGHTNESS   CONF_SUPPORTS_GET_COLOR_TEMPERATURE
CONF_IS_FRAME_TV    CONF_SLIDESHOW_API   CONF_IP_CONTROL_TOKEN
CONF_IP_CONTROL_MODEL_ID       CONF_IP_CONTROL_FW_VERSION
```

None were excluded. So each runtime write reloaded the entry. On a 2020 Frame — which drops off the network in standby, renegotiates the WS often, and **re-learns its Art/REST port on every reconnect** (the documented 8001/8002 split) — that is a reload every few minutes, which is exactly the flap. For SmartThings users, the OAuth token refresh does the same once per refresh.

The window fits: `_reload_fingerprint` landed **2026-06-23**, after 8.3.3; before it, rewriting these keys reloaded nothing.

## The fix

These are learned facts — by the time they are persisted the live client has already adopted them, so the write only needs to survive a restart, never a reload. All eleven move into `_NO_RELOAD_DATA_KEYS`.

A reconfigure **must** still reload, and a same-host re-pair or port re-detect would now change only excluded keys. So every reconfigure save path (main reconfigure, SmartThings device re-pick, IP Control pairing) bumps a new `CONF_RECONFIGURE_GENERATION` nonce, which is **not** excluded. That decouples the reconfigure-driven reload from the runtime writes, instead of relying on the fingerprint to notice connection changes — and it sidesteps HA's "don't combine an in-flow reload with an update listener" deprecation entirely.

Connection/identity settings that genuinely require a reload — `CONF_HOST`, `CONF_DEVICE_ID`, `CONF_API_KEY` — stay in the fingerprint.

## Tests

`tests/test_reload_fingerprint.py` — 10 cases:
- **behaviour** (the fingerprint reproduced against the *real* exclusion set): a rotated WS token, a re-learned REST port and an OAuth refresh leave it unchanged; a host change and a nonce bump change it;
- **the set**: all eleven learned keys excluded, `CONF_HOST`/`CONF_DEVICE_ID`/`CONF_API_KEY` not, the nonce not;
- **the flow**: all three reconfigure save paths bump the nonce, and `uuid` is imported.

119 unittest tests pass. black / flake8 / isort clean on `custom_components`. Version `8.8.4`.

## For @excprocess

The fix removes the reload regardless of which key was flapping on your TV. A debug log spanning two or three cycles would still confirm the exact trigger (WS token vs Art/REST port vs — if you use SmartThings — the OAuth refresh); I've asked for it on the issue, but it is not needed to ship this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_