### PR TITLE
fix(art): don't report art_mode_status on non-Frame TVs in Ambient Mode (#248) — 8.8.6

### DIFF
--- a/custom_components/samsungtv_smart/manifest.json
+++ b/custom_components/samsungtv_smart/manifest.json
@@ -26,5 +26,5 @@
     "Pillow>=10.0.0",
     "pillow-heif>=0.13.0"
   ],
-  "version": "8.8.5"
+  "version": "8.8.6"
 }

--- a/custom_components/samsungtv_smart/media_player.py
+++ b/custom_components/samsungtv_smart/media_player.py
@@ -2830,8 +2830,19 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         # every IP Control poll and independent of that option, so consult it
         # before the WS/SmartThings fallbacks. None = not readable -> fall
         # through unchanged (no IP Control, no snapshot, or TV asleep).
+        #
+        # Frame TVs only: pictureMode 'Ambient' means artwork on an LS03 Frame,
+        # but Samsung's unrelated Ambient Mode on a non-Frame set (e.g. QN90A)
+        # reports the same value, and those panels sit in it near-permanently.
+        # Without this guard art_mode_status would read 'on' for a TV that has
+        # no Art Mode at all (#248). support_art_mode already folds the WS
+        # artmode capability and the FrameTVSupport device flag, so it is the
+        # right gate; a non-Frame falls through to the previous behaviour.
         panel_art = self._ip_control_panel_art_cached()
-        if panel_art is not None:
+        if (
+            panel_art is not None
+            and self.support_art_mode != ArtModeSupport.UNSUPPORTED
+        ):
             return panel_art
         if self._get_device_spec("PowerState") == "standby":
             return False

--- a/tests/test_art_mode_status_panel_truth.py
+++ b/tests/test_art_mode_status_panel_truth.py
@@ -95,8 +95,17 @@ class ArtModeIsOnTest(unittest.TestCase):
             self.block.index("panel_art = self._ip_control_panel_art_cached()") :
         ]
         head = seg[: seg.index("PowerState")]
-        self.assertIn("if panel_art is not None:", head)
+        self.assertIn("panel_art is not None", head)
         self.assertIn("return panel_art", head)
+
+    def test_the_panel_is_only_trusted_on_art_capable_tvs(self):
+        # pictureMode 'Ambient' also means Samsung Ambient Mode on a non-Frame
+        # set (#248 regression), so the panel value is gated by support_art_mode.
+        seg = self.block[
+            self.block.index("panel_art = self._ip_control_panel_art_cached()") :
+        ]
+        guard = seg[: seg.index("return panel_art")]
+        self.assertIn("self.support_art_mode != ArtModeSupport.UNSUPPORTED", guard)
 
     def test_the_running_app_guard_still_leads(self):
         # A real foreground app must still win over any art signal.


### PR DESCRIPTION
Follow-up to #256 (8.8.5). A field regression caught by @ajguerre1 before it propagated.

## The regression

8.8.5 made `_art_mode_is_on()` read `art_mode_status` off `getTVStates.pictureMode == "Ambient"`. On a **non-Frame** set with IP Control paired (e.g. QN90A), that same value means Samsung's unrelated **Ambient Mode** — a different feature those panels sit in near-permanently — not Art Mode. With no capability guard, `art_mode_status` started reading `on` for TVs that have no Art Mode at all.

Confirmed on an 11-Frame + 2-QN90A fleet: after 8.8.5 both QN90As flipped `None` → `on`, while the (correctly absent) art-mode switch stayed absent.

## The fix (8.8.6)

Gate the panel consultation on `support_art_mode`, which already folds the WS artmode capability and the `FrameTVSupport` device flag:

```python
panel_art = self._ip_control_panel_art_cached()
if panel_art is not None and self.support_art_mode != ArtModeSupport.UNSUPPORTED:
    return panel_art
```

- **Non-Frame** → `UNSUPPORTED` → falls through to the previous behaviour, so `art_mode_status` goes back to `None`.
- **Frame** → `FULL`/`PARTIAL` → the 8.8.5 freeze fix stands.

## Tests

`tests/test_art_mode_status_panel_truth.py` gains a case pinning the guard (`self.support_art_mode != ArtModeSupport.UNSUPPORTED` in front of `return panel_art`), so a future rewrite can't drop it. 9 cases total, all pass; black/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qFfTuuqEjsyY32dckz2)_